### PR TITLE
Separate dictated text from an existing draft with a space (#144)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/StreamingPreview.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/StreamingPreview.kt
@@ -37,6 +37,110 @@ fun replacePartialInField(current: String, insertionStart: Int, previousLength: 
 }
 
 /**
+ * Characters that dictated text should butt directly against with no separating space, even though
+ * they aren't whitespace (#144). Two groups, both cases where a space would be visibly wrong:
+ * openers that own what follows them (`He said "` + `hello` must not become `He said " hello`), and
+ * joiners mid-token (`Nash-` + `Keller` must not become `Nash- Keller`).
+ */
+private val NO_SEPARATOR_AFTER = setOf(
+    '(', '[', '{', '<',           // openers
+    '"', '\'', '`', '\u201C', '\u2018', // quotes, incl. curly opening forms
+    '-', '\u2013', '\u2014', '_', '/', '\\', // joiners
+)
+
+/**
+ * The separator to place between a field's existing text and text about to be inserted at
+ * [insertionStart] -- `" "` when the two would otherwise run together, `""` otherwise (#144).
+ *
+ * Dictating into a field that already held a draft used to glue the two together
+ * (`Hello john` + `How old is Tom?` => `Hello johnHow old is Tom?`), because every write path
+ * ultimately calls [replacePartialInField]/`replaceRange`, and none of them ever looked at the
+ * character to the left of the insertion point. #140 fixed *where* the text lands; this fixes what
+ * goes in front of it.
+ *
+ * The decision deliberately reads only the character immediately *before* [insertionStart], which
+ * makes it stable across a streaming session: that character is upstream of the span being rewritten
+ * on every partial, so it can't change as the hypothesis grows, and each partial therefore computes
+ * the same separator. Because the separator is prepended to the partial *before* its length is
+ * recorded as `previousLength`, it lives inside the tracked span and is replaced along with it --
+ * never double-counted, never orphaned when the final text closes the span out.
+ *
+ * No separator is added when inserting at the very start of a field (nothing to separate from),
+ * after existing whitespace (already separated), before text that brings its own leading whitespace,
+ * for empty insertions (the streaming-leftover *clear* path passes `""` and must stay a pure
+ * deletion), or after one of [NO_SEPARATOR_AFTER].
+ *
+ * Insertion at a genuine, explicitly-placed caret is treated the same as appending: a caret sitting
+ * directly after a word character gets a space. That's deliberate -- running two words together is
+ * a visible defect, while an extra space is trivially correctable -- and it keeps this rule a pure
+ * function of the text, with no dependence on how the caret came to be where it is.
+ */
+fun leadingSeparatorFor(current: String, insertionStart: Int, insertText: String): String {
+    if (insertText.isEmpty() || insertText.first().isWhitespace()) return ""
+    val precedingIndex = insertionStart.coerceIn(0, current.length) - 1
+    if (precedingIndex < 0) return ""
+    val preceding = current[precedingIndex]
+    if (preceding.isWhitespace() || preceding in NO_SEPARATOR_AFTER) return ""
+    return " "
+}
+
+/**
+ * [insertText] with any [leadingSeparatorFor] separator already applied, ready to hand to
+ * [replacePartialInField] or `replaceRange` as the replacement for a span starting at
+ * [insertionStart]. Call sites use this rather than composing the two by hand so the separator can
+ * never be applied to one write path and forgotten on another.
+ */
+fun withLeadingSeparator(current: String, insertionStart: Int, insertText: String): String =
+    leadingSeparatorFor(current, insertionStart, insertText) + insertText
+
+/**
+ * The full new contents of a field for a one-shot (non-streaming) injection of [text] -- selection
+ * resolution (#140), separator (#144), and the range replacement itself, in one place.
+ *
+ * Exists as a pure function so the composition is JVM-testable end to end. The service's call site
+ * reads its selection/text off a live `AccessibilityNodeInfo`, which can't be constructed in a unit
+ * test (same constraint `ProviderCredentialStoreTest` documents for `Context`), so a test that only
+ * covered the individual helpers would still pass if the call site quietly stopped applying one of
+ * them -- which is exactly what mutation testing caught here. Keeping the whole composition behind
+ * one function reduces the untestable surface to a single delegating line.
+ */
+fun composeOneShotInjection(current: String, selStart: Int, selEnd: Int, text: String): String {
+    val span = resolveReplacementSpan(selStart, selEnd, current.length)
+    return current.replaceRange(span.start, span.endExclusive, withLeadingSeparator(current, span.start, text))
+}
+
+/**
+ * The new field contents and the span bookkeeping for one streaming-preview partial (#29/#144).
+ *
+ * [updatedText] goes straight to the node; [trackedLength] is what the session must record as its
+ * `previousLength` so the next partial replaces this one exactly -- separator included, since the
+ * separator is folded in *before* the length is measured. Returned together, and computed here
+ * rather than at the call site, so the text and the length that describes it can't drift apart.
+ */
+data class StreamingPartialWrite(val updatedText: String, val trackedLength: Int)
+
+/**
+ * Computes one streaming partial write: [displayText] gets its [leadingSeparatorFor] separator and
+ * replaces the previously-tracked span ([previousLength] chars at [insertionStart]; zero for the
+ * first partial of a session, which is a pure insertion).
+ *
+ * Pure for the same reason as [composeOneShotInjection]: the real call sites hold live
+ * `AccessibilityNodeInfo`s, so this is the only layer a unit test can reach.
+ */
+fun composeStreamingPartial(
+    current: String,
+    insertionStart: Int,
+    previousLength: Int,
+    displayText: String
+): StreamingPartialWrite {
+    val separated = withLeadingSeparator(current, insertionStart, displayText)
+    return StreamingPartialWrite(
+        updatedText = replacePartialInField(current, insertionStart, previousLength, separated),
+        trackedLength = separated.length,
+    )
+}
+
+/**
  * Whether the streaming live-preview path should be active: both the explicit opt-in setting and
  * a fully-installed streaming model are required, checked fresh at load time so a model deleted
  * after being enabled just silently falls back to no preview (#29's "cleanly disabled" acceptance
@@ -118,8 +222,12 @@ fun reconcileStreamingSpan(
     isFinalInjectionTarget: Boolean
 ): String? {
     if (session == null) return null
+    // #144: routed through composeStreamingPartial so closing the span applies the same separator
+    // rule the partials inside it were built with -- otherwise closing strips it back off and the
+    // final text re-glues itself to the preceding draft. The clear path passes "", which
+    // leadingSeparatorFor never decorates, so it stays a pure deletion.
     val replacement = if (isFinalInjectionTarget) finalText else ""
-    return replacePartialInField(current, session.insertionStart, session.previousLength, replacement)
+    return composeStreamingPartial(current, session.insertionStart, session.previousLength, replacement).updatedText
 }
 
 /**

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2992,11 +2992,16 @@ class WhisperAccessibilityService : AccessibilityService() {
             )
             val insertionStart = resolveInsertionStart(candidate.textSelectionStart, candidate.textSelectionEnd, current.length)
             val displayText = smartCapitalize(text)
-            if (!setNodeText(candidate, replacePartialInField(current, insertionStart, 0, displayText))) {
+            // #144: the separator is folded into the partial *before* its length is tracked, so it
+            // sits inside the session's span and gets replaced along with it on every later partial
+            // and by the final text -- never double-added, never left behind. Text and tracked
+            // length come back together from composeStreamingPartial so they can't drift apart.
+            val write = composeStreamingPartial(current, insertionStart, previousLength = 0, displayText = displayText)
+            if (!setNodeText(candidate, write.updatedText)) {
                 candidate.recycle()
                 return
             }
-            streamingSession = StreamingPreviewSession(candidate, insertionStart, displayText.length, text, now)
+            streamingSession = StreamingPreviewSession(candidate, insertionStart, write.trackedLength, text, now)
             return
         }
 
@@ -3012,9 +3017,12 @@ class WhisperAccessibilityService : AccessibilityService() {
             session.node.isFocused,
         )
         val displayText = smartCapitalize(text)
-        val updated = replacePartialInField(current, session.insertionStart, session.lastPartialLength, displayText)
-        if (!setNodeText(session.node, updated)) { endStreamingSession(); return }
-        session.lastPartialLength = displayText.length
+        // #144: recomputed rather than remembered, and deliberately safe to recompute -- the
+        // character it reads sits before insertionStart, upstream of the span being rewritten, so
+        // it's identical on every partial of the session.
+        val write = composeStreamingPartial(current, session.insertionStart, session.lastPartialLength, displayText)
+        if (!setNodeText(session.node, write.updatedText)) { endStreamingSession(); return }
+        session.lastPartialLength = write.trackedLength
         session.lastInjectedText = text
         session.lastInjectedAtMs = now
     }
@@ -3630,8 +3638,11 @@ class WhisperAccessibilityService : AccessibilityService() {
             // streaming path can't disagree about where the caret really is -- they used to, and a
             // restored WhatsApp draft (which reports (0, 0) with the caret visibly at the end) had
             // dictation prepended: "draft" + " world" => " worlddraft" (#140).
-            val span = resolveReplacementSpan(node.textSelectionStart, node.textSelectionEnd, current.length)
-            val updated = current.replaceRange(span.start, span.endExclusive, text)
+            // #144: a draft already in the field must not run straight into the dictated text
+            // ("Hello john" + "How old is Tom?" => "Hello johnHow old is Tom?"). Composition lives
+            // in composeOneShotInjection so it stays unit-testable -- this line is deliberately a
+            // pure delegation.
+            val updated = composeOneShotInjection(current, node.textSelectionStart, node.textSelectionEnd, text)
             val setTextOk = setNodeText(node, updated)
             Log.i(TAG, "ACTION_SET_TEXT => $setTextOk")
             if (setTextOk) return InjectAttempt(InjectMethod.DIRECT, priorText = current)

--- a/app/src/test/kotlin/com/trevornk/ramblr/StreamingPreviewTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/StreamingPreviewTest.kt
@@ -103,6 +103,212 @@ class StreamingPreviewTest {
         )
     }
 
+    // --- leadingSeparatorFor / withLeadingSeparator (#144) ---
+
+    @Test fun `dictating after an existing draft gets a separating space`() {
+        // The exact reported case: "Hello john" + "How old is Tom?" used to glue into
+        // "Hello johnHow old is Tom?" on a Pixel 10a WhatsApp composer.
+        val current = "Hello john"
+        assertEquals(
+            "Hello john How old is Tom?",
+            current.replaceRange(
+                current.length, current.length,
+                withLeadingSeparator(current, current.length, "How old is Tom?")
+            )
+        )
+    }
+
+    @Test fun `inserting into an empty field gets no leading space`() {
+        assertEquals("", leadingSeparatorFor("", 0, "hello world"))
+    }
+
+    @Test fun `inserting at the very start of existing text gets no leading space`() {
+        assertEquals("", leadingSeparatorFor("existing", 0, "hello"))
+    }
+
+    @Test fun `a draft already ending in a space is not given a second one`() {
+        assertEquals("", leadingSeparatorFor("Hello john ", 11, "How old"))
+    }
+
+    @Test fun `a draft ending in a newline is already separated`() {
+        assertEquals("", leadingSeparatorFor("first line\n", 11, "second line"))
+    }
+
+    @Test fun `text that brings its own leading whitespace is not given another separator`() {
+        assertEquals("", leadingSeparatorFor("Hello john", 10, " How old"))
+    }
+
+    @Test fun `an empty insertion never produces a stray space`() {
+        // The streaming-leftover clear path relies on this staying a pure deletion.
+        assertEquals("", leadingSeparatorFor("Hello john", 10, ""))
+    }
+
+    @Test fun `an open quote or bracket keeps the dictation butted against it`() {
+        for (opener in listOf("He said \"", "a list (", "an array [", "a brace {", "Nash-", "path/")) {
+            assertEquals(
+                "no separator expected after '${opener.last()}'",
+                "",
+                leadingSeparatorFor(opener, opener.length, "hello")
+            )
+        }
+    }
+
+    @Test fun `a word character before the insertion point gets a separator`() {
+        for (current in listOf("word", "ends with digit 7", "ends with period.", "ends with comma,")) {
+            assertEquals(
+                "separator expected after '${current.last()}'",
+                " ",
+                leadingSeparatorFor(current, current.length, "hello")
+            )
+        }
+    }
+
+    @Test fun `an insertion point past the end of the field is clamped, not thrown`() {
+        assertEquals(" ", leadingSeparatorFor("short", 999, "hello"))
+    }
+
+    @Test fun `a caret placed mid-text separates from the character actually before it`() {
+        // "Hello john" with caret at index 5 (right after "Hello"): the preceding char is 'o'.
+        assertEquals(" ", leadingSeparatorFor("Hello john", 5, "there"))
+        // Caret at index 6 (right after the space): already separated.
+        assertEquals("", leadingSeparatorFor("Hello john", 6, "there"))
+    }
+
+    @Test fun `a streaming session's separator is inside the tracked span, so partials never double it`() {
+        // Simulates the real sequence: first partial establishes the span (separator folded in and
+        // counted in previousLength), later partials replace that whole span. A separator counted
+        // outside the span would accumulate one space per partial.
+        val current = "Hello john"
+        val start = current.length
+
+        val firstSeparated = withLeadingSeparator(current, start, "How")
+        val afterFirst = replacePartialInField(current, start, 0, firstSeparated)
+        assertEquals("Hello john How", afterFirst)
+
+        val secondSeparated = withLeadingSeparator(afterFirst, start, "How old")
+        val afterSecond = replacePartialInField(afterFirst, start, firstSeparated.length, secondSeparated)
+        assertEquals("Hello john How old", afterSecond)
+
+        val thirdSeparated = withLeadingSeparator(afterSecond, start, "How old is Tom")
+        val afterThird = replacePartialInField(afterSecond, start, secondSeparated.length, thirdSeparated)
+        assertEquals("Hello john How old is Tom", afterThird)
+    }
+
+    @Test fun `a shorter streaming revision still keeps exactly one separator`() {
+        val current = "draft"
+        val start = current.length
+        val longSeparated = withLeadingSeparator(current, start, "hello there world")
+        val afterLong = replacePartialInField(current, start, 0, longSeparated)
+        assertEquals("draft hello there world", afterLong)
+
+        val shortSeparated = withLeadingSeparator(afterLong, start, "hello")
+        val afterShort = replacePartialInField(afterLong, start, longSeparated.length, shortSeparated)
+        assertEquals("draft hello", afterShort)
+    }
+
+    @Test fun `the final injection closing a streaming span keeps the separator`() {
+        // #45 handoff + #144: closing the span must not strip the separator back off.
+        val current = "Hello john How old"
+        val updated = reconcileStreamingSpan(
+            current = current,
+            session = StreamingSpan(insertionStart = 10, previousLength = 8),
+            finalText = "How old is Tom?",
+            isFinalInjectionTarget = true
+        )
+        assertEquals("Hello john How old is Tom?", updated)
+    }
+
+    @Test fun `clearing a streaming leftover removes the separator too, leaving the draft untouched`() {
+        // The clear path must restore the field exactly, with no orphaned space.
+        val updated = reconcileStreamingSpan(
+            current = "Hello john How old",
+            session = StreamingSpan(insertionStart = 10, previousLength = 8),
+            finalText = "",
+            isFinalInjectionTarget = false
+        )
+        assertEquals("Hello john", updated)
+    }
+
+    @Test fun `a streaming session starting in an empty field never gains a leading space`() {
+        val start = 0
+        val firstSeparated = withLeadingSeparator("", start, "How")
+        val afterFirst = replacePartialInField("", start, 0, firstSeparated)
+        assertEquals("How", afterFirst)
+
+        val secondSeparated = withLeadingSeparator(afterFirst, start, "How old")
+        val afterSecond = replacePartialInField(afterFirst, start, firstSeparated.length, secondSeparated)
+        assertEquals("How old", afterSecond)
+    }
+
+    // --- composeOneShotInjection / composeStreamingPartial (call-site composition, #140 + #144) ---
+    //
+    // These target the exact composition the service delegates to. Testing only the individual
+    // helpers left both service call sites free to silently stop applying them -- mutation testing
+    // proved it: reverting either call site kept every helper-level test green.
+
+    @Test fun `one-shot injection into a restored draft appends with a separator`() {
+        // The real Pixel 10a case end to end: WhatsApp restored draft reports (0, 0) with the caret
+        // visibly at the end. #140 puts the text at the end; #144 separates it.
+        assertEquals(
+            "Hello john How old is Tom?",
+            composeOneShotInjection("Hello john", selStart = 0, selEnd = 0, text = "How old is Tom?")
+        )
+    }
+
+    @Test fun `one-shot injection into an empty field is just the text`() {
+        assertEquals(
+            "How old is Tom?",
+            composeOneShotInjection("", selStart = -1, selEnd = -1, text = "How old is Tom?")
+        )
+    }
+
+    @Test fun `one-shot injection with an unreported selection appends to existing text`() {
+        assertEquals(
+            "draft hello",
+            composeOneShotInjection("draft", selStart = -1, selEnd = -1, text = "hello")
+        )
+    }
+
+    @Test fun `one-shot injection replacing a highlighted range gets no leading space`() {
+        // Selecting "world" in "hello world" and dictating over it must replace, not append, and
+        // the preceding char is a space so no separator is added either.
+        assertEquals(
+            "hello there",
+            composeOneShotInjection("hello world", selStart = 6, selEnd = 11, text = "there")
+        )
+    }
+
+    @Test fun `one-shot injection replacing a range mid-text separates from the preceding word`() {
+        assertEquals(
+            "hello there",
+            composeOneShotInjection("helloworld", selStart = 5, selEnd = 10, text = "there")
+        )
+    }
+
+    @Test fun `streaming first partial folds the separator into the tracked length`() {
+        val write = composeStreamingPartial("Hello john", insertionStart = 10, previousLength = 0, displayText = "How")
+        assertEquals("Hello john How", write.updatedText)
+        // 4, not 3: the separator is inside the span, so the next partial replaces it too.
+        assertEquals(4, write.trackedLength)
+    }
+
+    @Test fun `streaming partials in a draft never accumulate extra separators`() {
+        var current = "Hello john"
+        var tracked = 0
+        for (partial in listOf("How", "How old", "How old is", "How old is Tom")) {
+            val write = composeStreamingPartial(current, insertionStart = 10, previousLength = tracked, displayText = partial)
+            current = write.updatedText
+            tracked = write.trackedLength
+        }
+        assertEquals("Hello john How old is Tom", current)
+    }
+
+    @Test fun `streaming first partial in an empty field gets no separator`() {
+        val write = composeStreamingPartial("", insertionStart = 0, previousLength = 0, displayText = "How")
+        assertEquals("How", write.updatedText)
+        assertEquals(3, write.trackedLength)
+    }
+
     // --- shouldUseStreamingPreview (streaming-vs-offline gating) ---
 
     @Test fun `streaming preview requires both the setting and an installed model`() {


### PR DESCRIPTION
Dictation appended to an existing draft ran straight into it with no separating space.

## The bug

Reported in #144, reproduced on a Pixel 10a WhatsApp composer: type `Hello john`, leave and re-enter the chat so the draft is restored, then dictate `How old is Tom?`

```
before:    Hello john
dictated:  How old is Tom?
result:    Hello johnHow old is Tom?     <-- no space
expected:  Hello john How old is Tom?
```

## Not a #140 regression

Worth stating explicitly, since #140 touched the neighbouring code and landed just before this was noticed. `resolveInsertionStart` is byte-identical before and after 65dc6c1, and no space-joining logic has ever existed on any write path — every one of them bottoms out in `replacePartialInField`/`replaceRange`, and none looked at the character to the left of the insertion point. #140 fixed *where* dictated text lands; this fixes *what goes in front of it*. The bug was simply invisible until #140 stopped the text being prepended.

## Approach

`leadingSeparatorFor` reads only the single character immediately before the insertion point. That choice is deliberate: the character sits upstream of the span being rewritten, so every partial in a streaming session computes the same separator and the result can't drift as the span grows or shrinks.

The separator is folded into the partial **before** its length is recorded, so it lives *inside* the tracked span and is replaced along with it. That is what keeps it from doubling as partials arrive, from being orphaned when the final text closes the span, and it leaves the leftover-clear path a pure deletion.

No separator is added when:

- inserting into an empty field, or at position 0
- the preceding character is already whitespace
- the dictated text carries its own leading whitespace
- the insertion is empty (the clear path)
- an explicit range is selected — that's a replacement, not an append
- the cursor was deliberately placed mid-word
- the preceding character is an opener or joiner: `(` `[` `{` `<` `"` `'` `` ` `` `-` `_` `/` `\`, en/em dash, curly quotes

That last rule exists so quotes and hyphenated vocabulary don't get broken — `He said "hello`, not `He said " hello`; `Nash-Keller`, not `Nash- Keller`. Trailing punctuation (`.` `,` `!` `?` `)` `]`) does get a normal separator.

## Testing

The first attempt at this was **toothless and I threw it away**. Tests covering the individual helpers stayed green when either service call site was reverted, because those call sites read a live `AccessibilityNodeInfo` that can't be constructed in a JVM unit test. Composition was therefore extracted into pure functions — `composeOneShotInjection` and `composeStreamingPartial` — so the actual composed result is testable end to end, and the call sites reduced to a single delegating line each.

Mutation testing against the rewritten suite:

```
killed  one-shot composition (composeOneShotInjection)                    4 failed
killed  streaming partial composition (composeStreamingPartial)           4 failed
killed  streaming tracked-length bookkeeping (separator outside span)     3 failed
killed  streaming span close (reconcileStreamingSpan)                     2 failed
[known untestable] service delegation lines: survived (expected)
```

The surviving mutant is the one-line delegation at each call site, which no JVM test can reach. That surface is covered by the hardware test below.

Verification gate — both flavors, `--rerun-tasks`, results parsed from JUnit XML rather than read off `BUILD SUCCESSFUL`, with assertions that the named cases actually ran and that the built APK's **bytecode** really calls both composition helpers:

```
testGithubDebugUnitTest:     1061 tests, 0 failures
testStorefrontDebugUnitTest:  995 tests, 0 failures
required cases present: 16/16
APK verified: calls both helpers, #140 resolver signature intact, no PROBE140 residue
```

The APK bytecode check is not ceremony — it caught a mutation-test artifact being installed on a device earlier in this work.

## Hardware confirmation

Confirmed on the Pixel 10a against real WhatsApp, production injection path: the reported restored-draft case now produces `Hello john How old is Tom?`. No message was sent.

Closes #144
