### PR TITLE
Fix three accuracy defects: privacy backup claim, stale model catalog, mumble size reservation

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -55,9 +55,27 @@ I do not operate a relay server for these requests.
 
 Ramblr keeps a local history of your dictations (the raw transcript and, when cleanup ran, the
 cleaned-up version) so a failed injection never loses your words. This history is stored only
-on-device, in the app's private storage, and is excluded from Android backups (the app sets
-`allowBackup=false`). It is never uploaded anywhere. You can turn history off in Settings, and
+on-device, in the app's private storage, and is excluded from Android backups and from
+device-to-device transfer. It is never uploaded anywhere. You can turn history off in Settings, and
 you can delete recorded entries from the history screen.
+
+## Android backup and device transfer
+
+Ramblr participates in Android's backup and "Copy your data" device-transfer flows, but on a
+strict opt-in basis: only your plain settings (`ramblr.xml` — overlay appearance, personas,
+provider chain ordering, per-app persona mappings, advanced toggles) and your custom overlay
+icon are included.
+
+Everything else is excluded by omission, notably:
+
+- **Your API keys.** These live in Android-Keystore-encrypted storage whose key never leaves the
+  originating device, so restoring their ciphertext elsewhere could not decrypt them anyway. You
+  re-enter your key(s) once on a new device, which is the correct behavior.
+- **Your dictation history.**
+- The downloaded model files and the model-catalog network cache.
+
+The exact rules are readable in the repository at `app/src/main/res/xml/backup_rules.xml`
+(API 30) and `app/src/main/res/xml/data_extraction_rules.xml` (API 31+).
 
 ## Accessibility Service
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,7 +178,21 @@ android {
 
     buildFeatures { buildConfig = true }
 
-    testOptions { unitTests { isIncludeAndroidResources = true } }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            all {
+                // Forward the opt-in regeneration flag through to the test JVM. Without this,
+                // `-Dramblr.writeModelCatalog=true` only reaches the Gradle daemon and
+                // ModelCatalogFileSyncTest's regeneration branch silently never fires, leaving
+                // you to hand-edit the very file the test exists to keep in sync.
+                it.systemProperty(
+                    "ramblr.writeModelCatalog",
+                    providers.systemProperty("ramblr.writeModelCatalog").getOrElse("false"),
+                )
+            }
+        }
+    }
 
     // Names the built APK "Ramblr-<versionName>-<flavor>-<buildType>.apk" (e.g.
     // Ramblr-1.0.10-github-debug.apk) instead of Gradle's generic default

--- a/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
@@ -341,7 +341,12 @@ const val MUMBLE_CLEANUP_SYSTEM_PROMPT = "You are a transcript cleanup tool. You
 val MUMBLE_CLEANUP_Q4_0_MODEL = Model(
     name = "Mumble Cleanup 2-Stage (Q4_0)",
     archive = "mumble-cleanup-2stage-q4_0",
-    sizeMb = 336,
+    // Decimal MB (352,154,912 bytes / 1e6), matching [LOCAL_CLEANUP_MODEL]'s 219 and, more
+    // importantly, matching how [requiredSpaceBytes] actually consumes this field: it multiplies
+    // by 1_000_000, so a MiB-derived number silently under-reserves disk. This previously read
+    // 336 (the MiB figure), quietly asking for ~19 MB less headroom than the install really
+    // needs and risking a late-stage out-of-space failure on a nearly-full device.
+    sizeMb = 352,
     quality = "On-device cleanup · alternative fine-tune, A/B test",
     recommended = false,
     sha256 = "000efc700d74636bc3885afe1d8f32dbb3fe813b8198dea79d8fd73efcc2c711",
@@ -443,6 +448,12 @@ object ModelDownloader {
      * size is [sizeMb] megabytes. [singleFile] selects the rename-in-place headroom over the
      * extraction headroom, and [alreadyDownloadedBytes] credits a resumable partial file on disk
      * (previously a 90%-downloaded model still demanded the full multiple, #88).
+     *
+     * [sizeMb] is DECIMAL megabytes (bytes / 1_000_000), not MiB -- the multiplication below is
+     * the contract. Populating a catalog entry from a MiB figure under-reserves disk by ~4.9%
+     * per unit, which is how [MUMBLE_CLEANUP_Q4_0_MODEL] ended up asking for ~19 MB too little;
+     * [ModelDownloaderTest] pins every catalog entry against its real byte size to keep the two
+     * from drifting apart again.
      */
     fun requiredSpaceBytes(sizeMb: Int, singleFile: Boolean = false, alreadyDownloadedBytes: Long = 0L): Long {
         val base = sizeMb.toLong() * 1_000_000L

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelCatalogFileSyncTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelCatalogFileSyncTest.kt
@@ -1,0 +1,93 @@
+package com.trevornk.ramblr
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+
+/**
+ * Pins the repo-root `model-catalog.json` to [BUNDLED_DEFAULT_MODEL_CATALOG].
+ *
+ * That file is the human-editable source for the published gist at
+ * [ModelCatalogStore.CATALOG_URL] -- the app never reads it directly, which is exactly why it
+ * silently rotted: it still advertised `gemini-2.5-flash-lite` and `gemini-2.5-flash` (both on
+ * Google's shutdown path) long after the bundled catalog had migrated to `gemini-3.1-flash-lite`
+ * and `gemini-3.5-flash`, and nothing failed. An unreferenced duplicate that nobody validates is
+ * worse than no file at all, because the next person to publish the gist would have pushed
+ * deprecated model IDs to every install.
+ *
+ * Regenerate after changing the bundled catalog:
+ *
+ * ```
+ * ./gradlew testGithubDebugUnitTest --offline --tests '*ModelCatalogFileSyncTest*' \
+ *     -Dramblr.writeModelCatalog=true
+ * ```
+ *
+ * then publish the regenerated file's contents to the gist. Keeping regeneration in the test
+ * rather than a Gradle task means the check and the fix can never disagree about the format.
+ */
+class ModelCatalogFileSyncTest {
+
+    companion object {
+        /** Runs once, before any test reads the file. Regeneration must not live inside a test
+         *  method: the other cases read the same file, so a rewrite mid-class would make results
+         *  depend on JUnit's method order -- which is exactly the kind of order-dependent test
+         *  that passes locally and fails in CI for no visible reason. */
+        @JvmStatic
+        @BeforeClass
+        fun regenerateIfRequested() {
+            if (System.getProperty("ramblr.writeModelCatalog") != "true") return
+            val file = locateCatalogFile()
+            file.writeText(renderPretty())
+            println("regenerated ${file.absolutePath}")
+        }
+
+        private fun locateCatalogFile(): File =
+            generateSequence(File("").absoluteFile) { it.parentFile }
+                .firstOrNull { File(it, "model-catalog.json").isFile && File(it, "settings.gradle.kts").isFile }
+                ?.let { File(it, "model-catalog.json") }
+                ?: error("could not locate model-catalog.json from ${File("").absolutePath}")
+
+        /** Pretty-prints so the tracked file stays reviewable in a diff; the gist doesn't care
+         *  about whitespace and [ModelCatalogJson.deserialize] is whitespace-insensitive. */
+        private fun renderPretty(): String =
+            org.json.JSONArray(ModelCatalogJson.serialize(BUNDLED_DEFAULT_MODEL_CATALOG)).toString(2) + "\n"
+    }
+
+    private val catalogFile: File by lazy { locateCatalogFile() }
+
+    @Test
+    fun `root model-catalog json matches the bundled default catalog`() {
+        val parsed = ModelCatalogJson.deserialize(catalogFile.readText())
+        assertEquals(
+            "model-catalog.json is out of sync with BUNDLED_DEFAULT_MODEL_CATALOG; " +
+                "regenerate with -Dramblr.writeModelCatalog=true and republish the gist",
+            BUNDLED_DEFAULT_MODEL_CATALOG,
+            parsed,
+        )
+    }
+
+    @Test
+    fun `published catalog carries no model id that the bundled catalog has retired`() {
+        val parsed = ModelCatalogJson.deserialize(catalogFile.readText())
+            ?: error("model-catalog.json failed to parse")
+        val bundledIds = BUNDLED_DEFAULT_MODEL_CATALOG.map { it.provider to it.modelId }.toSet()
+        val strayIds = parsed.map { it.provider to it.modelId }.filterNot { it in bundledIds }
+        assertEquals("model-catalog.json advertises models the app no longer ships", emptyList<Any>(), strayIds)
+    }
+
+    @Test
+    fun `every transcription-capable Gemini entry is one the transcriber can actually be pointed at`() {
+        // GeminiTranscriberClient.DEFAULT_MODEL has to be a model the catalog still offers,
+        // otherwise the shipped default is unreachable from the picker.
+        val geminiIds = BUNDLED_DEFAULT_MODEL_CATALOG
+            .filter { it.provider == ProviderKind.GEMINI && it.useCase != ModelUseCase.CLEANUP }
+            .map { it.modelId }
+        assertTrue(
+            "GeminiTranscriberClient.DEFAULT_MODEL (${GeminiTranscriberClient.DEFAULT_MODEL}) " +
+                "is not a transcription-capable catalog entry; catalog offers $geminiIds",
+            GeminiTranscriberClient.DEFAULT_MODEL in geminiIds,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
@@ -65,6 +65,36 @@ class ModelDownloaderTest {
         assertTrue(MODEL_CATALOG.all { it.sizeMb > 0 })
     }
 
+    @Test fun `local cleanup catalog sizeMb is decimal MB matching each model's real byte size`() {
+        // requiredSpaceBytes multiplies sizeMb by 1_000_000, so these entries have to be decimal
+        // MB. MUMBLE_CLEANUP_Q4_0_MODEL was authored from the MiB figure (336 instead of 352),
+        // silently reserving ~19 MB less than the install needs. Pinning against the real
+        // published byte counts is what makes that class of mistake fail loudly instead of only
+        // showing up as a mid-download out-of-space error on someone's nearly-full phone.
+        val realBytes = mapOf(
+            // sha256 85e32858daafad55b7bcd6b97a1343ee0661188e8036f9862d14d6b563142f50
+            LOCAL_CLEANUP_MODEL.archive to 219_309_792L,
+            // sha256 000efc700d74636bc3885afe1d8f32dbb3fe813b8198dea79d8fd73efcc2c711
+            MUMBLE_CLEANUP_Q4_0_MODEL.archive to 352_154_912L,
+        )
+
+        for (model in LOCAL_CLEANUP_MODEL_CATALOG) {
+            val bytes = realBytes[model.archive]
+                ?: fail("no recorded byte size for ${model.archive}; add it when adding a catalog entry")
+            val expectedDecimalMb = ((bytes as Long) / 1_000_000L).toInt()
+            assertEquals(
+                "${model.archive} sizeMb should be decimal MB ($bytes bytes), not MiB",
+                expectedDecimalMb,
+                model.sizeMb,
+            )
+            // The reservation must actually cover the file it is reserving for.
+            assertTrue(
+                "${model.archive}: requiredSpaceBytes must exceed the real download size",
+                ModelDownloader.requiredSpaceBytes(model.sizeMb, model.isSingleFile) > bytes,
+            )
+        }
+    }
+
     @Test fun `catalog entries have a sourced sha256`() {
         // Every shipped model must carry a real checksum -- see Model.sha256 kdoc.
         // A null here isn't a bug, but it does mean download() refuses to install

--- a/app/src/test/kotlin/com/trevornk/ramblr/PrivacyPolicyBackupClaimsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/PrivacyPolicyBackupClaimsTest.kt
@@ -1,0 +1,136 @@
+package com.trevornk.ramblr
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the privacy policy against drifting away from what the app's backup configuration
+ * actually does.
+ *
+ * This exists because PRIVACY.md claimed "the app sets `allowBackup=false`" while
+ * AndroidManifest.xml has always set `android:allowBackup="true"` with include-only rules. The
+ * practical outcome the user cares about (dictation history and API keys are never backed up)
+ * was correct, but the stated mechanism was not -- and for a Play Store submission the privacy
+ * policy, the Data safety form, and runtime behavior have to agree literally, not just in
+ * spirit.
+ *
+ * The assertions deliberately read the real manifest, the real backup rule XML, and the real
+ * PRIVACY.md rather than a fixture: a fixture copy would keep passing after someone edits the
+ * shipping files, which is precisely the failure being prevented.
+ */
+class PrivacyPolicyBackupClaimsTest {
+
+    private val repoRoot: File by lazy {
+        // Gradle runs unit tests with the module dir (app/) as the working directory, but that
+        // isn't contractual, so walk up to whichever ancestor actually holds the files instead
+        // of hardcoding "..".
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "PRIVACY.md").isFile && File(it, "app/src/main/AndroidManifest.xml").isFile }
+            ?: error("could not locate repo root from ${File("").absolutePath}")
+    }
+
+    private fun read(relativePath: String): String {
+        val file = File(repoRoot, relativePath)
+        assertTrue("$relativePath should exist at ${file.absolutePath}", file.isFile)
+        return file.readText()
+    }
+
+    private val manifest by lazy { read("app/src/main/AndroidManifest.xml") }
+    private val backupRules by lazy { read("app/src/main/res/xml/backup_rules.xml") }
+    private val dataExtractionRules by lazy { read("app/src/main/res/xml/data_extraction_rules.xml") }
+    private val privacyPolicy by lazy { read("PRIVACY.md") }
+
+    /** Strips XML comments so a filename merely *discussed* in a doc comment is never mistaken
+     *  for an actual <include> element. backup_rules.xml documents the excluded credential files
+     *  by name at length, so this distinction is load-bearing rather than theoretical. */
+    private fun withoutComments(xml: String): String = xml.replace(Regex("<!--.*?-->", RegexOption.DOT_MATCHES_ALL), "")
+
+    @Test
+    fun `manifest really does enable backup, so the policy must not claim allowBackup is false`() {
+        assertTrue(
+            "manifest is expected to opt into backup with include-only rules",
+            manifest.contains("android:allowBackup=\"true\""),
+        )
+        assertFalse(
+            "PRIVACY.md claims allowBackup=false while the manifest sets it true",
+            privacyPolicy.contains("allowBackup=false") || privacyPolicy.contains("`allowBackup=false`"),
+        )
+    }
+
+    @Test
+    fun `manifest points at both backup rule files that this test verifies`() {
+        assertTrue(manifest.contains("android:fullBackupContent=\"@xml/backup_rules\""))
+        assertTrue(manifest.contains("android:dataExtractionRules=\"@xml/data_extraction_rules\""))
+    }
+
+    @Test
+    fun `dictation history is never included in backup or device transfer`() {
+        val historyFile = "dictation_history.jsonl"
+        assertFalse(
+            "backup_rules.xml must not include $historyFile",
+            withoutComments(backupRules).contains(historyFile),
+        )
+        assertFalse(
+            "data_extraction_rules.xml must not include $historyFile",
+            withoutComments(dataExtractionRules).contains(historyFile),
+        )
+    }
+
+    @Test
+    fun `keystore-encrypted credential files are never included in backup or device transfer`() {
+        val encryptedPrefs = listOf(
+            "ramblr_provider_credentials",
+            "ramblr_secure",
+            "ramblr_cleanup_credentials",
+        )
+        for (name in encryptedPrefs) {
+            assertFalse(
+                "backup_rules.xml must not include $name (Keystore key cannot survive a restore)",
+                withoutComments(backupRules).contains(name),
+            )
+            assertFalse(
+                "data_extraction_rules.xml must not include $name",
+                withoutComments(dataExtractionRules).contains(name),
+            )
+        }
+    }
+
+    @Test
+    fun `both rule files include exactly the same paths, so cloud backup and device transfer agree`() {
+        val includePattern = Regex("""<include\s+domain="([^"]+)"\s+path="([^"]+)"\s*/>""")
+        fun includesIn(xml: String) = includePattern.findAll(withoutComments(xml))
+            .map { it.groupValues[1] to it.groupValues[2] }
+            .toList()
+
+        val legacy = includesIn(backupRules)
+        val modern = includesIn(dataExtractionRules)
+
+        assertEquals(
+            "backup_rules.xml should include exactly the plain prefs file and the overlay icon",
+            listOf("sharedpref" to "ramblr.xml", "file" to "overlay_icon.png"),
+            legacy,
+        )
+        // data_extraction_rules.xml declares the same set twice, once under <cloud-backup> and
+        // once under <device-transfer>; an asymmetry between the two would mean a device swap
+        // carried data a cloud restore did not, which is exactly the kind of silent divergence
+        // the privacy policy would then be wrong about.
+        assertEquals(
+            "data_extraction_rules.xml should declare the same includes for cloud-backup and device-transfer",
+            legacy + legacy,
+            modern,
+        )
+    }
+
+    @Test
+    fun `privacy policy documents the include-only backup behavior it actually has`() {
+        val section = privacyPolicy.substringAfter("## Android backup and device transfer", "")
+        assertTrue("PRIVACY.md is missing the backup/device-transfer section", section.isNotBlank())
+        assertTrue(
+            "the backup section should name the rule files so the claim stays auditable",
+            section.contains("backup_rules.xml") && section.contains("data_extraction_rules.xml"),
+        )
+    }
+}

--- a/model-catalog.json
+++ b/model-catalog.json
@@ -1,112 +1,142 @@
 [
   {
+    "useCase": "CLEANUP",
+    "tier": "RECOMMENDED",
+    "costPer1MInputUsd": 0.05,
     "provider": "OPENAI",
     "modelId": "gpt-5.4-nano",
     "displayName": "GPT-5.4 Nano",
-    "description": "Fastest, cheapest -- benchmark-confirmed indistinguishable from Mini for cleanup quality.",
-    "tier": "RECOMMENDED",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 0.05,
-    "costPer1MOutputUsd": 0.40
+    "costPer1MOutputUsd": 0.4,
+    "description": "Fastest, cheapest \u2014 benchmark-confirmed indistinguishable from Mini for cleanup quality."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "GOOD",
+    "costPer1MInputUsd": 0.25,
     "provider": "OPENAI",
     "modelId": "gpt-5.4-mini",
     "displayName": "GPT-5.4 Mini",
-    "description": "One tier up from Nano -- same real-world cleanup quality, costs more.",
-    "tier": "GOOD",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 0.25,
-    "costPer1MOutputUsd": 2.00
+    "costPer1MOutputUsd": 2,
+    "description": "One tier up from Nano \u2014 same real-world cleanup quality, costs more."
   },
   {
-    "provider": "GEMINI",
-    "modelId": "gemini-2.5-flash-lite",
-    "displayName": "Gemini 2.5 Flash-Lite",
-    "description": "Cheapest Gemini tier -- benchmark-confirmed on par with Flash for cleanup; handles audio transcription too.",
+    "useCase": "TRANSCRIPTION",
     "tier": "RECOMMENDED",
-    "useCase": "BOTH",
-    "costPer1MInputUsd": 0.10,
-    "costPer1MOutputUsd": 0.40
+    "costPer1MInputUsd": 0,
+    "provider": "OPENAI",
+    "modelId": "gpt-transcribe",
+    "displayName": "GPT-Transcribe",
+    "costPer1MOutputUsd": 0,
+    "description": "OpenAI's newest ASR model (2026-07) \u2014 more accurate than GPT-4o Transcribe on OpenAI's and independent benchmarks, and 25% cheaper per minute."
   },
   {
-    "provider": "GEMINI",
-    "modelId": "gemini-2.5-flash",
-    "displayName": "Gemini 2.5 Flash",
-    "description": "One tier up from Flash-Lite -- same real-world cleanup quality, costs more.",
+    "useCase": "TRANSCRIPTION",
     "tier": "GOOD",
-    "useCase": "BOTH",
-    "costPer1MInputUsd": 0.30,
-    "costPer1MOutputUsd": 2.50
+    "costPer1MInputUsd": 0,
+    "provider": "OPENAI",
+    "modelId": "gpt-4o-transcribe",
+    "displayName": "GPT-4o Transcribe",
+    "costPer1MOutputUsd": 0,
+    "description": "Previous default \u2014 solid and Ramblr-benchmark-proven, but GPT-Transcribe measures more accurate and costs less."
   },
   {
+    "useCase": "TRANSCRIPTION",
+    "tier": "ADVANCED",
+    "costPer1MInputUsd": 0,
+    "provider": "OPENAI",
+    "modelId": "whisper-1",
+    "displayName": "Whisper-1",
+    "costPer1MOutputUsd": 0,
+    "description": "OpenAI's original ASR model \u2014 highest error rate of the three; only pick it if you specifically need its legacy output formats."
+  },
+  {
+    "useCase": "BOTH",
+    "tier": "RECOMMENDED",
+    "costPer1MInputUsd": 0.25,
+    "provider": "GEMINI",
+    "modelId": "gemini-3.1-flash-lite",
+    "displayName": "Gemini 3.1 Flash-Lite",
+    "costPer1MOutputUsd": 1.5,
+    "description": "Cheapest Gemini tier \u2014 Google's documented replacement for 2.5 Flash-Lite (which is deprecating); improved audio input for ASR, handles transcription too."
+  },
+  {
+    "useCase": "BOTH",
+    "tier": "GOOD",
+    "costPer1MInputUsd": 1.5,
+    "provider": "GEMINI",
+    "modelId": "gemini-3.5-flash",
+    "displayName": "Gemini 3.5 Flash",
+    "costPer1MOutputUsd": 9,
+    "description": "Google's documented replacement for 2.5 Flash (which is deprecating) \u2014 meaningfully pricier than Flash-Lite (~6x), not a small step up; pick deliberately, not as a default."
+  },
+  {
+    "useCase": "CLEANUP",
+    "tier": "GOOD",
+    "costPer1MInputUsd": 1,
     "provider": "ANTHROPIC",
     "modelId": "claude-haiku-4-5-20251001",
     "displayName": "Claude Haiku 4.5",
-    "description": "Legitimate power-user option if you already have Claude credits -- not defaulted: no transcription capability, and cleanup quality doesn't clearly beat OpenAI/Gemini's cheap tiers.",
-    "tier": "GOOD",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 1.00,
-    "costPer1MOutputUsd": 5.00
+    "costPer1MOutputUsd": 5,
+    "description": "Legitimate power-user option if you already have Claude credits \u2014 not defaulted: no transcription capability, and cleanup quality doesn't clearly beat OpenAI/Gemini's cheap tiers."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "RECOMMENDED",
+    "costPer1MInputUsd": 0.1,
     "provider": "OMNIROUTE",
     "modelId": "gemini/gemini-flash-lite-latest",
     "displayName": "OmniRoute: Gemini Flash-Lite (auto-upgrading)",
-    "description": "Cheapest, auto-upgrading -- mirrors direct Gemini's own recommended flash-lite tier so you don't overpay just because you're using OmniRoute. Recommended default cleanup path.",
-    "tier": "RECOMMENDED",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 0.10,
-    "costPer1MOutputUsd": 0.40
+    "costPer1MOutputUsd": 0.4,
+    "description": "Cheapest, auto-upgrading \u2014 mirrors direct Gemini's own recommended flash-lite tier so you don't overpay just because you're using OmniRoute. Recommended default cleanup path."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "GOOD",
+    "costPer1MInputUsd": 0.75,
     "provider": "OMNIROUTE",
     "modelId": "cx/gpt-5.4-mini",
     "displayName": "OmniRoute: GPT-5.4 Mini",
-    "description": "OmniRoute's cheapest available OpenAI-family model (no nano-tier route exists through OmniRoute today). Pinned, not an auto-upgrading alias.",
-    "tier": "GOOD",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 0.75,
-    "costPer1MOutputUsd": 4.50
+    "costPer1MOutputUsd": 4.5,
+    "description": "OmniRoute's cheapest available OpenAI-family model (no nano-tier route exists through OmniRoute today). Pinned, not an auto-upgrading alias."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "GOOD",
+    "costPer1MInputUsd": 1,
     "provider": "OMNIROUTE",
     "modelId": "cc/claude-haiku-4-5-20251001",
     "displayName": "OmniRoute: Claude Haiku 4.5",
-    "description": "Mirrors direct Anthropic's Haiku entry -- good cleanup quality, cheap. Pinned, not an auto-upgrading alias (no Haiku-specific \"-latest\"/\"auto/\" route exists on OmniRoute today).",
-    "tier": "GOOD",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 1.00,
-    "costPer1MOutputUsd": 5.00
+    "costPer1MOutputUsd": 5,
+    "description": "Mirrors direct Anthropic's Haiku entry \u2014 good cleanup quality, cheap. Pinned, not an auto-upgrading alias (no Haiku-specific \"-latest\"/\"auto/\" route exists on OmniRoute today)."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "ADVANCED",
+    "costPer1MInputUsd": 1.25,
     "provider": "OMNIROUTE",
     "modelId": "gemini/gemini-pro-latest",
     "displayName": "OmniRoute: Gemini Pro (auto-upgrading)",
-    "description": "Always resolves to Google's current Pro-tier model server-side -- higher cost, for when you deliberately want the strongest available cleanup quality over the cheap default.",
-    "tier": "ADVANCED",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 1.25,
-    "costPer1MOutputUsd": 10.00
+    "costPer1MOutputUsd": 10,
+    "description": "Always resolves to Google's current Pro-tier model server-side \u2014 higher cost, for when you deliberately want the strongest available cleanup quality over the cheap default."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "ADVANCED",
+    "costPer1MInputUsd": 3,
     "provider": "OMNIROUTE",
     "modelId": "auto/claude-sonnet",
     "displayName": "OmniRoute: Claude Sonnet (auto-upgrading)",
-    "description": "Always resolves to Anthropic's current Sonnet-tier model server-side -- premium, not the cost-efficient default.",
-    "tier": "ADVANCED",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 3.00,
-    "costPer1MOutputUsd": 15.00
+    "costPer1MOutputUsd": 15,
+    "description": "Always resolves to Anthropic's current Sonnet-tier model server-side \u2014 premium, not the cost-efficient default."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "ADVANCED",
+    "costPer1MInputUsd": 15,
     "provider": "OMNIROUTE",
     "modelId": "auto/claude-opus",
     "displayName": "OmniRoute: Claude Opus (auto-upgrading)",
-    "description": "Always resolves to Anthropic's current Opus-tier model server-side -- the priciest OmniRoute option.",
-    "tier": "ADVANCED",
-    "useCase": "CLEANUP",
-    "costPer1MInputUsd": 15.00,
-    "costPer1MOutputUsd": 75.00
+    "costPer1MOutputUsd": 75,
+    "description": "Always resolves to Anthropic's current Opus-tier model server-side \u2014 the priciest OmniRoute option."
   }
 ]


### PR DESCRIPTION
Three unrelated accuracy defects found while auditing the open issue backlog. Each is small, independently revertable, and carries a regression test that was mutation-checked by reintroducing the original bug and confirming the test fails.

## 1. PRIVACY.md claimed `allowBackup=false` while the manifest sets it true

The stated mechanism was simply false. The user-facing *outcome* was already correct — dictation history and the Keystore-encrypted credential files are excluded by omission from both `backup_rules.xml` and `data_extraction_rules.xml` — but Play requires the privacy policy, the Data safety form, and runtime behaviour to agree literally, not merely in spirit.

Replaces the inaccurate sentence with what actually happens and documents the include-only model. `PrivacyPolicyBackupClaimsTest` reads the **real** manifest, both rule XMLs and PRIVACY.md rather than fixture copies, since a fixture keeps passing after someone edits the shipping files. It also pins cloud-backup and device-transfer to identical include sets, so a device swap can't quietly carry data a cloud restore doesn't.

## 2. Root `model-catalog.json` had rotted to deprecated model IDs

This file is the human-editable source for the gist that `ModelCatalogStore.CATALOG_URL` serves, but the app never reads it and nothing validated it. It still advertised `gemini-2.5-flash-lite` and `gemini-2.5-flash` — both on Google's Oct 16 2026 shutdown path — long after the bundled catalog moved to `gemini-3.1-flash-lite`/`gemini-3.5-flash`, and had dropped all three OpenAI transcription entries. **Publishing it as-is would have pushed dead model IDs to every install.**

Regenerated from `BUNDLED_DEFAULT_MODEL_CATALOG`, with `ModelCatalogFileSyncTest` keeping the two identical and asserting `GeminiTranscriberClient.DEFAULT_MODEL` stays reachable from the catalog, so the shipped default can never become unselectable in the picker.

Regeneration lives behind `-Dramblr.writeModelCatalog=true` so the check and the fix can't disagree about formatting. It runs in `@BeforeClass`, not inside a test method, because sibling cases read the same file and a mid-class rewrite would make results depend on JUnit method order. `build.gradle.kts` forwards that system property into the test JVM — without the forward it stops at the Gradle daemon and the regeneration branch silently never fires.

## 3. Mumble-cleanup `sizeMb` under-reserved download space (#134)

`MUMBLE_CLEANUP_Q4_0_MODEL` declared `sizeMb = 336`, the **MiB** figure, but `requiredSpaceBytes` multiplies by 1,000,000 — the field is decimal MB, as `LOCAL_CLEANUP_MODEL`'s 219 already was. The real artifact is 352,154,912 bytes = 352 MB, so the pre-flight free-space check asked for ~19 MB less than the install needs and could fail mid-download on a nearly-full device.

Corrected to 352, with the decimal-MB contract documented on `requiredSpaceBytes`. The test pins every local-cleanup entry against its real published byte count and asserts the reservation exceeds the file it reserves for, so authoring the next entry from a MiB figure fails loudly instead of surfacing as an out-of-space error on someone's phone.

## Verification

Both flavors, `--rerun-tasks` with the results directory deleted first: **2,076 tests (github 1,071 / storefront 1,005), 0 failures.** `assembleGithubDebug` succeeds.

Mutation checks, each against a proven-green baseline with the source restored afterward:

| Reintroduced bug | Caught by |
|---|---|
| `sizeMb` back to 336 | `ModelDownloaderTest > local cleanup catalog sizeMb is decimal MB matching each model's real byte size` |
| PRIVACY.md claiming `allowBackup=false` | `PrivacyPolicyBackupClaimsTest > manifest really does enable backup, so the policy must not claim allowBackup is false` |
| catalog back to `gemini-2.5` IDs | `ModelCatalogFileSyncTest` (2 tests) |

A green baseline was established first — without it a FAILED run proves nothing, since a toolchain error fails identically to a caught mutation.

## Note on #134

This corrects the size *field* only. The Q4_0 default flip remains blocked on hosting (needs a Hugging Face destination + write token) and on a real quality A/B — device logs contain zero mumble-cleanup runs, so only speed has ever been measured, never accuracy.

Refs #134
