### PR TITLE
Fix WhatsApp placeholder prepend, cleanup executor routing, OmniRoute warmup, and local vocabulary interpolation

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
@@ -30,13 +30,30 @@ object LocalCleanupProvider {
 
     /**
      * The system prompt [CleanupWaterfallExecutor]'s LOCAL_LLM step should actually send for the
-     * currently [selectedModel] -- that model's own [Model.localSystemPrompt] when it declares
-     * one (a fine-tuned model like `mumble-cleanup-2stage` that requires its exact training
-     * prompt), otherwise [PostProcessor.SIMPLE_PROMPT] (the general-purpose default every other
-     * local model -- e.g. LFM2.5 -- is prompted with).
+     * currently [selectedModel]. Context-reading wrapper only -- the selection itself lives in
+     * [systemPromptFor], which is unit-testable without a Context (no Robolectric here, so
+     * pure-logic extraction is how the rest of this module stays covered).
      */
-    fun selectedSystemPrompt(ctx: Context): String =
-        selectedModel(ctx).localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT
+    fun selectedSystemPrompt(ctx: Context, terms: List<String>): String =
+        systemPromptFor(selectedModel(ctx), terms)
+
+    /**
+     * The model's own [Model.localSystemPrompt] when it declares one (a fine-tuned model like
+     * `mumble-cleanup-2stage` that requires its exact training prompt), otherwise the
+     * general-purpose [PostProcessor.SIMPLE_PROMPT] -- always interpolated.
+     *
+     * The interpolation fixes a real on-device failure: only the *cloud* prompt was run through
+     * [PostProcessor.interpolateVocabulary] (in WhisperAccessibilityService), so LFM2.5 got a
+     * literal [PostProcessor.VOCABULARY_PLACEHOLDER] as its system prompt and echoed
+     * `{{vocabulary}}` back as the whole cleaned transcript. Doing it in the one function that
+     * picks the prompt means no caller can reintroduce it by forgetting. Fine-tuned prompts carry
+     * no placeholder, so this is a no-op for them (see [MUMBLE_CLEANUP_SYSTEM_PROMPT]).
+     */
+    fun systemPromptFor(model: Model, terms: List<String>): String =
+        PostProcessor.interpolateVocabulary(
+            model.localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT,
+            terms,
+        )
 
     // A `run(text, prompt, modelPath, engine)` helper used to live here, kdoc-claiming the
     // Settings "Test" button drove local steps through it -- it never had a production caller

--- a/app/src/main/kotlin/com/trevornk/ramblr/NetworkWarmup.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/NetworkWarmup.kt
@@ -46,7 +46,11 @@ object NetworkWarmup {
             ProviderKind.OPENAI -> "api.openai.com"
             ProviderKind.ANTHROPIC -> "api.anthropic.com"
             ProviderKind.GEMINI -> "generativelanguage.googleapis.com"
-            ProviderKind.OMNIROUTE -> null // no fixed default host to guess at
+            // #110: unlike the other cloud providers there's no universal default host to guess
+            // at -- OmniRoute is a self-hosted gateway -- but when a dev has configured one via
+            // local.properties (see OmniRoute's kdoc), OmniRoute.BASE_URL is that real,
+            // build-time-known host and should be warmed exactly like everyone else's.
+            ProviderKind.OMNIROUTE -> if (OmniRoute.isConfigured) OmniRoute.BASE_URL.toHttpUrlOrNullHost() else null
             ProviderKind.LOCAL -> null
         }
     }

--- a/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
@@ -334,11 +334,14 @@ explanations, headers, or comments about your edits.
     }
 
     /**
-     * Provider-chain entry point for Phase 2 (#95). A single OPENAI entry deliberately runs through
-     * the same simple [process] path, with the OpenAI secret resolved from [ProviderCredentialStore]
-     * by the caller. Any real multi-step chain is adapted to [CleanupWaterfall] and executed by
-     * [CleanupWaterfallExecutor] unchanged, preserving its fail-fast grouping, cursor resume, and
-     * bounded local-inference deadline behavior.
+     * Provider-chain entry point for Phase 2 (#95). Every chain -- including a single OPENAI
+     * entry -- is adapted to [CleanupWaterfall] and executed by [CleanupWaterfallExecutor],
+     * preserving its fail-fast grouping, cursor resume, timeout discipline, and bounded
+     * local-inference deadline behavior (#105: a one-step waterfall was previously special-cased
+     * to call [process] directly via [NetworkClients.shared]'s much longer timeouts, bypassing
+     * [CleanupWaterfallExecutor]'s tighter [CleanupStepTimeouts] and hard cap; see
+     * [CleanupWaterfallPlanner.groupConsecutive] for why a single-step waterfall is already
+     * handled correctly here without any special case).
      */
     fun processProviderChain(
         text: String,
@@ -356,25 +359,16 @@ explanations, headers, or comments about your edits.
         // [CleanupWaterfallExecutor.execute] -- see its own kdoc on these same param names.
         benchmarkContext: android.content.Context? = null,
         benchmarkCorrelationId: String? = null,
+        // Test seam only, mirroring [CleanupWaterfallExecutor.execute]'s own default: production
+        // callers never pass this. Lets a unit test assert that every chain -- including the
+        // single-OpenAI one that #105 used to divert past the executor -- actually reaches
+        // CleanupWaterfallExecutor, without making a network call.
+        transport: CleanupHttpTransport = RealCleanupHttpTransport,
         callback: (Result) -> Unit,
     ) {
         val waterfall = ProviderChainRuntime.cleanupWaterfallFor(chain)
         if (waterfall.steps.isEmpty()) {
             callback(Result(null, "No cleanup steps configured"))
-            return
-        }
-
-        if (ProviderChainRuntime.isSingleOpenAiCleanup(chain)) {
-            val entry = chain.capableEntriesFor(needsTranscription = false).first()
-            process(
-                text = text,
-                prompt = prompt,
-                apiKey = credentialLookup(ProviderKind.OPENAI),
-                cancelHolder = cancelHolder,
-                baseUrl = entry.baseUrlOverride ?: DEFAULT_BASE_URL,
-                model = entry.model,
-                callback = callback,
-            )
             return
         }
 
@@ -385,6 +379,7 @@ explanations, headers, or comments about your edits.
             cursor = cursor,
             cancelHolder = cancelHolder,
             credentialLookup = { slot -> credentialLookup(ProviderChainRuntime.providerKindForCleanupSlot(slot)) },
+            transport = transport,
             localModelPath = localModelPath,
             localPrompt = localPrompt,
             benchmarkContext = benchmarkContext,

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProviderChainRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProviderChainRuntime.kt
@@ -37,8 +37,10 @@ object ProviderChainRuntime {
         return cleanupEntries.size == 1 && cleanupEntries[0].kind == ProviderKind.OPENAI
     }
 
-    /** True only when [chain] is exactly one OPENAI entry -- the simple single-provider path
-     *  that bypasses [CleanupWaterfallExecutor] entirely (see [PostProcessor.processProviderChain]). */
+    /** True unless [chain] is exactly one OPENAI entry. Since #105 this no longer selects between
+     *  execution paths -- every chain runs through [CleanupWaterfallExecutor] -- it only marks the
+     *  single-credential chain that [WhisperAccessibilityService] pre-flights for a missing key,
+     *  because it has no second step to fall through to. */
     fun shouldUseCleanupExecutor(chain: ProviderChain): Boolean = !isSingleOpenAiCleanup(chain)
 
     /** Maps executor credential slots to unified provider credential kinds. */

--- a/app/src/main/kotlin/com/trevornk/ramblr/StreamingPreview.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/StreamingPreview.kt
@@ -129,9 +129,60 @@ fun reconcileStreamingSpan(
  * this field" to insert relative to must check `isShowingHintText()` first, or the hint gets glued
  * onto the front of the dictated text with no separating space. Single shared choke point for that
  * check so it can't be missed at a new call site.
+ *
+ * [selectionStart]/[selectionEnd] are a second, independent line of defence added for #140
+ * (WhatsApp's "Message" composer). `isShowingHintText()` is only reliable for a placeholder rendered
+ * through the framework's own `android:hint` machinery. WhatsApp's composer instead seeds the
+ * placeholder as the field's own text: measured on-device it reports `text='Message'` with
+ * `isShowingHintText=false` AND `hintText=null`, so neither the #47 check nor any hint comparison
+ * can see it. What *does* distinguish it is the text selection: a placeholder has no cursor
+ * position inside it, so the node reports `-1/-1`, whereas a field holding real content always
+ * reports a real insertion point.
+ *
+ * Measured on a Pixel 10a across WhatsApp, Google Keep and Chrome (the full matrix is in #140).
+ * Placeholder states reported `-1/-1`; every field holding genuine text reported an index >= 0,
+ * including the cases most likely to be mistaken for a placeholder:
+ *  - a WhatsApp draft restored after navigating away and back  -> `0/0`
+ *  - Keep note title/body text in an unfocused node            -> `0/0`
+ *  - a web input prefilled via `value=` and programmatically focused, never touched by the
+ *    user, so no selection-changed event had ever fired for it -> `0/0`
+ *
+ * That last case is the specific hazard [resolveInsertionStart] documents below -- selection being
+ * unreported until a selection-changed event occurs -- which is why it was tested explicitly rather
+ * than assumed. It reports `0`, not `-1`, so it is not mistaken for a placeholder.
+ *
+ * The rule is deliberately conservative: it requires the node to be editable and focused, and the
+ * selection to be entirely absent, before overriding what the field claims to contain. An
+ * unfocused node is never blanked by this path, so a stray non-target node holding real text cannot
+ * be destroyed by it. If a future app reports no selection for genuine content, the failure mode is
+ * that the user's existing text is replaced rather than appended to -- hence the narrow guards.
+ *
+ * Note for maintainers: every parameter is required on purpose. Defaults here would let a new call
+ * site silently opt out of the #140 signals and quietly reinstate the bug; a compile error is the
+ * cheaper failure. An earlier attempt at #140 compared `text == hintText` instead. That was
+ * based on a UIAutomator dump of Keep's search field showing `text` and `hint` as an identical
+ * pair -- but UIAutomator does not expose `isShowingHintText`, and reading the real
+ * `AccessibilityNodeInfo` showed Keep already reports `isShowingHintText=true` there. The #47 check
+ * had always covered Keep; the hint comparison was redundant, did nothing for WhatsApp (which
+ * exposes no hint at all), and risked blanking a genuine draft that happened to equal the
+ * placeholder. It was removed in favour of the selection signal above.
  */
-fun resolveRealText(rawText: String?, isShowingHintText: Boolean): String =
-    if (isShowingHintText) "" else rawText.orEmpty()
+fun resolveRealText(
+    rawText: String?,
+    isShowingHintText: Boolean,
+    selectionStart: Int,
+    selectionEnd: Int,
+    isEditable: Boolean,
+    isFocused: Boolean,
+): String = when {
+    isShowingHintText -> ""
+    !rawText.isNullOrBlank() &&
+        isEditable &&
+        isFocused &&
+        selectionStart < 0 &&
+        selectionEnd < 0 -> ""
+    else -> rawText.orEmpty()
+}
 
 /**
  * Decides where the very first partial of a recording should be inserted (#42). Many Android
@@ -147,4 +198,36 @@ fun resolveInsertionStart(selStart: Int, selEnd: Int, currentTextLength: Int): I
     if (selStart < 0 || selEnd < 0) return currentTextLength
     if (selStart == 0 && selEnd == 0 && currentTextLength > 0) return currentTextLength
     return minOf(selStart, selEnd)
+}
+
+/**
+ * The span of existing text that a one-shot injection should overwrite: [start] inclusive,
+ * [endExclusive] exclusive, ready to hand straight to `String.replaceRange`.
+ */
+data class ReplacementSpan(val start: Int, val endExclusive: Int)
+
+/**
+ * The span that a one-shot (non-streaming) injection should overwrite, for the direct
+ * `ACTION_SET_TEXT` path.
+ *
+ * Start is delegated to [resolveInsertionStart] so this path can't disagree with the streaming path
+ * about where the cursor really is -- they previously did, and a WhatsApp draft restored by leaving
+ * and re-entering a chat (which reports `(0, 0)` with the caret visibly at the end) had dictation
+ * prepended rather than appended (#140).
+ *
+ * The end preserves a genuine ranged selection, so dictating over highlighted text still replaces
+ * it, which [resolveInsertionStart] alone would lose by collapsing to a single insertion point.
+ * When the start was overridden as unreliable, the span collapses to a pure insertion -- deleting a
+ * range computed from a selection we just declared untrustworthy would risk destroying real text.
+ * Both ends are clamped into `0..currentTextLength`, because a node can report a stale index past
+ * the end of its own current text and `replaceRange` would otherwise throw uncaught, taking down
+ * the whole accessibility service.
+ */
+fun resolveReplacementSpan(selStart: Int, selEnd: Int, currentTextLength: Int): ReplacementSpan {
+    val start = resolveInsertionStart(selStart, selEnd, currentTextLength)
+    val trusted = selStart >= 0 && selEnd >= 0 && start == minOf(selStart, selEnd)
+    val end = if (trusted) maxOf(selStart, selEnd) else start
+    val safeStart = start.coerceIn(0, currentTextLength)
+    val safeEnd = end.coerceIn(safeStart, currentTextLength)
+    return ReplacementSpan(safeStart, safeEnd)
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/TranscriberClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/TranscriberClient.kt
@@ -31,10 +31,22 @@ object TranscriberClient {
     fun transcriptionEndpoint(baseUrl: String): String =
         (PostProcessor.normalizeBaseUrl(baseUrl) ?: PostProcessor.DEFAULT_BASE_URL) + "/audio/transcriptions"
 
+    /**
+     * Parses `/audio/transcriptions`' JSON body.
+     *
+     * The transcript is trimmed (#140): every other transcription parser in the app already trims
+     * its model text -- [GeminiTranscriberClient.parseResponse], [LocalTranscriber.transcribe] and
+     * [StreamingTranscriber] all do -- and so does every cleanup provider
+     * ([PostProcessor.parseResponse], [AnthropicCleanupProvider.parseResponse], and the LOCAL_LLM
+     * step per #84). This parser was the sole exception, so leading/trailing whitespace and
+     * newlines in the model's transcript were injected verbatim into the user's field, pushing the
+     * cursor onto a new line after the dictated text. Cleanup-off (raw injection) makes this
+     * user-visible directly; with cleanup on, the cleanup step's own trim used to mask it.
+     */
     fun parseResponse(json: String): Result = try {
         val obj = JSONObject(json)
         when {
-            obj.has("text") -> Result(obj.getString("text"), null)
+            obj.has("text") -> Result(obj.getString("text").trim(), null)
             obj.has("error") -> Result(null, obj.getJSONObject("error").getString("message"))
             else -> Result(null, "Unknown response")
         }

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2980,7 +2980,14 @@ class WhisperAccessibilityService : AccessibilityService() {
         val session = streamingSession
         if (session == null) {
             val candidate = findDirectInjectionCandidate() ?: return
-            val current = resolveRealText(candidate.text?.toString(), candidate.isShowingHintText)
+            val current = resolveRealText(
+                candidate.text?.toString(),
+                candidate.isShowingHintText,
+                candidate.textSelectionStart,
+                candidate.textSelectionEnd,
+                candidate.isEditable,
+                candidate.isFocused,
+            )
             val insertionStart = resolveInsertionStart(candidate.textSelectionStart, candidate.textSelectionEnd, current.length)
             val displayText = smartCapitalize(text)
             if (!setNodeText(candidate, replacePartialInField(current, insertionStart, 0, displayText))) {
@@ -2994,7 +3001,14 @@ class WhisperAccessibilityService : AccessibilityService() {
         if (!shouldInjectPartial(text, session.lastInjectedText, session.lastInjectedAtMs, now, STREAMING_PARTIAL_MIN_INTERVAL_MS)) return
         if (!refreshNode(session.node)) { endStreamingSession(); return }
 
-        val current = resolveRealText(session.node.text?.toString(), session.node.isShowingHintText)
+        val current = resolveRealText(
+            session.node.text?.toString(),
+            session.node.isShowingHintText,
+            session.node.textSelectionStart,
+            session.node.textSelectionEnd,
+            session.node.isEditable,
+            session.node.isFocused,
+        )
         val displayText = smartCapitalize(text)
         val updated = replacePartialInField(current, session.insertionStart, session.lastPartialLength, displayText)
         if (!setNodeText(session.node, updated)) { endStreamingSession(); return }
@@ -3546,7 +3560,14 @@ class WhisperAccessibilityService : AccessibilityService() {
      *  than left concatenated alongside the final transcript. */
     private fun tryCloseStreamingSpan(node: AccessibilityNodeInfo, session: StreamingPreviewSession, text: String): InjectAttempt {
         if (!refreshNode(node)) return InjectAttempt(InjectMethod.NONE)
-        val current = resolveRealText(node.text?.toString(), node.isShowingHintText)
+        val current = resolveRealText(
+            node.text?.toString(),
+            node.isShowingHintText,
+            node.textSelectionStart,
+            node.textSelectionEnd,
+            node.isEditable,
+            node.isFocused,
+        )
         val updated = reconcileStreamingSpan(
             current, StreamingSpan(session.insertionStart, session.lastPartialLength), text, isFinalInjectionTarget = true
         ) ?: return InjectAttempt(InjectMethod.NONE)
@@ -3559,7 +3580,14 @@ class WhisperAccessibilityService : AccessibilityService() {
      *  gone stale by now just has nothing left to revert. */
     private fun clearStreamingLeftover(session: StreamingPreviewSession) {
         if (!refreshNode(session.node)) return
-        val current = resolveRealText(session.node.text?.toString(), session.node.isShowingHintText)
+        val current = resolveRealText(
+            session.node.text?.toString(),
+            session.node.isShowingHintText,
+            session.node.textSelectionStart,
+            session.node.textSelectionEnd,
+            session.node.isEditable,
+            session.node.isFocused,
+        )
         val cleared = reconcileStreamingSpan(
             current, StreamingSpan(session.insertionStart, session.lastPartialLength), finalText = "", isFinalInjectionTarget = false
         ) ?: return
@@ -3588,20 +3616,20 @@ class WhisperAccessibilityService : AccessibilityService() {
         node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
 
         if (node.isEditable || node.className?.toString()?.contains("EditText") == true) {
-            val current = resolveRealText(node.text?.toString(), node.isShowingHintText)
-            val start = if (node.textSelectionStart >= 0) node.textSelectionStart else current.length
-            val end = if (node.textSelectionEnd >= 0) node.textSelectionEnd else start
-            // Clamp to current's actual bounds (audit finding, two-model cross-examined): a node
-            // can self-report a stale/inconsistent selection index -- most plausibly right after
-            // resolveRealText substitutes "" for hint text above while the node's own
-            // textSelectionStart/End still reflects a positive index against the hint string it
-            // was just showing. Without this, replaceRange below throws IndexOutOfBoundsException
-            // uncaught (this method has no try/catch of its own; finishInjection's try/finally only
-            // recycles nodes), which would crash the whole accessibility service. Mirrors the same
-            // clamp StreamingPreview.replacePartialInField already applies for the same reason.
-            val replacementStart = minOf(start, end).coerceIn(0, current.length)
-            val replacementEnd = maxOf(start, end).coerceIn(replacementStart, current.length)
-            val updated = current.replaceRange(replacementStart, replacementEnd, text)
+            val current = resolveRealText(
+                node.text?.toString(),
+                node.isShowingHintText,
+                node.textSelectionStart,
+                node.textSelectionEnd,
+                node.isEditable,
+                node.isFocused,
+            )
+            // Delegated to a pure, unit-tested helper so this direct ACTION_SET_TEXT path and the
+            // streaming path can't disagree about where the caret really is -- they used to, and a
+            // restored WhatsApp draft (which reports (0, 0) with the caret visibly at the end) had
+            // dictation prepended: "draft" + " world" => " worlddraft" (#140).
+            val span = resolveReplacementSpan(node.textSelectionStart, node.textSelectionEnd, current.length)
+            val updated = current.replaceRange(span.start, span.endExclusive, text)
             val setTextOk = setNodeText(node, updated)
             Log.i(TAG, "ACTION_SET_TEXT => $setTextOk")
             if (setTextOk) return InjectAttempt(InjectMethod.DIRECT, priorText = current)

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2824,7 +2824,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                 cancelHolder = inFlightCall,
                 credentialLookup = { kind -> ProviderCredentialStore.get(this, kind) },
                 localModelPath = { ModelDownloader.localCleanupModelFile(this, LocalCleanupProvider.selectedModel(this))?.absolutePath },
-                localPrompt = LocalCleanupProvider.selectedSystemPrompt(this),
+                localPrompt = LocalCleanupProvider.selectedSystemPrompt(this, vocabulary),
                 benchmarkContext = this,
                 benchmarkCorrelationId = correlationIdFor(token),
             ) { result ->

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2785,10 +2785,12 @@ class WhisperAccessibilityService : AccessibilityService() {
                 return
             }
 
-            // The simple single-OpenAI chain fails before making a network call if its one required
-            // credential is missing. Real multi-step chains resolve credentials inside
+            // A single-OpenAI chain has exactly one required credential and no other step to fall
+            // through to, so a missing key is worth failing fast on here, before the executor makes
+            // a network call it can only fail. Real multi-step chains resolve credentials inside
             // CleanupWaterfallExecutor and can fall through past an unconfigured cloud step to
-            // another provider (including LOCAL).
+            // another provider (including LOCAL). Note this is only a pre-flight check -- since
+            // #105 every chain, this one included, is executed by CleanupWaterfallExecutor.
             if (!ProviderChainRuntime.shouldUseCleanupExecutor(providerChain) &&
                 ProviderCredentialStore.get(this, ProviderKind.OPENAI).isBlank()) {
                 handler.post {

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupProviderTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupProviderTest.kt
@@ -1,6 +1,7 @@
 package com.trevornk.ramblr
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -15,5 +16,70 @@ class LocalCleanupProviderTest {
     @Test fun `MODEL is the one curated local-cleanup catalog entry`() {
         assertEquals(LOCAL_CLEANUP_MODEL, LocalCleanupProvider.MODEL)
         assertTrue(LocalCleanupProvider.MODEL.isLocalCleanup)
+    }
+
+    // --- local-prompt vocabulary interpolation (systemPromptFor) -------------------------------
+    //
+    // Real on-device failure: with the LOCAL_LLM step selected, dictation injected the literal
+    // text "{{vocabulary}}" instead of the transcript. Only the cloud prompt was run through
+    // interpolateVocabulary in WhisperAccessibilityService, so LFM2.5 -- which declares no
+    // fine-tuned prompt and falls back to SIMPLE_PROMPT -- got the raw placeholder as its system
+    // prompt and echoed it back.
+    //
+    // These deliberately call systemPromptFor rather than PostProcessor.interpolateVocabulary,
+    // which was never the broken part: an earlier draft asserted on the latter and passed against
+    // the unfixed code. Mutation-check any change by reverting systemPromptFor's body to
+    // `model.localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT` -- three of these must fail.
+
+    @Test fun `the local fallback prompt still carries the placeholder to interpolate`() {
+        // If this constant ever loses its placeholder, interpolation silently becomes a no-op and
+        // local cleanup quietly stops honouring personal vocabulary -- fail loudly instead.
+        assertTrue(
+            "SIMPLE_PROMPT must contain the vocabulary placeholder for local cleanup to substitute",
+            PostProcessor.SIMPLE_PROMPT.contains(PostProcessor.VOCABULARY_PLACEHOLDER),
+        )
+    }
+
+    @Test fun `a model without its own prompt gets vocabulary interpolated, not a literal placeholder`() {
+        // LFM2.5 declares no localSystemPrompt, so it falls back to SIMPLE_PROMPT -- the exact
+        // path that shipped "{{vocabulary}}" to the screen.
+        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, listOf("Ramblr", "FastHTML"))
+        assertFalse(
+            "a literal {{vocabulary}} reaching the local model is the on-device bug",
+            prompt.contains(PostProcessor.VOCABULARY_PLACEHOLDER),
+        )
+        assertTrue(prompt.contains("Ramblr"))
+        assertTrue(prompt.contains("FastHTML"))
+    }
+
+    @Test fun `a model without its own prompt and no vocabulary terms still drops the placeholder`() {
+        // The empty-vocabulary case is the default for a fresh install, so it is the most likely
+        // path to ship broken: the clause collapses to "" but the placeholder must still be gone.
+        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList())
+        assertFalse(prompt.contains(PostProcessor.VOCABULARY_PLACEHOLDER))
+        assertFalse("no template syntax may survive into the system prompt", prompt.contains("{{"))
+    }
+
+    @Test fun `a fine-tuned model's exact training prompt is passed through byte for byte`() {
+        // mumble-cleanup-2stage must receive its exact training prompt; it declares no
+        // placeholder, so interpolation has to be a no-op even with vocabulary configured.
+        val model = LOCAL_CLEANUP_MODEL_CATALOG.first { it.localSystemPrompt != null }
+        assertEquals(
+            model.localSystemPrompt,
+            LocalCleanupProvider.systemPromptFor(model, listOf("Ramblr")),
+        )
+    }
+
+    @Test fun `no catalog model can send an uninterpolated placeholder to the local engine`() {
+        // Guards every current and future catalog entry, not just the two we know about.
+        LOCAL_CLEANUP_MODEL_CATALOG.forEach { model ->
+            listOf(emptyList(), listOf("Ramblr")).forEach { terms ->
+                assertFalse(
+                    "${model.archive} would send a literal placeholder to the local model",
+                    LocalCleanupProvider.systemPromptFor(model, terms)
+                        .contains(PostProcessor.VOCABULARY_PLACEHOLDER),
+                )
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/NetworkWarmupTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/NetworkWarmupTest.kt
@@ -66,6 +66,11 @@ class NetworkWarmupTest {
         // is false in this test run -- mirroring OmniRouteTest, this pins the contract against
         // OmniRoute.isConfigured itself rather than a hardcoded assumption about its value, so the
         // same test is correct here and for any dev with a real local.properties override.
+        //
+        // NOTE: because isConfigured is false on CI, this case alone asserts emptySet() and passes
+        // against the unfixed `-> null` too -- it cannot catch a regression in the environment that
+        // actually gates merges. The override case below is the one with real teeth on CI; keep
+        // both, since only this one pins the BuildConfig-sourced branch a configured dev hits.
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = emptyList(),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.OMNIROUTE))),

--- a/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorProviderChainRoutingTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorProviderChainRoutingTest.kt
@@ -1,0 +1,102 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers which execution path [PostProcessor.processProviderChain] dispatches a chain down (#105).
+ *
+ * The bug: a single-OpenAI cleanup chain -- the most common configuration in production -- was
+ * special-cased to call [PostProcessor.process] directly through `NetworkClients.shared`
+ * (20s connect / 120s read / 180s call), bypassing [CleanupWaterfallExecutor]'s far tighter
+ * [CleanupStepTimeouts] and hard cap. A stalled cleanup on the default config could therefore hang
+ * for minutes instead of failing over to raw-text injection in seconds, and benchmark correlation
+ * ids were silently dropped on that path.
+ *
+ * The pre-existing shape test in ProviderChainRuntimeTest asserts that such a chain *maps to* a
+ * one-step waterfall, but that passes just as happily while the special case diverts around the
+ * executor -- it never observes the dispatch. These tests observe it directly: the injected
+ * transport is reached only via [CleanupWaterfallExecutor], so a request arriving here at all is
+ * proof the executor ran, and the timeouts it is handed are the ones the issue was about.
+ */
+class PostProcessorProviderChainRoutingTest {
+
+    /** Records what the executor actually sent, and answers with a canned success. */
+    private class RecordingTransport : CleanupHttpTransport {
+        val urls = mutableListOf<String>()
+        val timeouts = mutableListOf<CleanupStepTimeouts>()
+
+        override fun send(
+            url: String,
+            headers: Map<String, String>,
+            jsonBody: String,
+            timeouts: CleanupStepTimeouts,
+            cancelHolder: InFlightCall,
+            callback: (CleanupHttpOutcome) -> Unit,
+        ) {
+            urls.add(url)
+            this.timeouts.add(timeouts)
+            callback(CleanupHttpOutcome.Ok("""{"choices":[{"message":{"content":"cleaned"}}]}"""))
+        }
+    }
+
+    private fun run(chain: ProviderChain): Pair<RecordingTransport, PostProcessor.Result> {
+        val transport = RecordingTransport()
+        var captured: PostProcessor.Result? = null
+        PostProcessor.processProviderChain(
+            text = "raw transcript",
+            prompt = "clean it up",
+            chain = chain,
+            cursor = CleanupWaterfallCursor(),
+            cancelHolder = InFlightCall(),
+            credentialLookup = { "test-key" },
+            transport = transport,
+            callback = { captured = it },
+        )
+        return transport to (captured ?: error("callback never fired"))
+    }
+
+    @Test fun `a single OpenAI chain is executed by CleanupWaterfallExecutor, not the direct path (#105)`() {
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini")))
+
+        val (transport, result) = run(chain)
+
+        // Reaching the injected transport at all is the assertion: the old special case called
+        // PostProcessor.process(), which builds its own OkHttp call and would never touch this.
+        assertEquals(1, transport.urls.size)
+        assertEquals("cleaned", result.text)
+    }
+
+    @Test fun `a single OpenAI chain gets the waterfall's tight timeouts, not the long shared ones (#105)`() {
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini")))
+
+        val (transport, _) = run(chain)
+
+        // The substance of #105: these are per-step cleanup timeouts, seconds not minutes. The
+        // bypassed path used NetworkClients.shared's 20s/120s budget sized for audio uploads.
+        val used = transport.timeouts.single()
+        assertTrue(
+            "connect timeout ${used.connectMs}ms should be a cleanup-sized budget, not an upload-sized one",
+            used.connectMs in 1..5_000,
+        )
+        assertTrue(
+            "read timeout ${used.readMs}ms should be a cleanup-sized budget, not an upload-sized one",
+            used.readMs in 1..30_000,
+        )
+    }
+
+    @Test fun `a multi provider chain still routes through the executor`() {
+        val chain = ProviderChain(
+            listOf(
+                ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini"),
+                ProviderChainEntry(ProviderKind.ANTHROPIC, "claude-haiku"),
+            ),
+        )
+
+        val (transport, result) = run(chain)
+
+        assertEquals(1, transport.urls.size) // first step succeeds, no failover needed
+        assertEquals("cleaned", result.text)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/ProviderChainRuntimeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ProviderChainRuntimeTest.kt
@@ -57,14 +57,10 @@ class ProviderChainRuntimeCleanupAdapterTest {
     }
 
     @Test fun `single OpenAI cleanup chain produces a one-step waterfall for CleanupWaterfallExecutor`() {
-        // Regression test for #105: PostProcessor.processProviderChain used to special-case
-        // isSingleOpenAiCleanup(chain) to call PostProcessor.process() directly (with much
-        // longer NetworkClients.shared timeouts), bypassing CleanupWaterfallExecutor's tighter
-        // CleanupStepTimeouts/CLEANUP_WATERFALL_HARD_CAP_MS. That special case is gone now --
-        // every chain, including this one, is executed via CleanupWaterfallExecutor.execute --
-        // so this pins the underlying invariant that made removing the special case safe: a
-        // single-OpenAI chain is exactly a one-step waterfall, which
-        // CleanupWaterfallPlanner.groupConsecutive already handles as its own single group.
+        // Companion to #105: a single-OpenAI chain is exactly a one-step waterfall, which
+        // CleanupWaterfallPlanner.groupConsecutive already handles as its own single group. That
+        // invariant is what made removing processProviderChain's special case safe. This asserts
+        // only the shape -- see PostProcessorProviderChainRoutingTest for the routing itself.
         val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini")))
 
         val waterfall = ProviderChainRuntime.cleanupWaterfallFor(chain)

--- a/app/src/test/kotlin/com/trevornk/ramblr/StreamingPreviewTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/StreamingPreviewTest.kt
@@ -163,17 +163,199 @@ class StreamingPreviewTest {
     }
 
     // --- resolveRealText (hint-text-is-not-content, #47) ---
+    //
+    // The #47 cases below predate the #140 selection signals, so they pin a plain focused field
+    // holding a real cursor -- the state in which only isShowingHintText decides the outcome.
+
+    /** A focused editable field with a real cursor: the #47 state, before #140's signals apply. */
+    private fun realText(rawText: String?, isShowingHintText: Boolean): String = resolveRealText(
+        rawText = rawText,
+        isShowingHintText = isShowingHintText,
+        selectionStart = 0,
+        selectionEnd = 0,
+        isEditable = true,
+        isFocused = true,
+    )
 
     @Test fun `hint text showing is treated as empty, not the hint string itself`() {
-        assertEquals("", resolveRealText(rawText = "RCS message", isShowingHintText = true))
+        assertEquals("", realText(rawText = "RCS message", isShowingHintText = true))
     }
 
     @Test fun `real typed text is returned unchanged when hint isn't showing`() {
-        assertEquals("already typed", resolveRealText(rawText = "already typed", isShowingHintText = false))
+        assertEquals("already typed", realText(rawText = "already typed", isShowingHintText = false))
     }
 
     @Test fun `null text with hint not showing resolves to empty`() {
-        assertEquals("", resolveRealText(rawText = null, isShowingHintText = false))
+        assertEquals("", realText(rawText = null, isShowingHintText = false))
+    }
+
+    // --- resolveRealText: self-drawn placeholders (#140) ---
+    // WhatsApp's "Message" composer reports isShowingHintText = false AND hintText = null while
+    // getText() still returns "Message", so neither the #47 check nor any hint comparison can see
+    // it. The distinguishing signal measured on-device is the text selection: a placeholder has no
+    // cursor inside it and reports -1/-1, while a field holding real content always reports an
+    // insertion point (>= 0). Every constant below is a value observed on a Pixel 10a.
+
+    @Test fun `WhatsApp's self-drawn placeholder with no selection is treated as empty`() {
+        // Measured: text='Message' hint=null showingHint=false selStart=-1 selEnd=-1
+        assertEquals(
+            "",
+            resolveRealText(
+                rawText = "Message",
+                isShowingHintText = false,
+                selectionStart = -1,
+                selectionEnd = -1,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `the same string typed by the user is kept, because it reports a real cursor`() {
+        // Measured: user typed "Message" -> selStart=7 selEnd=7. Identical text to the placeholder
+        // above, so selection is the only thing separating a real draft from a placeholder.
+        assertEquals(
+            "Message",
+            resolveRealText(
+                rawText = "Message",
+                isShowingHintText = false,
+                selectionStart = 7,
+                selectionEnd = 7,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `a restored WhatsApp draft is never treated as a placeholder`() {
+        // Measured: navigate away from a chat with an unsent draft and return -> selStart=0.
+        // This is the case that would silently destroy a user's unsent message if 0 were
+        // treated the same as -1.
+        assertEquals(
+            "DraftMyDraft",
+            resolveRealText(
+                rawText = "DraftMyDraft",
+                isShowingHintText = false,
+                selectionStart = 0,
+                selectionEnd = 0,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `prefilled text that never received a selection event is kept`() {
+        // Measured in Chrome: <input value="RealPrefilledText"> focused programmatically and never
+        // touched -- the exact "selection not yet reported" hazard resolveInsertionStart documents.
+        // It reports 0, not -1, so it must survive.
+        assertEquals(
+            "RealPrefilledText",
+            resolveRealText(
+                rawText = "RealPrefilledText",
+                isShowingHintText = false,
+                selectionStart = 0,
+                selectionEnd = 0,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `an unfocused node holding real text is never blanked`() {
+        // Measured: Keep note title/body nodes are collected as candidates while unfocused and
+        // hold genuine content. The focus guard keeps this path away from them entirely.
+        assertEquals(
+            "Mushrooms",
+            resolveRealText(
+                rawText = "Mushrooms",
+                isShowingHintText = false,
+                selectionStart = -1,
+                selectionEnd = -1,
+                isEditable = true,
+                isFocused = false,
+            ),
+        )
+    }
+
+    @Test fun `a non-editable node holding real text is never blanked`() {
+        assertEquals(
+            "static label",
+            resolveRealText(
+                rawText = "static label",
+                isShowingHintText = false,
+                selectionStart = -1,
+                selectionEnd = -1,
+                isEditable = false,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `Keep's search placeholder is still caught by the framework hint flag`() {
+        // Measured: Keep reports isShowingHintText=true, so #47's original check already covered
+        // it. This is why the earlier text==hint comparison was redundant.
+        assertEquals(
+            "",
+            resolveRealText(
+                rawText = "Search Keep",
+                isShowingHintText = true,
+                selectionStart = -1,
+                selectionEnd = -1,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `blank text is left untouched rather than treated as a placeholder`() {
+        // The placeholder branch deliberately requires non-blank text: a whitespace-only field is
+        // not a placeholder (no app draws one as spaces), and silently trimming the user's
+        // whitespace is not this function's job. It falls through and is returned verbatim.
+        assertEquals(
+            "   ",
+            resolveRealText(
+                rawText = "   ",
+                isShowingHintText = false,
+                selectionStart = -1,
+                selectionEnd = -1,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `a partially reported selection is not treated as a placeholder`() {
+        // Only a fully absent selection (-1/-1) is a placeholder signal; a half-reported
+        // selection is ambiguous and must not blank real content.
+        assertEquals(
+            "real text",
+            resolveRealText(
+                rawText = "real text",
+                isShowingHintText = false,
+                selectionStart = -1,
+                selectionEnd = 3,
+                isEditable = true,
+                isFocused = true,
+            ),
+        )
+    }
+
+    @Test fun `isShowingHintText still wins regardless of selection`() {
+        // The #47 framework-hint check must short-circuit before the #140 signals are consulted,
+        // in every selection state -- otherwise a hint reporting a real cursor would leak through.
+        for (selection in listOf(-1, 0, 4)) {
+            assertEquals(
+                "",
+                resolveRealText(
+                    rawText = "RCS message",
+                    isShowingHintText = true,
+                    selectionStart = selection,
+                    selectionEnd = selection,
+                    isEditable = true,
+                    isFocused = true,
+                ),
+            )
+        }
     }
 
     // --- resolveInsertionStart (first-partial insertion point, #42) ---
@@ -194,5 +376,66 @@ class StreamingPreviewTest {
 
     @Test fun `a genuine (0, 0) report against empty existing text is trusted`() {
         assertEquals(0, resolveInsertionStart(selStart = 0, selEnd = 0, currentTextLength = 0))
+    }
+
+    @Test fun `a restored WhatsApp draft appends at the end rather than prepending (#140)`() {
+        // Regression guard for the direct ACTION_SET_TEXT path in tryInjectIntoNode, which used to
+        // trust node.textSelectionStart directly instead of routing through this helper. Measured
+        // on-device: leaving a WhatsApp chat with an unsent draft and returning reports selStart=0
+        // while the visible cursor sits at the end, so dictating "draft" + " world" produced
+        // " worlddraft". Both paths now agree and insert at the end.
+        assertEquals(5, resolveInsertionStart(selStart = 0, selEnd = 0, currentTextLength = 5))
+    }
+
+    // --- resolveReplacementSpan (one-shot ACTION_SET_TEXT overwrite span, #140) ---
+
+    /** Applies the span the way tryInjectIntoNode does, so the tests assert real user-visible text. */
+    private fun inject(current: String, selStart: Int, selEnd: Int, spoken: String): String {
+        val span = resolveReplacementSpan(selStart, selEnd, current.length)
+        return current.replaceRange(span.start, span.endExclusive, spoken)
+    }
+
+    @Test fun `a restored draft reporting (0, 0) is appended to, not prepended (#140)`() {
+        // The exact on-device failure: WhatsApp draft restored by leaving and re-entering the chat.
+        assertEquals("draft world", inject("draft", selStart = 0, selEnd = 0, spoken = " world"))
+    }
+
+    @Test fun `an unreported selection appends at the end`() {
+        assertEquals("hello world", inject("hello", selStart = -1, selEnd = -1, spoken = " world"))
+    }
+
+    @Test fun `a genuine caret mid-text inserts exactly there`() {
+        assertEquals("hel-X-lo", inject("hel-lo", selStart = 4, selEnd = 4, spoken = "X-"))
+    }
+
+    @Test fun `a genuine ranged selection replaces the highlighted text`() {
+        // Dictating over a highlighted word must still overwrite it rather than insert alongside.
+        assertEquals("hello there", inject("hello world", selStart = 6, selEnd = 11, spoken = "there"))
+    }
+
+    @Test fun `a reversed ranged selection is normalised rather than crashing`() {
+        // Some nodes report the anchor after the focus when the user drags right-to-left.
+        assertEquals("hello there", inject("hello world", selStart = 11, selEnd = 6, spoken = "there"))
+    }
+
+    @Test fun `a genuine (0, 0) caret in an empty field is trusted`() {
+        assertEquals("world", inject("", selStart = 0, selEnd = 0, spoken = "world"))
+    }
+
+    @Test fun `a stale index past the end of the text is clamped instead of throwing`() {
+        // A node can report a selection against a string it is no longer showing; replaceRange
+        // would throw IndexOutOfBoundsException uncaught and kill the accessibility service.
+        assertEquals("hi world", inject("hi", selStart = 99, selEnd = 99, spoken = " world"))
+    }
+
+    @Test fun `a partially reported selection is treated as unreliable and appends`() {
+        assertEquals("hello world", inject("hello", selStart = 0, selEnd = -1, spoken = " world"))
+    }
+
+    @Test fun `an overridden start never deletes existing text`() {
+        // start is overridden to the end as unreliable; the span must collapse to a pure insertion
+        // rather than deleting through to a selEnd derived from the same distrusted report.
+        val span = resolveReplacementSpan(selStart = 0, selEnd = 0, currentTextLength = 5)
+        assertEquals(span.start, span.endExclusive)
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/TranscriberClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/TranscriberClientTest.kt
@@ -29,6 +29,28 @@ class TranscriberClientTest {
         assertNotNull(r.error)
     }
 
+    // --- transcript trimming (#140) ---
+    // A trailing newline in the model's transcript was injected verbatim into the user's field,
+    // leaving the cursor several lines below the dictated text (reported against Google Keep).
+    // Every other transcription parser in the app already trims; this one was the exception.
+
+    @Test fun `trailing newlines are trimmed off the transcript`() {
+        val r = TranscriberClient.parseResponse("""{"text": "Hello world\n\n\n"}""")
+        assertEquals("Hello world", r.text)
+        assertNull(r.error)
+    }
+
+    @Test fun `leading whitespace is trimmed off the transcript`() {
+        val r = TranscriberClient.parseResponse("""{"text": "  Hello world"}""")
+        assertEquals("Hello world", r.text)
+    }
+
+    @Test fun `interior newlines are preserved`() {
+        // Only the edges are trimmed -- a genuine multi-line dictation must survive intact.
+        val r = TranscriberClient.parseResponse("""{"text": "\nline one\nline two\n"}""")
+        assertEquals("line one\nline two", r.text)
+    }
+
     // -- endpoint construction honors the base-URL override (M5) --
 
     @Test fun `default base url resolves to OpenAI's transcriptions endpoint`() {


### PR DESCRIPTION
Four fixes found while chasing the WhatsApp placeholder report. Each is a separate commit with its own regression tests.

**#140 — 'Message' appears before dictated text** (65dc6c1)

The reported symptom was `Messagehello world` in WhatsApp. The original approach compared node text against `hintText`, which was derived from Keep and does not hold for WhatsApp: WhatsApp draws its own "Message" string with `hint=null` and `isShowingHintText=false`, so hint-equality never fires.

What actually distinguishes a self-drawn placeholder is the reported text selection. On-device node signals:

| state | text | selection |
|---|---|---|
| WhatsApp empty composer | `Message` | `-1/-1` |
| user literally typed "Message" | `Message` | `7/7` |
| restored draft | `draft` | `0/0` |
| Chrome prefilled input | value | `0/0` |

So the resolver treats self-drawn text as empty only when the node is editable, focused, and reports *both* selection offsets negative. Real text with a valid or zero selection is preserved — including a literal "Message" the user typed, restored drafts, and prefilled form content. Framework hints are still handled by `isShowingHintText`.

**#105 — single-OpenAI cleanup bypassed the executor** (40552af) and **#110 — NetworkWarmup never pre-warmed OmniRoute** (332fd41).

**New: local cleanup emitted a literal `{{vocabulary}}`** (6d1e0d2, filed as #141)

Found on-device while verifying the above. The cloud prompt was interpolated but the local prompt was passed through raw, so LFM2.5 — which has no fine-tuned prompt and falls back to `SIMPLE_PROMPT` — received `{{vocabulary}}` as its system prompt and echoed it back as the whole transcript. Interpolation now happens inside the function that picks the prompt.

## Verification

Local run of CI's exact task set (`testGithubDebugUnitTest testStorefrontDebugUnitTest assembleGithubDebug assembleStorefrontDebug`, `--rerun-tasks`), asserted against parsed JUnit XML rather than a build-log grep:

```
testGithubDebugUnitTest:     tests=1037 failures+errors=0
testStorefrontDebugUnitTest: tests=971  failures+errors=0
```

The #140 fix was confirmed end-to-end on a Pixel 10a through the real `injectText()` path in WhatsApp — `text="Message"` became `"hello world"`, with no prepend. No message was sent. The temporary debug broadcast hook used for that has been removed; verification asserts no `PROBE140` residue in `app/src`.

The #141 fix is bytecode-verified in the built APK (`systemPromptFor` calls `PostProcessor.interpolateVocabulary` in `classes4.dex`), so it is in the artifact and not just the source. Its on-device confirmation is still outstanding — the test device was locked when this was opened.

Refs #140, #105, #110, #141 — leaving all four open until on-device confirmation and reporter feedback land.
