### PR TITLE
Add offline scoring and fixture harness for the Gemini transcription benchmark (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,46 @@ runs don't clutter the repo; if you want to share or archive a specific report, 
 To add a new prompt variant to the comparison, add it to the `PROMPT_REGISTRY` map at the top of
 `EvalHarness.kt`.
 
+### Transcription benchmark (audio → text)
+
+The prompt eval harness above measures the *cleanup* stage. A separate manual benchmark measures
+the *transcription* stage — how accurately Gemini turns recorded audio into text — by calling the
+real shipped `GeminiTranscriberClient.transcribe` (same request shape, headers, OkHttp client, and
+async callback as production) and scoring the transcripts against ground truth.
+
+- `app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt` — the runner, a
+  standalone `main()`, **not** a JUnit test. Compiled by `make test` but never discovered or run
+  by it, exactly like `EvalHarness.kt`.
+- `TranscriptionMetrics.kt` / `TranscriptionEvalManifest.kt` / `WavPcm.kt` — the offline scoring,
+  manifest validation, and WAV→PCM conversion, each covered by real unit tests that *do* run in CI.
+- `app/src/test/resources/transcription_eval/` — the fixture corpus. **Shipped empty**: the
+  manifest is a zero-entry placeholder and no audio is checked in. Read that directory's
+  `README.md` before adding fixtures.
+
+⚠️ **Cost:** this calls the real Gemini API and spends real credits, once per fixture × model ×
+repetition. Cost is *not* reported: `GeminiTranscriberClient.Result` discards the response's
+`usageMetadata`, so token counts aren't observable from the production path, and the report
+deliberately does not estimate them.
+
+⚠️ **Privacy:** this **uploads audio to Google**. Recorded human speech is biometric data — never
+commit it to this repo, and never benchmark a recording you don't have consent to use. Prefer
+synthetic TTS fixtures. See `app/src/test/resources/transcription_eval/README.md`.
+
+```bash
+export GEMINI_API_KEY=AIza...                                     # never committed; no .env is read
+./gradlew runGeminiTranscriptionBenchmark                          # defaults to the catalog's Gemini models
+GEMINI_TRANSCRIPTION_MODELS=gemini-3.5-flash ./gradlew runGeminiTranscriptionBenchmark
+GEMINI_TRANSCRIPTION_REPETITIONS=3 ./gradlew runGeminiTranscriptionBenchmark   # expose run-to-run variance
+TRANSCRIPTION_EVAL_DIR=/path/to/private/corpus ./gradlew runGeminiTranscriptionBenchmark
+```
+
+Each run writes a Markdown and a JSON report to the gitignored `eval-reports/`, recording the
+commit SHA, UTC timestamp, exact model ids, repetition count, call timeout, manifest checksum,
+every raw transcript/error/latency, and aggregated micro-WER/CER, exact-match rates, success rate,
+failure categories, and p50/p95/mean latency. The run refuses to start — rather than quietly
+substituting a default — if the API key is missing, the model list is empty, or any fixture fails
+validation.
+
 ### Tests
 
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -334,6 +334,27 @@ tasks.register<JavaExec>("runEvalHarness") {
     classpath = tasks.named<Test>("testGithubDebugUnitTest").get().classpath
 }
 
+// Manual dev tool (#129) -- deliberately NOT wired into test/check/build/CI, exactly like
+// runEvalHarness above. Benchmarks the real production transcription path
+// (GeminiTranscriberClient.transcribe) against the audio fixture corpus in
+// app/src/test/resources/transcription_eval/, scoring WER/CER offline and writing a report to
+// the gitignored eval-reports/ directory.
+//
+// This one uploads AUDIO to Google and spends real credits -- see the "Transcription benchmark"
+// section of README.md before running it. GeminiTranscriptionBenchmark.kt declares only main()
+// (no @Test methods), so Gradle compiles it as a test source but JUnit never discovers it.
+//
+// Usage: GEMINI_API_KEY=... ./gradlew runGeminiTranscriptionBenchmark
+tasks.register<JavaExec>("runGeminiTranscriptionBenchmark") {
+    group = "verification"
+    description = "Manual dev tool: benchmarks GeminiTranscriberClient against the local audio " +
+        "fixture corpus and writes a WER/CER report. Uploads audio to Google and costs real " +
+        "API credits; not part of build/test/check."
+    dependsOn("compileGithubDebugUnitTestKotlin")
+    mainClass.set("com.trevornk.ramblr.tools.GeminiTranscriptionBenchmarkKt")
+    classpath = tasks.named<Test>("testGithubDebugUnitTest").get().classpath
+}
+
 // Native libs (#36/#37, F-Droid prep): both the speech-to-text lib (libsherpa-onnx-jni.so,
 // against the ../sherpa-onnx submodule) and the on-device LLM cleanup shim (against the
 // ../llama.cpp submodule) are built from source via the externalNativeBuild/cmake block in

--- a/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionEvalManifestTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionEvalManifestTest.kt
@@ -1,0 +1,422 @@
+package com.trevornk.ramblr
+
+import com.trevornk.ramblr.tools.TranscriptionEvalManifest
+import com.trevornk.ramblr.tools.TranscriptionEvalManifest.Fixture
+import com.trevornk.ramblr.tools.BenchmarkArgs
+import com.trevornk.ramblr.tools.categorizeFailure
+import com.trevornk.ramblr.tools.resolveConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Tests for the fixture manifest data model, parser, and validator. The validator must fail loudly
+ * on every malformed-corpus shape; in particular an empty model list must be rejected rather than
+ * silently falling back to [GeminiTranscriberClient.DEFAULT_MODEL], because a benchmark that
+ * quietly benchmarks a different model than you asked for is worse than one that refuses to run.
+ */
+class TranscriptionEvalManifestTest {
+
+    @get:Rule val temp = TemporaryFolder()
+
+    private fun writeAudio(name: String, bytes: ByteArray = byteArrayOf(1, 2, 3, 4)): File {
+        val f = File(temp.root, name)
+        f.parentFile?.mkdirs()
+        f.writeBytes(bytes)
+        return f
+    }
+
+    private fun sha256Of(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    private fun fixture(
+        id: String = "f1",
+        audioPath: String = "f1.wav",
+        referenceText: String = "hello world",
+        durationMs: Long = 1500,
+        language: String = "en-US",
+        scenarios: List<String> = listOf("short_command"),
+        source: String = "synthetic-tts",
+        consent: String = "CC0-1.0",
+        sha256: String? = null,
+    ) = Fixture(id, audioPath, referenceText, durationMs, language, scenarios, source, consent, sha256)
+
+    // ---------------------------------------------------------------- parsing
+
+    @Test fun `parses a full manifest into real typed fields`() {
+        val json = """
+            {
+              "version": 1,
+              "fixtures": [
+                {
+                  "id": "clip-a",
+                  "audioPath": "clip-a.wav",
+                  "referenceText": "turn on the kitchen light",
+                  "durationMs": 2400,
+                  "language": "en-US",
+                  "scenarios": ["short_command", "numbers_and_punctuation"],
+                  "source": "synthetic TTS, Piper en_US-lessac",
+                  "consent": "CC0-1.0 synthetic voice, no human speaker",
+                  "sha256": "abc123"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val manifest = TranscriptionEvalManifest.parse(json)
+        assertEquals(1, manifest.version)
+        assertEquals(1, manifest.fixtures.size)
+        val f = manifest.fixtures.single()
+        assertEquals("clip-a", f.id)
+        assertEquals("clip-a.wav", f.audioPath)
+        assertEquals("turn on the kitchen light", f.referenceText)
+        assertEquals(2400L, f.durationMs)
+        assertEquals("en-US", f.language)
+        assertEquals(listOf("short_command", "numbers_and_punctuation"), f.scenarios)
+        assertEquals("synthetic TTS, Piper en_US-lessac", f.source)
+        assertEquals("CC0-1.0 synthetic voice, no human speaker", f.consent)
+        assertEquals("abc123", f.sha256)
+    }
+
+    @Test fun `parses a placeholder manifest with an empty fixture list`() {
+        val manifest = TranscriptionEvalManifest.parse("""{"version":1,"fixtures":[]}""")
+        assertEquals(0, manifest.fixtures.size)
+    }
+
+    @Test fun `rejects malformed json with a structured error`() {
+        val error = try {
+            TranscriptionEvalManifest.parse("{ not json")
+            null
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            e.message
+        }
+        assertTrue("expected a parse error, got $error", error != null && error.contains("parse", ignoreCase = true))
+    }
+
+    @Test fun `rejects a manifest missing the fixtures array`() {
+        val error = try {
+            TranscriptionEvalManifest.parse("""{"version":1}""")
+            null
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            e.message
+        }
+        assertTrue("expected a fixtures error, got $error", error != null && error!!.contains("fixtures"))
+    }
+
+    @Test fun `rejects a fixture missing a required field`() {
+        val error = try {
+            TranscriptionEvalManifest.parse("""{"version":1,"fixtures":[{"id":"a"}]}""")
+            null
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            e.message
+        }
+        assertTrue("expected a missing-field error, got $error", error != null && error!!.contains("audioPath"))
+    }
+
+    // ---------------------------------------------------------------- fixture validation
+
+    @Test fun `a well-formed manifest with existing audio validates clean`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture()), temp.root)
+        assertEquals(emptyList<String>(), errors)
+    }
+
+    @Test fun `an empty fixture list is allowed as a placeholder corpus`() {
+        assertEquals(emptyList<String>(), TranscriptionEvalManifest.validateFixtures(emptyList(), temp.root))
+    }
+
+    @Test fun `rejects duplicate fixture ids`() {
+        writeAudio("f1.wav")
+        writeAudio("f2.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(id = "dup", audioPath = "f1.wav"), fixture(id = "dup", audioPath = "f2.wav")),
+            temp.root,
+        )
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("duplicate", ignoreCase = true))
+        assertTrue(errors.single(), errors.single().contains("dup"))
+    }
+
+    @Test fun `rejects a blank fixture id`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(id = "   ")), temp.root)
+        assertTrue(errors.toString(), errors.any { it.contains("id", ignoreCase = true) && it.contains("blank") })
+    }
+
+    @Test fun `rejects a blank reference transcript`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(referenceText = "   \n ")), temp.root)
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("referenceText"))
+        assertTrue(errors.single(), errors.single().contains("blank"))
+    }
+
+    @Test fun `rejects a fixture whose audio file is missing`() {
+        // No file written on disk at all.
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(audioPath = "nope.wav")), temp.root)
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("nope.wav"))
+        assertTrue(errors.single(), errors.single().contains("missing", ignoreCase = true))
+    }
+
+    @Test fun `rejects an unknown scenario category`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(scenarios = listOf("short_command", "yodelling"))),
+            temp.root,
+        )
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("yodelling"))
+        assertTrue(errors.single(), errors.single().contains("scenario", ignoreCase = true))
+    }
+
+    @Test fun `every advertised known scenario actually validates`() {
+        writeAudio("f1.wav")
+        assertTrue(TranscriptionEvalManifest.KNOWN_SCENARIOS.isNotEmpty())
+        val errors = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(scenarios = TranscriptionEvalManifest.KNOWN_SCENARIOS.toList())),
+            temp.root,
+        )
+        assertEquals(emptyList<String>(), errors)
+    }
+
+    @Test fun `rejects an empty scenario list`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(scenarios = emptyList())), temp.root)
+        assertTrue(errors.toString(), errors.any { it.contains("scenario", ignoreCase = true) })
+    }
+
+    @Test fun `rejects a non-positive duration`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(durationMs = 0)), temp.root)
+        assertTrue(errors.toString(), errors.any { it.contains("durationMs") })
+    }
+
+    @Test fun `rejects blank provenance and consent metadata`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(source = " ", consent = "")),
+            temp.root,
+        )
+        assertEquals(2, errors.size)
+        assertTrue(errors.toString(), errors.any { it.contains("source") })
+        assertTrue(errors.toString(), errors.any { it.contains("consent") })
+    }
+
+    @Test fun `rejects a blank language tag`() {
+        writeAudio("f1.wav")
+        val errors = TranscriptionEvalManifest.validateFixtures(listOf(fixture(language = "")), temp.root)
+        assertTrue(errors.toString(), errors.any { it.contains("language") })
+    }
+
+    @Test fun `verifies the declared sha256 against the real file bytes`() {
+        val bytes = byteArrayOf(9, 8, 7, 6, 5)
+        writeAudio("f1.wav", bytes)
+        val good = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(sha256 = sha256Of(bytes))),
+            temp.root,
+        )
+        assertEquals(emptyList<String>(), good)
+
+        val bad = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(sha256 = "0".repeat(64))),
+            temp.root,
+        )
+        assertEquals(1, bad.size)
+        assertTrue(bad.single(), bad.single().contains("sha256"))
+    }
+
+    @Test fun `collects every problem rather than stopping at the first`() {
+        val errors = TranscriptionEvalManifest.validateFixtures(
+            listOf(fixture(id = "a", audioPath = "gone.wav", referenceText = "", scenarios = listOf("bogus"))),
+            temp.root,
+        )
+        assertTrue("expected several errors, got $errors", errors.size >= 3)
+    }
+
+    // ---------------------------------------------------------------- model-list validation
+
+    @Test fun `a normal model list validates clean`() {
+        assertEquals(
+            emptyList<String>(),
+            TranscriptionEvalManifest.validateModelIds(listOf("gemini-3.1-flash-lite", "gemini-3.5-flash")),
+        )
+    }
+
+    /**
+     * Mutation target (c). Removing the empty-list rejection must break this test. An empty list
+     * must NOT be silently replaced with [GeminiTranscriberClient.DEFAULT_MODEL].
+     */
+    @Test fun `rejects an empty model list instead of falling back to the production default`() {
+        val errors = TranscriptionEvalManifest.validateModelIds(emptyList())
+        assertEquals("empty model list must produce exactly one error, got $errors", 1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("empty", ignoreCase = true))
+        assertTrue(errors.single(), errors.single().contains("model", ignoreCase = true))
+        // And the error must not be a disguised fallback announcement.
+        assertFalse(errors.single(), errors.single().contains(GeminiTranscriberClient.DEFAULT_MODEL))
+    }
+
+    @Test fun `rejects a blank model id`() {
+        val errors = TranscriptionEvalManifest.validateModelIds(listOf("gemini-3.5-flash", "   "))
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("blank"))
+    }
+
+    @Test fun `rejects duplicate model ids`() {
+        val errors = TranscriptionEvalManifest.validateModelIds(listOf("gemini-3.5-flash", "gemini-3.5-flash"))
+        assertEquals(1, errors.size)
+        assertTrue(errors.single(), errors.single().contains("duplicate", ignoreCase = true))
+        assertTrue(errors.single(), errors.single().contains("gemini-3.5-flash"))
+    }
+
+    // ---------------------------------------------------------------- checksum + throwing wrapper
+
+    @Test fun `manifest checksum is a stable sha256 of the raw document`() {
+        val doc = """{"version":1,"fixtures":[]}"""
+        val checksum = TranscriptionEvalManifest.checksum(doc)
+        assertEquals(64, checksum.length)
+        assertEquals(sha256Of(doc.toByteArray(Charsets.UTF_8)), checksum)
+        assertEquals(checksum, TranscriptionEvalManifest.checksum(doc))
+        assertFalse(checksum == TranscriptionEvalManifest.checksum("""{"version":2,"fixtures":[]}"""))
+    }
+
+    @Test fun `validateOrThrow surfaces every collected error in one exception`() {
+        val message = try {
+            TranscriptionEvalManifest.validateOrThrow(listOf(fixture(audioPath = "gone.wav")), temp.root, emptyList())
+            null
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            e.message
+        }
+        assertTrue("expected a combined error, got $message", message != null && message!!.contains("gone.wav"))
+        assertTrue(message!!, message.contains("model", ignoreCase = true))
+    }
+
+    @Test fun `validateOrThrow passes for a clean manifest and model list`() {
+        writeAudio("f1.wav")
+        TranscriptionEvalManifest.validateOrThrow(listOf(fixture()), temp.root, listOf("gemini-3.5-flash"))
+    }
+
+    // ---------------------------------------------------------------- shipped placeholder manifest
+
+    @Test fun `the checked-in placeholder manifest parses and validates`() {
+        val stream = javaClass.classLoader!!.getResourceAsStream("transcription_eval/manifest.json")
+        requireNotNull(stream) { "transcription_eval/manifest.json must be on the test resources path" }
+        val doc = stream.use { it.readBytes().toString(Charsets.UTF_8) }
+        val manifest = TranscriptionEvalManifest.parse(doc)
+        // Deliberately a placeholder: no invented fixture entries without matching audio.
+        assertEquals(emptyList<Fixture>(), manifest.fixtures)
+    }
+
+    // ---------------------------------------------------------------- benchmark config resolver
+    // resolveConfig is the benchmark runner's entire "should this run start" decision, extracted
+    // as a pure function precisely so it can be driven here with no network and no env vars.
+
+    private fun writeManifest(body: String): File {
+        val f = File(temp.root, "manifest.json")
+        f.writeText(body)
+        return f
+    }
+
+    private fun resolveError(args: BenchmarkArgs): String {
+        val message = try {
+            resolveConfig(args)
+            null
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            e.message
+        }
+        assertTrue("expected resolveConfig to reject $args", message != null)
+        return message!!
+    }
+
+    @Test fun `resolveConfig rejects a missing api key`() {
+        writeManifest("""{"version":1,"fixtures":[]}""")
+        val message = resolveError(BenchmarkArgs(false, null, null, temp.root.path))
+        assertTrue(message, message.contains("GEMINI_API_KEY"))
+    }
+
+    @Test fun `resolveConfig rejects an explicitly empty model override without falling back`() {
+        writeManifest("""{"version":1,"fixtures":[]}""")
+        val message = resolveError(BenchmarkArgs(true, "  ,  ", null, temp.root.path))
+        assertTrue(message, message.contains("empty", ignoreCase = true))
+        assertFalse(message, message.contains(GeminiTranscriberClient.DEFAULT_MODEL))
+    }
+
+    @Test fun `resolveConfig rejects a placeholder manifest with no fixtures`() {
+        writeManifest("""{"version":1,"fixtures":[]}""")
+        val message = resolveError(BenchmarkArgs(true, null, null, temp.root.path))
+        assertTrue(message, message.contains("no fixtures"))
+    }
+
+    @Test fun `resolveConfig rejects a non-numeric or non-positive repetition count`() {
+        writeManifest("""{"version":1,"fixtures":[]}""")
+        assertTrue(resolveError(BenchmarkArgs(true, null, "abc", temp.root.path)).contains("integer"))
+        assertTrue(resolveError(BenchmarkArgs(true, null, "0", temp.root.path)).contains("at least 1"))
+    }
+
+    @Test fun `resolveConfig rejects a missing manifest file`() {
+        val message = resolveError(BenchmarkArgs(true, null, null, File(temp.root, "nowhere").path))
+        assertTrue(message, message.contains("Manifest not found"))
+    }
+
+    @Test fun `resolveConfig returns a usable config for a valid corpus`() {
+        writeAudio("f1.wav", byteArrayOf(1, 2, 3, 4))
+        writeManifest(
+            """
+            {"version":1,"fixtures":[{"id":"f1","audioPath":"f1.wav","referenceText":"hello world",
+             "durationMs":1000,"language":"en-US","scenarios":["short_command"],
+             "source":"synthetic-tts","consent":"CC0-1.0"}]}
+            """.trimIndent()
+        )
+        val config = resolveConfig(BenchmarkArgs(true, "gemini-3.5-flash,gemini-3.1-flash-lite", "3", temp.root.path))
+        assertEquals(listOf("gemini-3.5-flash", "gemini-3.1-flash-lite"), config.modelIds)
+        assertEquals(3, config.repetitions)
+        assertEquals(1, config.fixtures.size)
+        assertEquals(6, config.totalCalls) // 1 fixture x 2 models x 3 repetitions
+        assertEquals(64, config.manifestChecksum.length)
+        assertTrue(config.callTimeoutSeconds > 0)
+    }
+
+    @Test fun `resolveConfig uses the live catalog models when no override is given`() {
+        writeAudio("f1.wav")
+        writeManifest(
+            """
+            {"version":1,"fixtures":[{"id":"f1","audioPath":"f1.wav","referenceText":"hi",
+             "durationMs":500,"language":"en-US","scenarios":["short_command"],
+             "source":"synthetic-tts","consent":"CC0-1.0"}]}
+            """.trimIndent()
+        )
+        val config = resolveConfig(BenchmarkArgs(true, null, null, temp.root.path))
+        assertEquals(listOf("gemini-3.1-flash-lite", "gemini-3.5-flash"), config.modelIds)
+        assertEquals(1, config.repetitions)
+    }
+
+    @Test fun `resolveConfig reports fixture problems and model problems together`() {
+        writeManifest(
+            """
+            {"version":1,"fixtures":[{"id":"f1","audioPath":"gone.wav","referenceText":"hi",
+             "durationMs":500,"language":"en-US","scenarios":["short_command"],
+             "source":"synthetic-tts","consent":"CC0-1.0"}]}
+            """.trimIndent()
+        )
+        val message = resolveError(BenchmarkArgs(true, "", null, temp.root.path))
+        assertTrue(message, message.contains("gone.wav"))
+        assertTrue(message, message.contains("empty", ignoreCase = true))
+    }
+
+    // ---------------------------------------------------------------- failure categorization
+
+    @Test fun `failure categories map real client error strings to buckets`() {
+        assertEquals("none", categorizeFailure(null))
+        assertEquals("timeout", categorizeFailure("timeout"))
+        assertEquals("quota/rate-limit", categorizeFailure("RESOURCE_EXHAUSTED: quota exceeded"))
+        assertEquals("auth", categorizeFailure("API key not valid"))
+        assertEquals("empty/blocked response", categorizeFailure("No text content in response"))
+        assertEquals("bad model/endpoint", categorizeFailure("Invalid Gemini endpoint: ..."))
+        assertEquals("other", categorizeFailure("something unexpected"))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionMetricsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionMetricsTest.kt
@@ -1,0 +1,274 @@
+package com.trevornk.ramblr
+
+import com.trevornk.ramblr.tools.TranscriptionMetrics
+import com.trevornk.ramblr.tools.TranscriptionMetrics.Normalization
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the offline scoring half of the #129 transcription benchmark. Every assertion
+ * is on a real computed value (edit counts, rates, percentiles) rather than on a proxy such as
+ * "the function returned something non-null" -- the micro-vs-macro test in particular exists to
+ * be killed by swapping micro-aggregation for an unweighted mean.
+ */
+class TranscriptionMetricsTest {
+
+    // ---------------------------------------------------------------- normalization
+
+    @Test fun `normalized mode lowercases collapses whitespace and strips punctuation`() {
+        assertEquals(
+            "hello world",
+            TranscriptionMetrics.normalize("  Hello,   WORLD!!  ", Normalization.NORMALIZED),
+        )
+    }
+
+    @Test fun `strict mode preserves case and punctuation but collapses whitespace`() {
+        assertEquals(
+            "Hello, WORLD!!",
+            TranscriptionMetrics.normalize("  Hello,   WORLD!!  ", Normalization.STRICT),
+        )
+    }
+
+    @Test fun `curly apostrophes and unicode dashes fold to ascii in both modes`() {
+        assertEquals("don't do it", TranscriptionMetrics.normalize("don\u2019t do it", Normalization.NORMALIZED))
+        assertEquals("Don't", TranscriptionMetrics.normalize("Don\u2019t", Normalization.STRICT))
+        // en dash, em dash, non-breaking hyphen all fold to '-'
+        assertEquals("a-b-c-d", TranscriptionMetrics.normalize("a\u2013b\u2014c\u2011d", Normalization.STRICT))
+    }
+
+    @Test fun `nfkc folds compatibility forms and composes accents`() {
+        // U+FB01 LATIN SMALL LIGATURE FI -> "fi"
+        assertEquals("file", TranscriptionMetrics.normalize("\uFB01le", Normalization.STRICT))
+        // Decomposed e + combining acute -> precomposed U+00E9
+        assertEquals("caf\u00E9", TranscriptionMetrics.normalize("cafe\u0301", Normalization.STRICT))
+        // Full-width digits -> ASCII digits
+        assertEquals("123", TranscriptionMetrics.normalize("\uFF11\uFF12\uFF13", Normalization.STRICT))
+    }
+
+    @Test fun `normalized mode keeps intra-word apostrophes and does not merge words`() {
+        assertEquals("don't stop", TranscriptionMetrics.normalize("Don\u2019t, stop.", Normalization.NORMALIZED))
+    }
+
+    // ---------------------------------------------------------------- exact match
+
+    @Test fun `strict exact match is true only for byte-identical-after-nfkc text`() {
+        assertTrue(TranscriptionMetrics.strictExactMatch("Hello, world.", "Hello, world."))
+        assertFalse(TranscriptionMetrics.strictExactMatch("Hello, world.", "hello world"))
+    }
+
+    @Test fun `case-only difference fails strict but passes normalized`() {
+        assertFalse(TranscriptionMetrics.strictExactMatch("Hello World", "hello world"))
+        assertTrue(TranscriptionMetrics.normalizedExactMatch("Hello World", "hello world"))
+        assertEquals(0.0, TranscriptionMetrics.wer("Hello World", "hello world", Normalization.NORMALIZED), 1e-9)
+        assertEquals(1.0, TranscriptionMetrics.wer("Hello World", "hello world", Normalization.STRICT), 1e-9)
+    }
+
+    @Test fun `punctuation-only difference fails strict but passes normalized`() {
+        assertFalse(TranscriptionMetrics.strictExactMatch("hey, there!", "hey there"))
+        assertTrue(TranscriptionMetrics.normalizedExactMatch("hey, there!", "hey there"))
+        assertEquals(0.0, TranscriptionMetrics.wer("hey, there!", "hey there", Normalization.NORMALIZED), 1e-9)
+        // Strict keeps the punctuation attached to the tokens, so both words are substitutions.
+        assertEquals(1.0, TranscriptionMetrics.wer("hey, there!", "hey there", Normalization.STRICT), 1e-9)
+    }
+
+    // ---------------------------------------------------------------- word edit distance
+
+    @Test fun `identical text has zero edits of every kind`() {
+        val edits = TranscriptionMetrics.wordEdits("the quick brown fox", "the quick brown fox")
+        assertEquals(0, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(0, edits.insertions)
+        assertEquals(0, edits.total)
+        assertEquals(4, edits.referenceLength)
+        assertEquals(0.0, TranscriptionMetrics.wer("the quick brown fox", "the quick brown fox"), 1e-9)
+    }
+
+    @Test fun `single substitution is counted as exactly one substitution`() {
+        val edits = TranscriptionMetrics.wordEdits("the quick brown fox", "the quick green fox")
+        assertEquals(1, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(0, edits.insertions)
+        assertEquals(4, edits.referenceLength)
+        assertEquals(0.25, TranscriptionMetrics.wer("the quick brown fox", "the quick green fox"), 1e-9)
+    }
+
+    @Test fun `single deletion is counted as exactly one deletion`() {
+        val edits = TranscriptionMetrics.wordEdits("the quick brown fox", "the quick fox")
+        assertEquals(0, edits.substitutions)
+        assertEquals(1, edits.deletions)
+        assertEquals(0, edits.insertions)
+        assertEquals(0.25, TranscriptionMetrics.wer("the quick brown fox", "the quick fox"), 1e-9)
+    }
+
+    @Test fun `single insertion is counted as exactly one insertion`() {
+        val edits = TranscriptionMetrics.wordEdits("the quick brown fox", "the very quick brown fox")
+        assertEquals(0, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(1, edits.insertions)
+        assertEquals(0.25, TranscriptionMetrics.wer("the quick brown fox", "the very quick brown fox"), 1e-9)
+    }
+
+    @Test fun `mixed edits are decomposed into each category`() {
+        // ref: a b c d   hyp: a x c d e  -> 1 substitution (b->x), 1 insertion (e)
+        val edits = TranscriptionMetrics.wordEdits("a b c d", "a x c d e")
+        assertEquals(1, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(1, edits.insertions)
+        assertEquals(2, edits.total)
+        assertEquals(0.5, TranscriptionMetrics.wer("a b c d", "a x c d e"), 1e-9)
+    }
+
+    @Test fun `wer above one is possible when the hypothesis rambles`() {
+        // ref is 1 word, hyp is 7 words -> 6 insertions over a 1-word reference = 6.0
+        val edits = TranscriptionMetrics.wordEdits("hi", "hi there my friend how are you")
+        assertEquals(6, edits.insertions)
+        assertEquals(1, edits.referenceLength)
+        assertEquals(6.0, TranscriptionMetrics.wer("hi", "hi there my friend how are you"), 1e-9)
+    }
+
+    // ---------------------------------------------------------------- char edit distance
+
+    @Test fun `character edits count per-character substitutions insertions and deletions`() {
+        val edits = TranscriptionMetrics.charEdits("kitten", "sitting")
+        assertEquals(2, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(1, edits.insertions)
+        assertEquals(3, edits.total)
+        assertEquals(6, edits.referenceLength)
+        assertEquals(3.0 / 6.0, TranscriptionMetrics.cer("kitten", "sitting"), 1e-9)
+    }
+
+    @Test fun `cer is zero for identical strings and counts whitespace-normalized characters`() {
+        assertEquals(0.0, TranscriptionMetrics.cer("hello world", "hello   world"), 1e-9)
+    }
+
+    // ---------------------------------------------------------------- empty reference
+
+    @Test fun `empty reference and empty hypothesis score zero`() {
+        assertEquals(0.0, TranscriptionMetrics.wer("", ""), 1e-9)
+        assertEquals(0.0, TranscriptionMetrics.cer("", ""), 1e-9)
+        assertEquals(0, TranscriptionMetrics.wordEdits("", "").total)
+        assertTrue(TranscriptionMetrics.normalizedExactMatch("", "   "))
+    }
+
+    @Test fun `empty reference with non-empty hypothesis records insertions and scores one`() {
+        val edits = TranscriptionMetrics.wordEdits("", "spurious words here")
+        assertEquals(3, edits.insertions)
+        assertEquals(0, edits.substitutions)
+        assertEquals(0, edits.deletions)
+        assertEquals(0, edits.referenceLength)
+        // Rate is undefined mathematically (division by zero); the contract pins it at 1.0.
+        assertEquals(1.0, TranscriptionMetrics.wer("", "spurious words here"), 1e-9)
+        assertEquals(1.0, TranscriptionMetrics.cer("", "abc"), 1e-9)
+    }
+
+    @Test fun `non-empty reference with empty hypothesis is all deletions`() {
+        val edits = TranscriptionMetrics.wordEdits("one two three", "")
+        assertEquals(3, edits.deletions)
+        assertEquals(0, edits.insertions)
+        assertEquals(1.0, TranscriptionMetrics.wer("one two three", ""), 1e-9)
+    }
+
+    // ---------------------------------------------------------------- micro vs macro
+
+    /**
+     * The load-bearing test for the aggregation contract. The corpus is deliberately unbalanced:
+     * one 1-word clip that is entirely wrong (per-clip WER 1.0) and one 99-word clip with a single
+     * error (per-clip WER ~0.0101). An unweighted mean of the per-clip rates gives ~0.505; the
+     * correct micro aggregation (sum edits / sum reference words) gives 2/100 = 0.02. Replacing
+     * micro with a mean must break this test.
+     */
+    @Test fun `micro aggregation weights by reference length and differs from the macro mean`() {
+        val longRef = (1..99).joinToString(" ") { "word$it" }
+        val longHyp = (1..99).joinToString(" ") { if (it == 50) "WRONGTOKEN" else "word$it" }
+        val corpus = listOf(
+            TranscriptionMetrics.score("alpha", "beta"),
+            TranscriptionMetrics.score(longRef, longHyp),
+        )
+
+        val agg = TranscriptionMetrics.aggregate(corpus)
+
+        assertEquals(2, agg.clipCount)
+        assertEquals(100, agg.totalReferenceWords)
+        assertEquals(2, agg.totalWordEdits)
+        assertEquals(0.02, agg.microWer, 1e-9)
+        assertEquals((1.0 + 1.0 / 99.0) / 2.0, agg.macroWer, 1e-9)
+        // The whole point: the two aggregations must not coincide on this corpus.
+        assertNotEquals(agg.macroWer, agg.microWer, 1e-6)
+        assertTrue("macro must be far larger here, got ${agg.macroWer} vs ${agg.microWer}", agg.macroWer > agg.microWer * 10)
+    }
+
+    @Test fun `micro cer is a character-weighted ratio not a mean of per-clip cers`() {
+        val corpus = listOf(
+            TranscriptionMetrics.score("ab", "xy"),          // 2 char edits over 2 ref chars
+            TranscriptionMetrics.score("a".repeat(98), "a".repeat(98)), // 0 edits over 98 ref chars
+        )
+        val agg = TranscriptionMetrics.aggregate(corpus)
+        assertEquals(100, agg.totalReferenceChars)
+        assertEquals(2, agg.totalCharEdits)
+        assertEquals(0.02, agg.microCer, 1e-9)
+        assertEquals(0.5, agg.macroCer, 1e-9)
+        assertNotEquals(agg.macroCer, agg.microCer, 1e-6)
+    }
+
+    @Test fun `aggregate reports strict and normalized exact match rates separately`() {
+        val corpus = listOf(
+            TranscriptionMetrics.score("Hello world", "Hello world"),   // strict + normalized
+            TranscriptionMetrics.score("Hello world", "hello, world!"), // normalized only
+            TranscriptionMetrics.score("Hello world", "goodbye world"), // neither
+            TranscriptionMetrics.score("Hello world", "totally different"),
+        )
+        val agg = TranscriptionMetrics.aggregate(corpus)
+        assertEquals(0.25, agg.strictExactMatchRate, 1e-9)
+        assertEquals(0.5, agg.normalizedExactMatchRate, 1e-9)
+    }
+
+    @Test fun `aggregating an empty corpus yields zeroed stats rather than NaN`() {
+        val agg = TranscriptionMetrics.aggregate(emptyList())
+        assertEquals(0, agg.clipCount)
+        assertEquals(0.0, agg.microWer, 1e-9)
+        assertEquals(0.0, agg.macroWer, 1e-9)
+        assertEquals(0.0, agg.strictExactMatchRate, 1e-9)
+    }
+
+    // ---------------------------------------------------------------- latency percentiles
+
+    @Test fun `percentiles use nearest rank on the sorted sample`() {
+        val values = listOf(100L, 200L, 300L, 400L, 500L, 600L, 700L, 800L, 900L, 1000L)
+        val stats = TranscriptionMetrics.latencyStats(values)
+        assertEquals(550.0, stats.meanMs!!, 1e-9)
+        // nearest-rank: ceil(0.50 * 10) = 5 -> 5th smallest = 500
+        assertEquals(500L, stats.p50Ms)
+        // nearest-rank: ceil(0.95 * 10) = 10 -> 10th smallest = 1000
+        assertEquals(1000L, stats.p95Ms)
+        assertEquals(100L, stats.minMs)
+        assertEquals(1000L, stats.maxMs)
+        assertEquals(10, stats.count)
+    }
+
+    @Test fun `percentiles are order independent`() {
+        val shuffled = listOf(900L, 100L, 500L, 300L, 700L)
+        val stats = TranscriptionMetrics.latencyStats(shuffled)
+        assertEquals(500L, stats.p50Ms) // ceil(0.5*5)=3 -> 3rd smallest of 100,300,500,700,900
+        assertEquals(900L, stats.p95Ms) // ceil(0.95*5)=5 -> 5th smallest
+        assertEquals(500.0, stats.meanMs!!, 1e-9)
+    }
+
+    @Test fun `single sample percentiles equal that sample`() {
+        val stats = TranscriptionMetrics.latencyStats(listOf(42L))
+        assertEquals(42L, stats.p50Ms)
+        assertEquals(42L, stats.p95Ms)
+        assertEquals(42.0, stats.meanMs!!, 1e-9)
+    }
+
+    @Test fun `empty latency sample is reported as absent rather than zero`() {
+        val stats = TranscriptionMetrics.latencyStats(emptyList())
+        assertEquals(0, stats.count)
+        assertEquals(null, stats.p50Ms)
+        assertEquals(null, stats.p95Ms)
+        assertEquals(null, stats.meanMs)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/WavPcmTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/WavPcmTest.kt
@@ -1,0 +1,244 @@
+package com.trevornk.ramblr
+
+import com.trevornk.ramblr.tools.WavPcm
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import java.io.ByteArrayOutputStream
+
+/**
+ * Tests for the RIFF chunk walker. Every WAV byte sequence here is generated programmatically --
+ * no audio assets are checked in. The `LIST chunk before data` case is the mutation target: a
+ * naive 44-byte header skip produces the wrong payload for it and must fail these assertions.
+ */
+class WavPcmTest {
+
+    @get:Rule val temp = TemporaryFolder()
+
+    // ------------------------------------------------------------ byte-level WAV builders
+
+    private fun le16(v: Int) = byteArrayOf((v and 0xFF).toByte(), ((v shr 8) and 0xFF).toByte())
+    private fun le32(v: Int) = byteArrayOf(
+        (v and 0xFF).toByte(),
+        ((v shr 8) and 0xFF).toByte(),
+        ((v shr 16) and 0xFF).toByte(),
+        ((v shr 24) and 0xFF).toByte(),
+    )
+
+    private fun ascii(s: String) = s.toByteArray(Charsets.US_ASCII)
+
+    private fun fmtChunk(
+        audioFormat: Int = 1,
+        channels: Int = 1,
+        sampleRate: Int = 16000,
+        bitsPerSample: Int = 16,
+        extraFmtBytes: ByteArray = ByteArray(0),
+    ): ByteArray {
+        val blockAlign = channels * bitsPerSample / 8
+        val byteRate = sampleRate * blockAlign
+        val body = ByteArrayOutputStream()
+        body.write(le16(audioFormat))
+        body.write(le16(channels))
+        body.write(le32(sampleRate))
+        body.write(le32(byteRate))
+        body.write(le16(blockAlign))
+        body.write(le16(bitsPerSample))
+        body.write(extraFmtBytes)
+        val bodyBytes = body.toByteArray()
+        val out = ByteArrayOutputStream()
+        out.write(ascii("fmt "))
+        out.write(le32(bodyBytes.size))
+        out.write(bodyBytes)
+        return out.toByteArray()
+    }
+
+    private fun chunk(id: String, payload: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write(ascii(id))
+        out.write(le32(payload.size))
+        out.write(payload)
+        if (payload.size % 2 == 1) out.write(0) // RIFF word-alignment pad byte
+        return out.toByteArray()
+    }
+
+    private fun riff(vararg chunks: ByteArray): ByteArray {
+        val body = ByteArrayOutputStream()
+        body.write(ascii("WAVE"))
+        chunks.forEach { body.write(it) }
+        val bodyBytes = body.toByteArray()
+        val out = ByteArrayOutputStream()
+        out.write(ascii("RIFF"))
+        out.write(le32(bodyBytes.size))
+        out.write(bodyBytes)
+        return out.toByteArray()
+    }
+
+    /** Deterministic pseudo-PCM: [sampleCount] signed 16-bit LE samples with recognisable values. */
+    private fun pcm(sampleCount: Int, seed: Int = 0): ByteArray {
+        val out = ByteArrayOutputStream()
+        for (i in 0 until sampleCount) {
+            val v = ((i * 37 + seed) % 30000) - 15000
+            out.write(le16(v and 0xFFFF))
+        }
+        return out.toByteArray()
+    }
+
+    // ------------------------------------------------------------ happy paths
+
+    @Test fun `extracts pcm from a canonical 44-byte-header wav`() {
+        val body = pcm(64)
+        val wav = riff(fmtChunk(), chunk("data", body))
+        assertEquals("canonical WAV should be exactly 44 bytes of header", 44 + body.size, wav.size)
+        assertArrayEquals(body, WavPcm.extractPcm(wav))
+    }
+
+    /**
+     * The naive-44-byte-skip killer. A `LIST`/`INFO` metadata chunk sits between `fmt ` and
+     * `data`, so the PCM begins well past byte 44. A fixed skip would return metadata bytes plus
+     * a truncated tail; only a real chunk walk returns the exact payload.
+     */
+    @Test fun `extracts pcm when an extra LIST chunk precedes the data chunk`() {
+        val body = pcm(128, seed = 7)
+        val listPayload = ascii("INFOISFT") + le32(14) + ascii("Ramblr eval 1\u0000")
+        val wav = riff(fmtChunk(), chunk("LIST", listPayload), chunk("data", body))
+
+        assertTrue("data must start past byte 44 for this test to be meaningful", wav.size - body.size > 44)
+        val extracted = WavPcm.extractPcm(wav)
+        assertEquals(body.size, extracted.size)
+        assertArrayEquals(body, extracted)
+    }
+
+    @Test fun `extracts pcm when several chunks precede data and one has an odd length`() {
+        val body = pcm(32, seed = 3)
+        val wav = riff(
+            fmtChunk(),
+            chunk("fact", le32(32)),
+            chunk("junk", ascii("odd-length-metadata")), // 19 bytes -> pad byte exercised
+            chunk("data", body),
+        )
+        assertArrayEquals(body, WavPcm.extractPcm(wav))
+    }
+
+    @Test fun `tolerates a fmt chunk with extension bytes`() {
+        val body = pcm(16)
+        val wav = riff(fmtChunk(extraFmtBytes = le16(0)), chunk("data", body))
+        assertArrayEquals(body, WavPcm.extractPcm(wav))
+    }
+
+    @Test fun `ignores trailing chunks after data`() {
+        val body = pcm(16, seed = 11)
+        val wav = riff(fmtChunk(), chunk("data", body), chunk("LIST", ascii("INFOtrailer")))
+        assertArrayEquals(body, WavPcm.extractPcm(wav))
+    }
+
+    @Test fun `parses the format header fields`() {
+        val wav = riff(fmtChunk(), chunk("data", pcm(8)))
+        val format = WavPcm.readFormat(wav)
+        assertEquals(1, format.audioFormat)
+        assertEquals(1, format.channels)
+        assertEquals(16000, format.sampleRate)
+        assertEquals(16, format.bitsPerSample)
+    }
+
+    @Test fun `writes raw pcm to a temp file that matches the data chunk byte for byte`() {
+        val body = pcm(100, seed = 5)
+        val wav = riff(fmtChunk(), chunk("LIST", ascii("INFOxx")), chunk("data", body))
+        val wavFile = temp.newFile("fixture.wav")
+        wavFile.writeBytes(wav)
+
+        val pcmFile = WavPcm.extractPcmToTempFile(wavFile)
+        try {
+            assertEquals(body.size.toLong(), pcmFile.length())
+            assertArrayEquals(body, pcmFile.readBytes())
+        } finally {
+            pcmFile.delete()
+        }
+    }
+
+    // ------------------------------------------------------------ rejection paths
+
+    private fun expectReject(wav: ByteArray, expectedFragment: String) {
+        val error = try {
+            WavPcm.extractPcm(wav)
+            null
+        } catch (e: WavPcm.UnsupportedWavException) {
+            e.message ?: ""
+        }
+        assertTrue(
+            "expected an UnsupportedWavException mentioning '$expectedFragment', got: $error",
+            error != null && error.contains(expectedFragment, ignoreCase = true),
+        )
+    }
+
+    @Test fun `rejects a non-PCM compressed format`() {
+        expectReject(riff(fmtChunk(audioFormat = 3), chunk("data", pcm(8))), "PCM")
+    }
+
+    @Test fun `rejects the wrong sample rate`() {
+        expectReject(riff(fmtChunk(sampleRate = 44100), chunk("data", pcm(8))), "44100")
+    }
+
+    @Test fun `rejects stereo audio`() {
+        expectReject(riff(fmtChunk(channels = 2), chunk("data", pcm(8))), "channel")
+    }
+
+    @Test fun `rejects 8-bit and 24-bit depths`() {
+        expectReject(riff(fmtChunk(bitsPerSample = 8), chunk("data", pcm(8))), "bit")
+        expectReject(riff(fmtChunk(bitsPerSample = 24), chunk("data", pcm(8))), "bit")
+    }
+
+    @Test fun `rejects a file that is not RIFF`() {
+        val notRiff = ascii("OggS") + ByteArray(60)
+        expectReject(notRiff, "RIFF")
+    }
+
+    @Test fun `rejects a RIFF file whose form type is not WAVE`() {
+        val bytes = ascii("RIFF") + le32(40) + ascii("AVI ") + ByteArray(36)
+        expectReject(bytes, "WAVE")
+    }
+
+    @Test fun `rejects a wav with no fmt chunk`() {
+        expectReject(riff(chunk("data", pcm(8))), "fmt")
+    }
+
+    @Test fun `rejects a wav with no data chunk`() {
+        expectReject(riff(fmtChunk(), chunk("LIST", ascii("INFOnope"))), "data")
+    }
+
+    @Test fun `rejects an empty data chunk`() {
+        expectReject(riff(fmtChunk(), chunk("data", ByteArray(0))), "empty")
+    }
+
+    @Test fun `rejects a truncated file`() {
+        expectReject(ascii("RIFF") + le32(4), "truncat")
+    }
+
+    @Test fun `rejects a chunk header that declares a length running past the end of file`() {
+        val out = ByteArrayOutputStream()
+        out.write(ascii("WAVE"))
+        out.write(fmtChunk())
+        out.write(ascii("data"))
+        out.write(le32(1_000_000)) // lies about its size
+        out.write(pcm(4))
+        val body = out.toByteArray()
+        val wav = ascii("RIFF") + le32(body.size) + body
+        expectReject(wav, "truncat")
+    }
+
+    @Test fun `rejects a negative or absurd chunk length`() {
+        val out = ByteArrayOutputStream()
+        out.write(ascii("WAVE"))
+        out.write(ascii("junk"))
+        out.write(le32(-16)) // reads as a huge unsigned value
+        out.write(ByteArray(8))
+        val body = out.toByteArray()
+        expectReject(ascii("RIFF") + le32(body.size) + body, "truncat")
+    }
+
+    @Test fun `rejects an odd-sized data chunk that cannot hold whole 16-bit samples`() {
+        expectReject(riff(fmtChunk(), chunk("data", ByteArray(7))), "sample")
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt
@@ -1,0 +1,494 @@
+package com.trevornk.ramblr.tools
+
+import com.trevornk.ramblr.GeminiTranscriberClient
+import com.trevornk.ramblr.InFlightCall
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
+
+/**
+ * Manual dev tool for issue #129 — NOT a JUnit test and NOT run by `make test` / CI.
+ *
+ * Measures how well the **production transcription path** actually transcribes audio, by calling
+ * the real shipped [GeminiTranscriberClient.transcribe] (same request shape, same headers, same
+ * OkHttp client, same async callback contract) for every fixture x model x repetition in the
+ * corpus under `app/src/test/resources/transcription_eval/`, then scoring the results with
+ * [TranscriptionMetrics] and writing a Markdown + JSON report to `eval-reports/` (gitignored).
+ *
+ * Mirrors [EvalHarness]'s structure deliberately — same "declare only main(), so Gradle compiles
+ * it but JUnit never discovers it" trick, same manual JavaExec task, same gitignored report
+ * directory — but is a separate tool because it benchmarks a completely different stage of the
+ * pipeline (audio -> text) with completely different metrics (WER/CER, not human-judged cleanup
+ * quality) and completely different cost and privacy characteristics (it uploads audio).
+ *
+ * **This tool calls the real Gemini API, spends real credits, and uploads audio to Google.**
+ * See the "Transcription benchmark" section of README.md.
+ *
+ * Run via: `./gradlew runGeminiTranscriptionBenchmark`
+ *
+ * ## Known limitation: no cost accounting
+ * [GeminiTranscriberClient.Result] carries only `text`/`error` — the production client discards
+ * the response's `usageMetadata`, so token counts are simply not observable from this path. This
+ * report therefore records latency and accuracy but **no billed-cost figures**. Estimating cost
+ * from clip duration would be a fabrication; if real cost accounting is needed, the production
+ * Result type has to surface usage metadata first.
+ */
+
+/** Env var holding the API key. Its *value* is never printed, logged, or written to a report. */
+private const val API_KEY_ENV = "GEMINI_API_KEY"
+
+/** Comma-separated model id override. No default substitution happens if it's set but empty. */
+private const val MODELS_ENV = "GEMINI_TRANSCRIPTION_MODELS"
+
+/** Repetition count override — >1 exposes run-to-run nondeterminism in the model's output. */
+private const val REPETITIONS_ENV = "GEMINI_TRANSCRIPTION_REPETITIONS"
+
+/** Corpus directory override, for keeping a private fixture corpus outside the repo. */
+private const val EVAL_DIR_ENV = "TRANSCRIPTION_EVAL_DIR"
+
+private const val DEFAULT_EVAL_DIR = "app/src/test/resources/transcription_eval"
+
+/**
+ * Default candidate models: the two Gemini entries the live model catalog
+ * ([com.trevornk.ramblr.ModelCatalogStore.CATALOG_URL]) currently offers — RECOMMENDED and GOOD.
+ * These are what a user can actually pick in the app, which is the only list worth benchmarking.
+ */
+private val DEFAULT_MODELS = listOf("gemini-3.1-flash-lite", "gemini-3.5-flash")
+
+/** Per-call ceiling. The production OkHttp client has its own timeouts; this latch bound only
+ *  guarantees the benchmark can never wedge forever waiting on a callback that never fires. */
+private const val CALL_TIMEOUT_SECONDS = 180L
+
+// ---------------------------------------------------------------------- pure configuration
+
+/** A fully validated, ready-to-execute benchmark configuration. Contains no secret. */
+data class BenchmarkConfig(
+    val evalDir: File,
+    val manifestFile: File,
+    val manifestChecksum: String,
+    val fixtures: List<TranscriptionEvalManifest.Fixture>,
+    val modelIds: List<String>,
+    val repetitions: Int,
+    val callTimeoutSeconds: Long,
+) {
+    val totalCalls: Int get() = fixtures.size * modelIds.size * repetitions
+}
+
+/**
+ * Raw, unvalidated inputs — deliberately a plain data class of strings so unit tests can drive
+ * [resolveConfig] without setting process environment variables or touching the network.
+ * [apiKeyPresent] is a boolean, not the key: the key never enters this layer at all.
+ */
+data class BenchmarkArgs(
+    val apiKeyPresent: Boolean,
+    val modelsRaw: String?,
+    val repetitionsRaw: String?,
+    val evalDirRaw: String?,
+)
+
+/**
+ * The entire "should this run start, and with what?" decision as a **pure function**: no network,
+ * no environment reads, no output. Returns the config or throws
+ * [TranscriptionEvalManifest.ManifestException] listing every problem at once.
+ */
+fun resolveConfig(args: BenchmarkArgs): BenchmarkConfig {
+    val problems = mutableListOf<String>()
+
+    if (!args.apiKeyPresent) {
+        problems.add("$API_KEY_ENV is not set — this tool calls the real Gemini API and needs a key")
+    }
+
+    val repetitions = when (val raw = args.repetitionsRaw?.trim()?.takeIf { it.isNotEmpty() }) {
+        null -> 1
+        else -> raw.toIntOrNull().also {
+            if (it == null) problems.add("$REPETITIONS_ENV must be an integer, got '$raw'")
+            else if (it < 1) problems.add("$REPETITIONS_ENV must be at least 1, got $it")
+        } ?: 1
+    }
+
+    // An explicitly-set-but-empty override is an error, not a cue to fall back to the defaults:
+    // "GEMINI_TRANSCRIPTION_MODELS=" almost certainly means a broken shell expansion, and
+    // silently benchmarking a different model set than the operator believes they configured
+    // produces results that look fine and mean nothing.
+    val modelIds: List<String> = when (val raw = args.modelsRaw) {
+        null -> DEFAULT_MODELS
+        else -> raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+    }
+    problems.addAll(TranscriptionEvalManifest.validateModelIds(modelIds))
+
+    val evalDir = File(args.evalDirRaw?.trim()?.takeIf { it.isNotEmpty() } ?: DEFAULT_EVAL_DIR)
+    val manifestFile = File(evalDir, "manifest.json")
+    var fixtures: List<TranscriptionEvalManifest.Fixture> = emptyList()
+    var checksum = ""
+
+    if (!manifestFile.isFile) {
+        problems.add("Manifest not found at ${manifestFile.path} (run this from the repo root, or set $EVAL_DIR_ENV)")
+    } else {
+        val document = manifestFile.readText()
+        checksum = TranscriptionEvalManifest.checksum(document)
+        try {
+            fixtures = TranscriptionEvalManifest.parse(document).fixtures
+            problems.addAll(TranscriptionEvalManifest.validateFixtures(fixtures, evalDir))
+            if (fixtures.isEmpty()) {
+                problems.add(
+                    "Manifest at ${manifestFile.path} declares no fixtures. The checked-in manifest is a " +
+                        "placeholder — add your own audio fixtures first (see ${evalDir.path}/README.md)."
+                )
+            }
+        } catch (e: TranscriptionEvalManifest.ManifestException) {
+            problems.add(e.message ?: "Manifest failed to parse")
+        }
+    }
+
+    if (problems.isNotEmpty()) {
+        throw TranscriptionEvalManifest.ManifestException(
+            "Cannot start the transcription benchmark (${problems.size} problem(s)):\n" +
+                problems.joinToString("\n") { "  - $it" }
+        )
+    }
+
+    return BenchmarkConfig(
+        evalDir = evalDir,
+        manifestFile = manifestFile,
+        manifestChecksum = checksum,
+        fixtures = fixtures,
+        modelIds = modelIds,
+        repetitions = repetitions,
+        callTimeoutSeconds = CALL_TIMEOUT_SECONDS,
+    )
+}
+
+// ---------------------------------------------------------------------- per-call results
+
+/** One (fixture, model, repetition) attempt. Exactly one of [transcript]/[error] is non-null. */
+data class CallOutcome(
+    val fixtureId: String,
+    val modelId: String,
+    val repetition: Int,
+    val transcript: String?,
+    val error: String?,
+    val latencyMs: Long,
+) {
+    val succeeded: Boolean get() = transcript != null
+}
+
+/** Coarse failure buckets for the report's failure-category table. Pattern-matched on the error
+ *  text because that's all the production Result type exposes — no status code survives it. */
+fun categorizeFailure(error: String?): String = when {
+    error == null -> "none"
+    error.contains("timeout", ignoreCase = true) || error.contains("timed out", ignoreCase = true) -> "timeout"
+    error.contains("quota", ignoreCase = true) || error.contains("rate limit", ignoreCase = true) ||
+        error.contains("RESOURCE_EXHAUSTED", ignoreCase = true) -> "quota/rate-limit"
+    error.contains("permission", ignoreCase = true) || error.contains("API key", ignoreCase = true) ||
+        error.contains("UNAUTHENTICATED", ignoreCase = true) -> "auth"
+    error.contains("No text content", ignoreCase = true) || error.contains("No candidates", ignoreCase = true) ||
+        error.contains("safety", ignoreCase = true) -> "empty/blocked response"
+    error.contains("Invalid Gemini endpoint", ignoreCase = true) || error.contains("not found", ignoreCase = true) -> "bad model/endpoint"
+    error.contains("Unable to resolve host", ignoreCase = true) || error.contains("connect", ignoreCase = true) -> "network"
+    else -> "other"
+}
+
+/** Blocking wrapper around the async production client: enqueues the real call and waits on a
+ *  latch with a hard bound, so one hung callback can't stall a whole benchmark run. */
+private fun transcribeBlocking(
+    pcmFile: File,
+    apiKey: String,
+    model: String,
+    timeoutSeconds: Long,
+): Pair<GeminiTranscriberClient.Result, Long> {
+    val latch = CountDownLatch(1)
+    // AtomicReference rather than a plain var: the callback runs on an OkHttp dispatcher thread,
+    // so the write must be safely published to the thread awaiting the latch.
+    val result = java.util.concurrent.atomic.AtomicReference<GeminiTranscriberClient.Result?>(null)
+    val holder = InFlightCall()
+    val start = System.nanoTime()
+
+    GeminiTranscriberClient.transcribe(
+        pcmFile = pcmFile,
+        apiKey = apiKey,
+        model = model,
+        cancelHolder = holder,
+        callback = { r ->
+            result.set(r)
+            latch.countDown()
+        },
+    )
+
+    val completed = latch.await(timeoutSeconds, TimeUnit.SECONDS)
+    val latencyMs = (System.nanoTime() - start) / 1_000_000
+    if (!completed) {
+        holder.cancel()
+        return GeminiTranscriberClient.Result(null, "Timed out after ${timeoutSeconds}s waiting for the transcription callback") to latencyMs
+    }
+    val settled = result.get()
+        ?: GeminiTranscriberClient.Result(null, "Callback fired without producing a Result")
+    return settled to latencyMs
+}
+
+// ---------------------------------------------------------------------- reporting
+
+/** Everything needed to render a report, computed offline from [CallOutcome]s. */
+data class BenchmarkReport(
+    val commitSha: String,
+    val timestampUtc: String,
+    val config: BenchmarkConfig,
+    val outcomes: List<CallOutcome>,
+)
+
+private fun currentCommitSha(): String = try {
+    val process = ProcessBuilder("git", "rev-parse", "HEAD").redirectErrorStream(true).start()
+    val out = process.inputStream.bufferedReader().readText().trim()
+    if (process.waitFor() == 0 && out.isNotEmpty()) out else "unknown"
+} catch (e: Exception) {
+    "unknown (${e.message})"
+}
+
+/** Scores a model's successful calls against the fixture references. */
+private fun scoresFor(
+    model: String,
+    outcomes: List<CallOutcome>,
+    fixturesById: Map<String, TranscriptionEvalManifest.Fixture>,
+): List<TranscriptionMetrics.ClipScore> =
+    outcomes.filter { it.modelId == model && it.succeeded }.mapNotNull { outcome ->
+        fixturesById[outcome.fixtureId]?.let { fixture ->
+            TranscriptionMetrics.score(fixture.referenceText, outcome.transcript!!)
+        }
+    }
+
+fun renderMarkdown(report: BenchmarkReport): String {
+    val cfg = report.config
+    val fixturesById = cfg.fixtures.associateBy { it.id }
+    val sb = StringBuilder()
+
+    sb.append("# Gemini transcription benchmark (#129)\n\n")
+    sb.append("- Commit: `${report.commitSha}`\n")
+    sb.append("- Run at (UTC): `${report.timestampUtc}`\n")
+    sb.append("- Models: ${cfg.modelIds.joinToString(", ") { "`$it`" }}\n")
+    sb.append("- Repetitions per fixture/model: ${cfg.repetitions}\n")
+    sb.append("- Per-call timeout: ${cfg.callTimeoutSeconds}s (plus the production OkHttp client's own timeouts)\n")
+    sb.append("- Manifest: `${cfg.manifestFile.path}` (sha256 `${cfg.manifestChecksum}`)\n")
+    sb.append("- Fixtures: ${cfg.fixtures.size}, total calls: ${cfg.totalCalls}\n\n")
+    sb.append(
+        "> Cost accounting is unavailable: `GeminiTranscriberClient.Result` discards the response's " +
+            "`usageMetadata`, so token counts are not observable from the production path. No cost " +
+            "figures are estimated here — that would be fabrication.\n\n"
+    )
+
+    sb.append("## Summary by model\n\n")
+    sb.append("| Model | Calls | Success | micro-WER | micro-CER | macro-WER | Strict exact | Norm exact | p50 ms | p95 ms | mean ms |\n")
+    sb.append("|---|---|---|---|---|---|---|---|---|---|---|\n")
+    for (model in cfg.modelIds) {
+        val modelOutcomes = report.outcomes.filter { it.modelId == model }
+        val agg = TranscriptionMetrics.aggregate(scoresFor(model, report.outcomes, fixturesById))
+        val latency = TranscriptionMetrics.latencyStats(modelOutcomes.filter { it.succeeded }.map { it.latencyMs })
+        val successRate = if (modelOutcomes.isEmpty()) 0.0
+        else modelOutcomes.count { it.succeeded }.toDouble() / modelOutcomes.size
+        sb.append(
+            "| `$model` | ${modelOutcomes.size} | ${"%.1f%%".format(successRate * 100)} | " +
+                "${"%.4f".format(agg.microWer)} | ${"%.4f".format(agg.microCer)} | ${"%.4f".format(agg.macroWer)} | " +
+                "${"%.1f%%".format(agg.strictExactMatchRate * 100)} | ${"%.1f%%".format(agg.normalizedExactMatchRate * 100)} | " +
+                "${latency.p50Ms ?: "-"} | ${latency.p95Ms ?: "-"} | ${latency.meanMs?.let { "%.0f".format(it) } ?: "-"} |\n"
+        )
+    }
+    sb.append("\nmicro-WER is the headline figure (summed edits / summed reference words). macro-WER ")
+    sb.append("(the unweighted mean of per-clip rates) is shown only so corpus skew is visible.\n\n")
+
+    sb.append("## Edit breakdown by model\n\n")
+    sb.append("| Model | Substitutions | Deletions | Insertions | Ref words | Ref chars |\n|---|---|---|---|---|---|\n")
+    for (model in cfg.modelIds) {
+        val agg = TranscriptionMetrics.aggregate(scoresFor(model, report.outcomes, fixturesById))
+        sb.append("| `$model` | ${agg.totalSubstitutions} | ${agg.totalDeletions} | ${agg.totalInsertions} | ${agg.totalReferenceWords} | ${agg.totalReferenceChars} |\n")
+    }
+    sb.append("\n")
+
+    val failures = report.outcomes.filter { !it.succeeded }
+    sb.append("## Failure categories\n\n")
+    if (failures.isEmpty()) {
+        sb.append("No failed calls.\n\n")
+    } else {
+        sb.append("| Category | Count |\n|---|---|\n")
+        failures.groupingBy { categorizeFailure(it.error) }.eachCount()
+            .toList().sortedByDescending { it.second }
+            .forEach { (category, count) -> sb.append("| $category | $count |\n") }
+        sb.append("\n")
+    }
+
+    sb.append("## Per-call detail\n\n")
+    for (fixture in cfg.fixtures) {
+        sb.append("### `${fixture.id}` — ${fixture.scenarios.joinToString(", ")} (${fixture.durationMs} ms, ${fixture.language})\n\n")
+        sb.append("**Reference:**\n\n```\n${fixture.referenceText}\n```\n\n")
+        report.outcomes.filter { it.fixtureId == fixture.id }.forEach { outcome ->
+            sb.append("**`${outcome.modelId}` rep ${outcome.repetition}** — ${outcome.latencyMs} ms\n\n")
+            if (outcome.transcript != null) {
+                val score = TranscriptionMetrics.score(fixture.referenceText, outcome.transcript)
+                sb.append("```\n${outcome.transcript}\n```\n\n")
+                sb.append(
+                    "_WER ${"%.4f".format(score.wer)} (S${score.wordEdits.substitutions}/D${score.wordEdits.deletions}/I${score.wordEdits.insertions}), " +
+                        "CER ${"%.4f".format(score.cer)}, strict exact: ${score.strictExactMatch}, normalized exact: ${score.normalizedExactMatch}_\n\n"
+                )
+            } else {
+                sb.append("_Error (${categorizeFailure(outcome.error)}): ${outcome.error}_\n\n")
+            }
+        }
+        sb.append("---\n\n")
+    }
+    return sb.toString()
+}
+
+fun renderJson(report: BenchmarkReport): String {
+    val cfg = report.config
+    val fixturesById = cfg.fixtures.associateBy { it.id }
+    val root = JSONObject()
+    root.put("commitSha", report.commitSha)
+    root.put("timestampUtc", report.timestampUtc)
+    root.put("models", JSONArray(cfg.modelIds))
+    root.put("repetitions", cfg.repetitions)
+    root.put("callTimeoutSeconds", cfg.callTimeoutSeconds)
+    root.put("manifestPath", cfg.manifestFile.path)
+    root.put("manifestSha256", cfg.manifestChecksum)
+    root.put("fixtureCount", cfg.fixtures.size)
+    root.put("totalCalls", cfg.totalCalls)
+    root.put("costAccounting", "unavailable: GeminiTranscriberClient.Result discards usageMetadata")
+
+    val perModel = JSONArray()
+    for (model in cfg.modelIds) {
+        val modelOutcomes = report.outcomes.filter { it.modelId == model }
+        val agg = TranscriptionMetrics.aggregate(scoresFor(model, report.outcomes, fixturesById))
+        val latency = TranscriptionMetrics.latencyStats(modelOutcomes.filter { it.succeeded }.map { it.latencyMs })
+        perModel.put(
+            JSONObject()
+                .put("model", model)
+                .put("calls", modelOutcomes.size)
+                .put("successes", modelOutcomes.count { it.succeeded })
+                .put("successRate", if (modelOutcomes.isEmpty()) 0.0 else modelOutcomes.count { it.succeeded }.toDouble() / modelOutcomes.size)
+                .put("microWer", agg.microWer)
+                .put("microCer", agg.microCer)
+                .put("macroWer", agg.macroWer)
+                .put("macroCer", agg.macroCer)
+                .put("substitutions", agg.totalSubstitutions)
+                .put("deletions", agg.totalDeletions)
+                .put("insertions", agg.totalInsertions)
+                .put("referenceWords", agg.totalReferenceWords)
+                .put("referenceChars", agg.totalReferenceChars)
+                .put("strictExactMatchRate", agg.strictExactMatchRate)
+                .put("normalizedExactMatchRate", agg.normalizedExactMatchRate)
+                .put("latencyP50Ms", latency.p50Ms ?: JSONObject.NULL)
+                .put("latencyP95Ms", latency.p95Ms ?: JSONObject.NULL)
+                .put("latencyMeanMs", latency.meanMs ?: JSONObject.NULL)
+                .put("latencyMinMs", latency.minMs ?: JSONObject.NULL)
+                .put("latencyMaxMs", latency.maxMs ?: JSONObject.NULL)
+        )
+    }
+    root.put("perModel", perModel)
+
+    val failureCategories = JSONObject()
+    report.outcomes.filter { !it.succeeded }.groupingBy { categorizeFailure(it.error) }.eachCount()
+        .forEach { (category, count) -> failureCategories.put(category, count) }
+    root.put("failureCategories", failureCategories)
+
+    val calls = JSONArray()
+    report.outcomes.forEach { outcome ->
+        val obj = JSONObject()
+            .put("fixtureId", outcome.fixtureId)
+            .put("model", outcome.modelId)
+            .put("repetition", outcome.repetition)
+            .put("latencyMs", outcome.latencyMs)
+            .put("transcript", outcome.transcript ?: JSONObject.NULL)
+            .put("error", outcome.error ?: JSONObject.NULL)
+            .put("failureCategory", categorizeFailure(outcome.error))
+        fixturesById[outcome.fixtureId]?.let { fixture ->
+            obj.put("reference", fixture.referenceText)
+            if (outcome.transcript != null) {
+                val score = TranscriptionMetrics.score(fixture.referenceText, outcome.transcript)
+                obj.put("wer", score.wer)
+                obj.put("cer", score.cer)
+                obj.put("substitutions", score.wordEdits.substitutions)
+                obj.put("deletions", score.wordEdits.deletions)
+                obj.put("insertions", score.wordEdits.insertions)
+                obj.put("strictExactMatch", score.strictExactMatch)
+                obj.put("normalizedExactMatch", score.normalizedExactMatch)
+            }
+        }
+        calls.put(obj)
+    }
+    root.put("calls", calls)
+    return root.toString(2)
+}
+
+// ---------------------------------------------------------------------- entry point
+
+fun main() {
+    val apiKey = System.getenv(API_KEY_ENV)
+
+    val config = try {
+        resolveConfig(
+            BenchmarkArgs(
+                // Only presence is passed in; the key itself never reaches the pure config layer,
+                // so it can never end up in a config-derived log line or report field.
+                apiKeyPresent = !apiKey.isNullOrBlank(),
+                modelsRaw = System.getenv(MODELS_ENV),
+                repetitionsRaw = System.getenv(REPETITIONS_ENV),
+                evalDirRaw = System.getenv(EVAL_DIR_ENV),
+            )
+        )
+    } catch (e: TranscriptionEvalManifest.ManifestException) {
+        System.err.println(e.message)
+        exitProcess(1)
+    }
+    // Non-null by construction: resolveConfig rejects a missing key before returning.
+    val key = apiKey!!
+
+    println(
+        "Running ${config.fixtures.size} fixture(s) x ${config.modelIds.size} model(s) x " +
+            "${config.repetitions} repetition(s) = ${config.totalCalls} call(s) against the real " +
+            "Gemini API. This uploads audio to Google and spends real credits."
+    )
+
+    val outcomes = mutableListOf<CallOutcome>()
+    for (fixture in config.fixtures) {
+        val wavFile = File(config.evalDir, fixture.audioPath)
+        val pcmFile = try {
+            WavPcm.extractPcmToTempFile(wavFile)
+        } catch (e: WavPcm.UnsupportedWavException) {
+            System.err.println("Skipping fixture '${fixture.id}': ${e.message}")
+            config.modelIds.forEach { model ->
+                for (rep in 1..config.repetitions) {
+                    outcomes.add(CallOutcome(fixture.id, model, rep, null, "WAV decode failed: ${e.message}", 0))
+                }
+            }
+            continue
+        }
+        try {
+            for (model in config.modelIds) {
+                for (rep in 1..config.repetitions) {
+                    print("  ${fixture.id} x $model rep $rep ... ")
+                    val (result, latencyMs) = transcribeBlocking(pcmFile, key, model, config.callTimeoutSeconds)
+                    println(if (result.error == null) "ok (${latencyMs}ms)" else "error: ${result.error} (${latencyMs}ms)")
+                    outcomes.add(CallOutcome(fixture.id, model, rep, result.text, result.error, latencyMs))
+                }
+            }
+        } finally {
+            pcmFile.delete()
+        }
+    }
+
+    val report = BenchmarkReport(
+        commitSha = currentCommitSha(),
+        timestampUtc = Instant.now().toString(),
+        config = config,
+        outcomes = outcomes,
+    )
+
+    val stamp = report.timestampUtc.replace(":", "-").replace(".", "-")
+    val outDir = File("eval-reports")
+    outDir.mkdirs()
+    val mdFile = File(outDir, "transcription-benchmark-$stamp.md")
+    val jsonFile = File(outDir, "transcription-benchmark-$stamp.json")
+    mdFile.writeText(renderMarkdown(report))
+    jsonFile.writeText(renderJson(report))
+    println("Report written to ${mdFile.path} and ${jsonFile.path}")
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/TranscriptionEvalManifest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/TranscriptionEvalManifest.kt
@@ -1,0 +1,198 @@
+package com.trevornk.ramblr.tools
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Fixture-corpus manifest for the #129 transcription benchmark: pure data model, parser, and
+ * validator with no network and no Android dependencies, so the entire "is this run even
+ * well-formed" decision is unit-testable offline.
+ *
+ * Every rejection here is deliberate and loud. A benchmark that silently drops a fixture with a
+ * missing audio file, silently scores against a blank reference, or silently substitutes a
+ * default model for an empty model list produces numbers that look plausible and mean nothing —
+ * far more dangerous than a run that refuses to start.
+ */
+object TranscriptionEvalManifest {
+
+    /** Structured failure for a manifest that cannot be parsed or does not validate. */
+    class ManifestException(message: String) : Exception(message)
+
+    /**
+     * One benchmark clip. [source] and [consent] are mandatory metadata, not decoration: recorded
+     * human speech is biometric data, so every fixture must carry its provenance and the licence
+     * or consent under which it may be redistributed (see the corpus README).
+     */
+    data class Fixture(
+        val id: String,
+        val audioPath: String,
+        val referenceText: String,
+        val durationMs: Long,
+        val language: String,
+        val scenarios: List<String>,
+        val source: String,
+        val consent: String,
+        val sha256: String? = null,
+    )
+
+    data class Manifest(val version: Int, val fixtures: List<Fixture>)
+
+    /** Scenario categories a fixture may be tagged with. A closed vocabulary so per-scenario
+     *  breakdowns stay comparable across runs instead of fragmenting into typo'd one-off tags. */
+    val KNOWN_SCENARIOS: Set<String> = setOf(
+        "short_command",
+        "long_dictation",
+        "technical_jargon",
+        "numbers_and_punctuation",
+        "proper_nouns",
+        "self_correction",
+        "noisy_environment",
+        "accented_speech",
+        "fast_speech",
+        "quiet_speech",
+        "code_switching",
+        "silence_or_nonspeech",
+    )
+
+    // ------------------------------------------------------------------ parsing
+
+    private fun JSONObject.requiredString(field: String, context: String): String =
+        if (has(field) && !isNull(field)) getString(field)
+        else throw ManifestException("$context is missing required field '$field'")
+
+    private fun JSONObject.requiredLong(field: String, context: String): Long =
+        if (has(field) && !isNull(field)) getLong(field)
+        else throw ManifestException("$context is missing required field '$field'")
+
+    /** Parses a manifest document. Structural problems (bad JSON, missing fields) throw here;
+     *  semantic problems (missing audio, duplicate ids) are reported by [validateFixtures]. */
+    fun parse(json: String): Manifest = try {
+        val root = JSONObject(json)
+        if (!root.has("fixtures")) throw ManifestException("Manifest is missing the 'fixtures' array")
+        val array: JSONArray = root.getJSONArray("fixtures")
+        val fixtures = (0 until array.length()).map { i ->
+            val obj = array.getJSONObject(i)
+            val context = "fixtures[$i]"
+            val scenariosArray = obj.optJSONArray("scenarios") ?: JSONArray()
+            Fixture(
+                id = obj.requiredString("id", context),
+                audioPath = obj.requiredString("audioPath", context),
+                referenceText = obj.requiredString("referenceText", context),
+                durationMs = obj.requiredLong("durationMs", context),
+                language = obj.requiredString("language", context),
+                scenarios = (0 until scenariosArray.length()).map { scenariosArray.getString(it) },
+                source = obj.requiredString("source", context),
+                consent = obj.requiredString("consent", context),
+                sha256 = obj.optString("sha256", "").takeIf { it.isNotBlank() },
+            )
+        }
+        Manifest(version = root.optInt("version", 1), fixtures = fixtures)
+    } catch (e: JSONException) {
+        throw ManifestException("Failed to parse transcription eval manifest: ${e.message}")
+    }
+
+    fun parse(file: File): Manifest =
+        if (!file.isFile) throw ManifestException("Manifest not found: ${file.path}")
+        else parse(file.readText())
+
+    /** SHA-256 of the raw manifest document, recorded in every report so a set of results can be
+     *  tied back to the exact corpus definition that produced them. */
+    fun checksum(document: String): String = sha256Hex(document.toByteArray(Charsets.UTF_8))
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    // ------------------------------------------------------------------ validation
+
+    /**
+     * Returns every problem found in [fixtures], resolved against [audioRoot]. An empty list means
+     * the corpus is usable. All problems are collected rather than throwing on the first, so a
+     * broken corpus can be fixed in one pass instead of one error per run.
+     */
+    fun validateFixtures(fixtures: List<Fixture>, audioRoot: File): List<String> {
+        val errors = mutableListOf<String>()
+
+        fixtures.groupBy { it.id.trim() }
+            .filter { (id, group) -> id.isNotEmpty() && group.size > 1 }
+            .forEach { (id, group) -> errors.add("Duplicate fixture id '$id' used by ${group.size} fixtures") }
+
+        fixtures.forEachIndexed { index, fixture ->
+            val label = "fixtures[$index]" + if (fixture.id.isNotBlank()) " (id '${fixture.id}')" else ""
+
+            if (fixture.id.isBlank()) errors.add("$label: id is blank")
+            if (fixture.referenceText.isBlank()) errors.add("$label: referenceText is blank — a fixture with no ground truth cannot be scored")
+            if (fixture.language.isBlank()) errors.add("$label: language tag is blank")
+            if (fixture.source.isBlank()) errors.add("$label: source (provenance) is blank — every fixture must record where its audio came from")
+            if (fixture.consent.isBlank()) errors.add("$label: consent/licence is blank — voice recordings are biometric data and need explicit consent or licence terms")
+            if (fixture.durationMs <= 0) errors.add("$label: durationMs must be positive, got ${fixture.durationMs}")
+
+            if (fixture.scenarios.isEmpty()) {
+                errors.add("$label: no scenario tags — tag at least one of ${KNOWN_SCENARIOS.sorted().joinToString()}")
+            }
+            fixture.scenarios.filterNot { it in KNOWN_SCENARIOS }.forEach { unknown ->
+                errors.add("$label: unknown scenario category '$unknown' (known: ${KNOWN_SCENARIOS.sorted().joinToString()})")
+            }
+
+            if (fixture.audioPath.isBlank()) {
+                errors.add("$label: audioPath is blank")
+            } else {
+                val audio = File(audioRoot, fixture.audioPath)
+                if (!audio.isFile) {
+                    errors.add("$label: audio file is missing at ${audio.path}")
+                } else {
+                    val declared = fixture.sha256
+                    if (declared != null) {
+                        val actual = sha256Hex(audio.readBytes())
+                        if (!actual.equals(declared, ignoreCase = true)) {
+                            errors.add("$label: sha256 mismatch — manifest declares $declared, file is $actual")
+                        }
+                    }
+                }
+            }
+        }
+        return errors
+    }
+
+    /**
+     * Returns every problem with the requested model list.
+     *
+     * An empty list is an error, never a cue to fall back to
+     * [com.trevornk.ramblr.GeminiTranscriberClient.DEFAULT_MODEL]: the whole purpose of this
+     * benchmark is comparing named models, and a run that quietly benchmarks the shipped default
+     * while the operator believes they configured something else produces actively misleading
+     * results.
+     */
+    fun validateModelIds(modelIds: List<String>): List<String> {
+        val errors = mutableListOf<String>()
+        if (modelIds.isEmpty()) {
+            errors.add(
+                "Model list is empty — specify at least one model id via GEMINI_TRANSCRIPTION_MODELS. " +
+                    "The benchmark will not substitute a default on your behalf."
+            )
+            return errors
+        }
+        modelIds.forEachIndexed { index, id ->
+            if (id.isBlank()) errors.add("Model id at position $index is blank")
+        }
+        modelIds.filter { it.isNotBlank() }
+            .groupBy { it }
+            .filter { it.value.size > 1 }
+            .forEach { (id, group) -> errors.add("Duplicate model id '$id' listed ${group.size} times") }
+        return errors
+    }
+
+    /** Convenience wrapper: validates fixtures and models together and throws one combined
+     *  [ManifestException] listing every problem, or returns normally when everything is clean. */
+    fun validateOrThrow(fixtures: List<Fixture>, audioRoot: File, modelIds: List<String>) {
+        val errors = validateFixtures(fixtures, audioRoot) + validateModelIds(modelIds)
+        if (errors.isNotEmpty()) {
+            throw ManifestException(
+                "Transcription eval configuration is invalid (${errors.size} problem(s)):\n" +
+                    errors.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/TranscriptionMetrics.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/TranscriptionMetrics.kt
@@ -1,0 +1,290 @@
+package com.trevornk.ramblr.tools
+
+import java.text.Normalizer
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Pure-Kotlin transcription scoring for the manual Gemini transcription benchmark (#129). No
+ * Android dependencies, no I/O, no network — everything here is a deterministic function of its
+ * inputs so it can be unit tested exhaustively without touching a provider API.
+ *
+ * Two comparison modes are supported and both are reported, because they answer different
+ * questions:
+ *  - [Normalization.STRICT]  — "did the model produce the exact text the user would have typed?"
+ *    Case and punctuation count. Only Unicode compatibility folding (NFKC), apostrophe/dash
+ *    variant folding, and whitespace collapsing are applied, since those differences are
+ *    typography noise rather than transcription errors.
+ *  - [Normalization.NORMALIZED] — the conventional ASR scoring mode: additionally lowercased and
+ *    punctuation-stripped, so a model that declines to punctuate isn't penalised on word accuracy.
+ *
+ * Corpus aggregation is deliberately **micro** (sum of edits / sum of reference lengths), not an
+ * unweighted mean of per-clip rates. A macro mean lets one three-word clip outweigh a two-minute
+ * one and produces numbers that don't correspond to any real error count; both are reported so
+ * the difference is visible, but the headline figure is micro.
+ */
+object TranscriptionMetrics {
+
+    enum class Normalization { STRICT, NORMALIZED }
+
+    /** Edit-distance decomposition. [referenceLength] is the token count of the *reference*, which
+     *  is the denominator for WER/CER — insertions can push a rate above 1.0, by design. */
+    data class EditCounts(
+        val substitutions: Int,
+        val deletions: Int,
+        val insertions: Int,
+        val referenceLength: Int,
+    ) {
+        val total: Int get() = substitutions + deletions + insertions
+    }
+
+    /** All scores for one reference/hypothesis pair. */
+    data class ClipScore(
+        val reference: String,
+        val hypothesis: String,
+        val wordEdits: EditCounts,
+        val charEdits: EditCounts,
+        val wer: Double,
+        val cer: Double,
+        val strictExactMatch: Boolean,
+        val normalizedExactMatch: Boolean,
+    )
+
+    /** Corpus-level roll-up. Micro figures are the headline; macro figures are reported alongside
+     *  purely so a skewed corpus is obvious rather than hidden. */
+    data class Aggregate(
+        val clipCount: Int,
+        val totalWordEdits: Int,
+        val totalReferenceWords: Int,
+        val totalCharEdits: Int,
+        val totalReferenceChars: Int,
+        val microWer: Double,
+        val microCer: Double,
+        val macroWer: Double,
+        val macroCer: Double,
+        val strictExactMatchRate: Double,
+        val normalizedExactMatchRate: Double,
+        val totalSubstitutions: Int,
+        val totalDeletions: Int,
+        val totalInsertions: Int,
+    )
+
+    /** Latency distribution. Every field is null for an empty sample rather than a fake 0, so a
+     *  report can't imply "0 ms" when it actually means "no successful calls". */
+    data class LatencyStats(
+        val count: Int,
+        val meanMs: Double?,
+        val p50Ms: Long?,
+        val p95Ms: Long?,
+        val minMs: Long?,
+        val maxMs: Long?,
+    )
+
+    // ------------------------------------------------------------------ normalization
+
+    private val APOSTROPHE_VARIANTS = charArrayOf(
+        '\u2018', '\u2019', '\u201A', '\u201B', '\u02BC', '\u02B9', '\u00B4', '\u2032', '\u0060',
+    )
+    private val DASH_VARIANTS = charArrayOf(
+        '\u2010', '\u2011', '\u2012', '\u2013', '\u2014', '\u2015', '\u2212', '\uFE58', '\uFE63', '\uFF0D',
+    )
+
+    /** Strips everything that is neither a letter, a digit, whitespace, nor an apostrophe. */
+    private val PUNCTUATION = Regex("[^\\p{L}\\p{N}\\s']")
+
+    /** Apostrophes not sitting between two word characters — i.e. quote marks, not contractions. */
+    private val EDGE_APOSTROPHE = Regex("(?<![\\p{L}\\p{N}])'|'(?![\\p{L}\\p{N}])")
+
+    private val WHITESPACE = Regex("\\s+")
+
+    /**
+     * Applies the scoring contract's text normalization. Both modes apply NFKC (so ligatures,
+     * full-width forms, and decomposed accents don't register as errors), fold curly apostrophes
+     * and Unicode dash variants to their ASCII equivalents, collapse runs of whitespace, and trim.
+     * [Normalization.NORMALIZED] additionally lowercases and removes punctuation, keeping
+     * contraction apostrophes so "don't" doesn't become the two tokens "don" and "t".
+     */
+    fun normalize(text: String, mode: Normalization): String {
+        var s = Normalizer.normalize(text, Normalizer.Form.NFKC)
+        val sb = StringBuilder(s.length)
+        for (c in s) {
+            when {
+                c in APOSTROPHE_VARIANTS -> sb.append('\'')
+                c in DASH_VARIANTS -> sb.append('-')
+                else -> sb.append(c)
+            }
+        }
+        s = sb.toString()
+        if (mode == Normalization.NORMALIZED) {
+            s = s.lowercase()
+            s = PUNCTUATION.replace(s, " ")
+            s = EDGE_APOSTROPHE.replace(s, "")
+        }
+        return WHITESPACE.replace(s, " ").trim()
+    }
+
+    private fun words(text: String, mode: Normalization): List<String> =
+        normalize(text, mode).let { if (it.isEmpty()) emptyList() else it.split(' ') }
+
+    private fun chars(text: String, mode: Normalization): List<Char> =
+        normalize(text, mode).toList()
+
+    // ------------------------------------------------------------------ edit distance
+
+    /**
+     * Levenshtein with per-operation backtracking so substitutions, deletions, and insertions are
+     * reported separately instead of collapsed into a single distance. Ties are broken
+     * substitution > deletion > insertion, which is the conventional ASR alignment preference.
+     *
+     * O(n*m) time, O(n*m) memory for the backtrace — fine for dictation-length clips.
+     */
+    private fun <T> edits(reference: List<T>, hypothesis: List<T>): EditCounts {
+        val n = reference.size
+        val m = hypothesis.size
+        if (n == 0) return EditCounts(0, 0, m, 0)
+        if (m == 0) return EditCounts(0, n, 0, n)
+
+        val cost = Array(n + 1) { IntArray(m + 1) }
+        for (i in 0..n) cost[i][0] = i
+        for (j in 0..m) cost[0][j] = j
+        for (i in 1..n) {
+            for (j in 1..m) {
+                val sub = cost[i - 1][j - 1] + if (reference[i - 1] == hypothesis[j - 1]) 0 else 1
+                val del = cost[i - 1][j] + 1 // reference token absent from hypothesis
+                val ins = cost[i][j - 1] + 1 // hypothesis token absent from reference
+                cost[i][j] = min(sub, min(del, ins))
+            }
+        }
+
+        var i = n
+        var j = m
+        var substitutions = 0
+        var deletions = 0
+        var insertions = 0
+        while (i > 0 || j > 0) {
+            when {
+                i > 0 && j > 0 && reference[i - 1] == hypothesis[j - 1] && cost[i][j] == cost[i - 1][j - 1] -> {
+                    i--; j--
+                }
+                i > 0 && j > 0 && cost[i][j] == cost[i - 1][j - 1] + 1 -> {
+                    substitutions++; i--; j--
+                }
+                i > 0 && cost[i][j] == cost[i - 1][j] + 1 -> {
+                    deletions++; i--
+                }
+                j > 0 && cost[i][j] == cost[i][j - 1] + 1 -> {
+                    insertions++; j--
+                }
+                // Unreachable for a well-formed DP table; fail loudly rather than silently
+                // mis-attributing an edit category.
+                else -> error("Edit backtrace stalled at ($i,$j) — DP table is inconsistent")
+            }
+        }
+        return EditCounts(substitutions, deletions, insertions, n)
+    }
+
+    /** Word-level edit decomposition under [mode] (default: the conventional ASR normalization). */
+    fun wordEdits(reference: String, hypothesis: String, mode: Normalization = Normalization.NORMALIZED): EditCounts =
+        edits(words(reference, mode), words(hypothesis, mode))
+
+    /** Character-level edit decomposition under [mode]. */
+    fun charEdits(reference: String, hypothesis: String, mode: Normalization = Normalization.NORMALIZED): EditCounts =
+        edits(chars(reference, mode), chars(hypothesis, mode))
+
+    /** Rate contract: edits / reference length; an empty reference scores 0.0 when the hypothesis
+     *  is also empty and 1.0 otherwise (the ratio is undefined, and 1.0 is the pessimistic read). */
+    private fun rate(counts: EditCounts): Double =
+        if (counts.referenceLength == 0) {
+            if (counts.total == 0) 0.0 else 1.0
+        } else {
+            counts.total.toDouble() / counts.referenceLength.toDouble()
+        }
+
+    fun wer(reference: String, hypothesis: String, mode: Normalization = Normalization.NORMALIZED): Double =
+        rate(wordEdits(reference, hypothesis, mode))
+
+    fun cer(reference: String, hypothesis: String, mode: Normalization = Normalization.NORMALIZED): Double =
+        rate(charEdits(reference, hypothesis, mode))
+
+    /** Equal after typography folding only — case and punctuation still count. */
+    fun strictExactMatch(reference: String, hypothesis: String): Boolean =
+        normalize(reference, Normalization.STRICT) == normalize(hypothesis, Normalization.STRICT)
+
+    /** Equal after the full ASR normalization (case- and punctuation-insensitive). */
+    fun normalizedExactMatch(reference: String, hypothesis: String): Boolean =
+        normalize(reference, Normalization.NORMALIZED) == normalize(hypothesis, Normalization.NORMALIZED)
+
+    /** Scores one reference/hypothesis pair on every metric at once. */
+    fun score(reference: String, hypothesis: String): ClipScore {
+        val w = wordEdits(reference, hypothesis)
+        val c = charEdits(reference, hypothesis)
+        return ClipScore(
+            reference = reference,
+            hypothesis = hypothesis,
+            wordEdits = w,
+            charEdits = c,
+            wer = rate(w),
+            cer = rate(c),
+            strictExactMatch = strictExactMatch(reference, hypothesis),
+            normalizedExactMatch = normalizedExactMatch(reference, hypothesis),
+        )
+    }
+
+    // ------------------------------------------------------------------ aggregation
+
+    /**
+     * Corpus roll-up. [Aggregate.microWer]/[Aggregate.microCer] divide the summed edit counts by
+     * the summed reference lengths — the only aggregation that equals "how many words did this
+     * model get wrong across everything I gave it". [Aggregate.macroWer]/[Aggregate.macroCer]
+     * (the unweighted mean of per-clip rates) are reported for contrast only; they are NOT the
+     * headline metric and must never be substituted for the micro figures.
+     */
+    fun aggregate(scores: List<ClipScore>): Aggregate {
+        if (scores.isEmpty()) {
+            return Aggregate(0, 0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0)
+        }
+        val totalWordEdits = scores.sumOf { it.wordEdits.total }
+        val totalReferenceWords = scores.sumOf { it.wordEdits.referenceLength }
+        val totalCharEdits = scores.sumOf { it.charEdits.total }
+        val totalReferenceChars = scores.sumOf { it.charEdits.referenceLength }
+        return Aggregate(
+            clipCount = scores.size,
+            totalWordEdits = totalWordEdits,
+            totalReferenceWords = totalReferenceWords,
+            totalCharEdits = totalCharEdits,
+            totalReferenceChars = totalReferenceChars,
+            microWer = if (totalReferenceWords == 0) 0.0 else totalWordEdits.toDouble() / totalReferenceWords.toDouble(),
+            microCer = if (totalReferenceChars == 0) 0.0 else totalCharEdits.toDouble() / totalReferenceChars.toDouble(),
+            macroWer = scores.map { it.wer }.average(),
+            macroCer = scores.map { it.cer }.average(),
+            strictExactMatchRate = scores.count { it.strictExactMatch }.toDouble() / scores.size.toDouble(),
+            normalizedExactMatchRate = scores.count { it.normalizedExactMatch }.toDouble() / scores.size.toDouble(),
+            totalSubstitutions = scores.sumOf { it.wordEdits.substitutions },
+            totalDeletions = scores.sumOf { it.wordEdits.deletions },
+            totalInsertions = scores.sumOf { it.wordEdits.insertions },
+        )
+    }
+
+    // ------------------------------------------------------------------ latency
+
+    /** Nearest-rank percentiles (ceil(p * n) on the sorted sample), which always returns an
+     *  actually-observed latency rather than an interpolated value that never happened. */
+    fun latencyStats(samplesMs: List<Long>): LatencyStats {
+        if (samplesMs.isEmpty()) return LatencyStats(0, null, null, null, null, null)
+        val sorted = samplesMs.sorted()
+        return LatencyStats(
+            count = sorted.size,
+            meanMs = sorted.average(),
+            p50Ms = percentile(sorted, 0.50),
+            p95Ms = percentile(sorted, 0.95),
+            minMs = sorted.first(),
+            maxMs = sorted.last(),
+        )
+    }
+
+    private fun percentile(sorted: List<Long>, p: Double): Long {
+        val rank = ceil(p * sorted.size).toInt()
+        return sorted[min(sorted.size - 1, max(0, rank - 1))]
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/WavPcm.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/WavPcm.kt
@@ -1,0 +1,156 @@
+package com.trevornk.ramblr.tools
+
+import java.io.File
+
+/**
+ * Minimal RIFF/WAVE reader for the #129 transcription benchmark.
+ *
+ * Exists because [com.trevornk.ramblr.GeminiTranscriberClient.transcribe] consumes a **raw PCM**
+ * file and wraps it in a WAV header itself; handing it a `.wav` would produce a double-headered
+ * payload with 44 bytes of garbage at the front of the audio. The benchmark fixtures are stored
+ * as `.wav` (self-describing, playable, verifiable), so they have to be unwrapped first.
+ *
+ * The `data` chunk is located by **walking the chunk headers**, not by assuming the canonical
+ * 44-byte layout. Real-world WAV writers routinely emit `LIST`/`INFO`, `fact`, or `junk` chunks
+ * between `fmt ` and `data`; a fixed 44-byte skip silently yields metadata bytes interpreted as
+ * audio, which would show up as a mysteriously terrible WER rather than as an error.
+ *
+ * Only the exact format the app records is accepted (16 kHz, mono, signed 16-bit little-endian
+ * PCM) — anything else is rejected loudly rather than resampled, because a silently resampled
+ * fixture would make the benchmark measure the resampler instead of the model.
+ */
+object WavPcm {
+
+    const val REQUIRED_SAMPLE_RATE = 16_000
+    const val REQUIRED_CHANNELS = 1
+    const val REQUIRED_BITS_PER_SAMPLE = 16
+    private const val WAVE_FORMAT_PCM = 1
+
+    /** Structured failure: a file that isn't a WAV, is truncated, or isn't the required format. */
+    class UnsupportedWavException(message: String) : Exception(message)
+
+    data class Format(
+        val audioFormat: Int,
+        val channels: Int,
+        val sampleRate: Int,
+        val bitsPerSample: Int,
+    )
+
+    private fun u32(bytes: ByteArray, offset: Int): Long =
+        (bytes[offset].toLong() and 0xFF) or
+            ((bytes[offset + 1].toLong() and 0xFF) shl 8) or
+            ((bytes[offset + 2].toLong() and 0xFF) shl 16) or
+            ((bytes[offset + 3].toLong() and 0xFF) shl 24)
+
+    private fun u16(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xFF) or ((bytes[offset + 1].toInt() and 0xFF) shl 8)
+
+    private fun ascii(bytes: ByteArray, offset: Int, length: Int): String =
+        String(bytes, offset, length, Charsets.US_ASCII)
+
+    private fun require(condition: Boolean, message: () -> String) {
+        if (!condition) throw UnsupportedWavException(message())
+    }
+
+    /** One located chunk: its 4-char id and the [start, end) range of its payload in the file. */
+    private data class Chunk(val id: String, val payloadStart: Int, val payloadEnd: Int)
+
+    /**
+     * Walks the RIFF chunk list from byte 12 (immediately after `RIFF<size>WAVE`), honouring each
+     * chunk's declared size and RIFF's word-alignment pad byte for odd-sized payloads.
+     */
+    private fun walkChunks(bytes: ByteArray): List<Chunk> {
+        require(bytes.size >= 12) { "File is truncated: ${bytes.size} bytes, need at least a 12-byte RIFF header" }
+        require(ascii(bytes, 0, 4) == "RIFF") { "Not a RIFF file: leading bytes are '${ascii(bytes, 0, 4)}'" }
+        require(ascii(bytes, 8, 4) == "WAVE") { "RIFF form type is '${ascii(bytes, 8, 4)}', expected 'WAVE'" }
+
+        val chunks = mutableListOf<Chunk>()
+        var offset = 12
+        while (offset + 8 <= bytes.size) {
+            val id = ascii(bytes, offset, 4)
+            val declared = u32(bytes, offset + 4)
+            val payloadStart = offset + 8
+            require(declared >= 0 && payloadStart + declared <= bytes.size.toLong()) {
+                "Chunk '$id' declares $declared payload bytes at offset $payloadStart but the file is " +
+                    "truncated at ${bytes.size} bytes"
+            }
+            val payloadEnd = (payloadStart + declared).toInt()
+            chunks.add(Chunk(id, payloadStart, payloadEnd))
+            // RIFF pads odd-sized payloads to an even boundary; the pad byte is not part of the payload.
+            offset = payloadEnd + (declared % 2).toInt()
+        }
+        require(chunks.isNotEmpty()) { "File is truncated: no RIFF chunks after the WAVE header" }
+        return chunks
+    }
+
+    private fun formatOf(bytes: ByteArray, chunks: List<Chunk>): Format {
+        val fmt = chunks.firstOrNull { it.id == "fmt " }
+            ?: throw UnsupportedWavException("No 'fmt ' chunk found (chunks present: ${chunks.joinToString { "'${it.id}'" }})")
+        require(fmt.payloadEnd - fmt.payloadStart >= 16) {
+            "'fmt ' chunk is truncated: ${fmt.payloadEnd - fmt.payloadStart} bytes, need at least 16"
+        }
+        return Format(
+            audioFormat = u16(bytes, fmt.payloadStart),
+            channels = u16(bytes, fmt.payloadStart + 2),
+            sampleRate = u32(bytes, fmt.payloadStart + 4).toInt(),
+            bitsPerSample = u16(bytes, fmt.payloadStart + 14),
+        )
+    }
+
+    /** Reads the `fmt ` chunk without extracting audio or enforcing the required format. */
+    fun readFormat(bytes: ByteArray): Format = formatOf(bytes, walkChunks(bytes))
+
+    private fun checkSupported(format: Format) {
+        require(format.audioFormat == WAVE_FORMAT_PCM) {
+            "Unsupported WAV encoding: audioFormat=${format.audioFormat}, only uncompressed PCM (1) is supported"
+        }
+        require(format.sampleRate == REQUIRED_SAMPLE_RATE) {
+            "Unsupported sample rate ${format.sampleRate} Hz, benchmark fixtures must be $REQUIRED_SAMPLE_RATE Hz"
+        }
+        require(format.channels == REQUIRED_CHANNELS) {
+            "Unsupported channel count ${format.channels}, benchmark fixtures must be mono ($REQUIRED_CHANNELS channel)"
+        }
+        require(format.bitsPerSample == REQUIRED_BITS_PER_SAMPLE) {
+            "Unsupported bit depth ${format.bitsPerSample}-bit, benchmark fixtures must be $REQUIRED_BITS_PER_SAMPLE-bit"
+        }
+    }
+
+    /**
+     * Returns the raw signed-16-bit-LE PCM payload of the `data` chunk. Throws
+     * [UnsupportedWavException] for anything that isn't 16 kHz mono 16-bit PCM, or whose chunk
+     * structure is malformed.
+     */
+    fun extractPcm(bytes: ByteArray): ByteArray {
+        val chunks = walkChunks(bytes)
+        checkSupported(formatOf(bytes, chunks))
+        val data = chunks.firstOrNull { it.id == "data" }
+            ?: throw UnsupportedWavException("No 'data' chunk found (chunks present: ${chunks.joinToString { "'${it.id}'" }})")
+        val size = data.payloadEnd - data.payloadStart
+        require(size > 0) { "'data' chunk is empty — the fixture contains no audio" }
+        val frameBytes = REQUIRED_CHANNELS * REQUIRED_BITS_PER_SAMPLE / 8
+        require(size % frameBytes == 0) {
+            "'data' chunk is $size bytes, not a whole number of $frameBytes-byte 16-bit mono samples"
+        }
+        return bytes.copyOfRange(data.payloadStart, data.payloadEnd)
+    }
+
+    fun extractPcm(wavFile: File): ByteArray = try {
+        extractPcm(wavFile.readBytes())
+    } catch (e: UnsupportedWavException) {
+        throw UnsupportedWavException("${wavFile.path}: ${e.message}")
+    }
+
+    /**
+     * Extracts [wavFile]'s PCM payload to a fresh temp file, which is what
+     * [com.trevornk.ramblr.GeminiTranscriberClient.transcribe] expects as its `pcmFile`. The
+     * caller owns the returned file and should delete it; it is also marked delete-on-exit so a
+     * crashed benchmark run doesn't leave audio lying around indefinitely.
+     */
+    fun extractPcmToTempFile(wavFile: File): File {
+        val pcm = extractPcm(wavFile)
+        val out = File.createTempFile("ramblr-eval-", ".pcm")
+        out.deleteOnExit()
+        out.writeBytes(pcm)
+        return out
+    }
+}

--- a/app/src/test/resources/transcription_eval/README.md
+++ b/app/src/test/resources/transcription_eval/README.md
@@ -1,0 +1,130 @@
+# Transcription eval fixture corpus (#129)
+
+This directory defines the fixture corpus for the **manual** Gemini transcription benchmark
+(`app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt`). It is
+deliberately shipped **empty**: `manifest.json` contains a placeholder, zero-entry `fixtures`
+array, and **no audio files are checked into this repository**.
+
+Nothing in this directory runs during `make test`, `./gradlew testGithubDebugUnitTest`, or CI.
+The benchmark is a `main()` entry point, never a JUnit test.
+
+## Why no audio is checked in
+
+Recorded human speech is **biometric data**. A voice recording identifies its speaker, cannot be
+revoked once published, and is subject to biometric-privacy law in several jurisdictions
+(BIPA, GDPR Art. 9 special-category data, and others). Committing a colleague's or a user's voice
+to a public git repository is irreversible. So: no recorded human speech is committed here, ever.
+
+## Fixture contract
+
+Each entry in `manifest.json`'s `fixtures` array is an object with these fields — all required
+except `sha256`:
+
+| Field           | Type      | Meaning |
+|-----------------|-----------|---------|
+| `id`            | string    | Unique, stable, non-blank identifier. Used as the report row key. |
+| `audioPath`     | string    | Path to the `.wav`, relative to this directory. The file must exist. |
+| `referenceText` | string    | Ground-truth transcript. Must be non-blank. |
+| `durationMs`    | number    | Clip duration in milliseconds. Must be positive. |
+| `language`      | string    | BCP-47 tag, e.g. `en-US`. Non-blank. |
+| `scenarios`     | string[]  | One or more tags from the closed vocabulary below. |
+| `source`        | string    | Provenance: exactly where this audio came from. Non-blank. |
+| `consent`       | string    | Consent record or licence under which the audio may be used and redistributed. Non-blank. |
+| `sha256`        | string?   | Optional lowercase hex SHA-256 of the audio file. Verified when present. |
+
+Known scenario categories (`TranscriptionEvalManifest.KNOWN_SCENARIOS`) — an unknown tag is a
+validation error, not a warning:
+
+`short_command`, `long_dictation`, `technical_jargon`, `numbers_and_punctuation`, `proper_nouns`,
+`self_correction`, `noisy_environment`, `accented_speech`, `fast_speech`, `quiet_speech`,
+`code_switching`, `silence_or_nonspeech`.
+
+The manifest is rejected outright (the run does not start) on: duplicate ids, a blank id, a blank
+reference, a missing audio file, an unknown scenario tag, an empty scenario list, a non-positive
+duration, blank provenance/consent, a blank language tag, or a `sha256` that doesn't match the
+file on disk.
+
+## Required audio format
+
+`GeminiTranscriberClient.transcribe` consumes **raw PCM** and applies its own WAV header, so the
+benchmark unwraps each fixture with `WavPcm` before calling it. Fixtures must therefore be:
+
+- RIFF/WAVE container
+- uncompressed PCM (`audioFormat == 1`)
+- **16 000 Hz** sample rate
+- **mono** (1 channel)
+- **signed 16-bit little-endian** samples
+
+Anything else is rejected with a clear error rather than resampled — a silently resampled fixture
+would make the benchmark measure the resampler, not the model. Extra chunks (`LIST`, `fact`,
+`junk`) between `fmt ` and `data` are fine; the parser walks the chunk headers rather than
+assuming the canonical 44-byte layout.
+
+Convert an existing file with:
+
+```bash
+ffmpeg -i input.m4a -ac 1 -ar 16000 -sample_fmt s16 -c:a pcm_s16le clip-a.wav
+```
+
+## Ground-truth authoring rule
+
+**Write `referenceText` BEFORE you look at any model output.** Transcribe the clip by ear (or take
+the exact script that was read aloud / fed to TTS), commit it, and only then run the benchmark.
+
+Authoring or "correcting" a reference after seeing a model's transcript silently converts the
+benchmark into a measurement of how much you agree with that model. If a reference turns out to be
+genuinely wrong, fix it in its own commit that states what was wrong and why, and treat every
+previously recorded score for that clip as void.
+
+## Acceptable fixture sources
+
+In descending order of preference:
+
+1. **Synthetic TTS** (Piper, espeak-ng, macOS `say`) of scripts you wrote. No human speaker, no
+   biometric exposure, permissive licence. Note the exact engine and voice in `source`.
+2. **Your own voice**, recorded by you, with `consent` stating you are the speaker and consent to
+   the use. Still not committed to the repo — keep it local (see below).
+3. **Openly licensed speech corpora** (Common Voice CC0, LibriSpeech CC BY 4.0). Record the corpus,
+   clip id, and licence in `source`/`consent`.
+
+Never: recordings of other people without written consent, anything captured from a real user of
+the app, or anything with third-party content you cannot relicense.
+
+## Keeping local fixtures out of git
+
+Keep local audio in this directory and do **not** `git add` it. Verify before every commit:
+
+```bash
+git status --short app/src/test/resources/transcription_eval/
+```
+
+If you maintain a private corpus, keep it outside the repo entirely and point the benchmark at it
+with `TRANSCRIPTION_EVAL_DIR=/path/to/corpus`.
+
+## Scoring and normalization contract
+
+Implemented by `TranscriptionMetrics`. Every run reports both comparison modes:
+
+- **STRICT** — NFKC normalization, apostrophe/dash variant folding, whitespace collapsing, and
+  nothing else. Case and punctuation count as errors. Answers "did the model produce the text the
+  user would have typed?"
+- **NORMALIZED** — everything STRICT does, plus lowercasing and punctuation stripping
+  (contraction apostrophes preserved, so `don't` stays one token). The conventional ASR mode.
+
+Metrics:
+
+- **WER** = word edit distance / reference word count, with substitutions, deletions, and
+  insertions reported separately. Insertions can push the rate above 1.0; that is intended.
+- **CER** = the same at character level.
+- **Exact-match rates** under both modes.
+- **Empty-reference contract**: an empty reference with an empty hypothesis scores 0.0; an empty
+  reference with a non-empty hypothesis scores 1.0 (the ratio is undefined; 1.0 is the pessimistic
+  reading). The validator rejects blank references anyway, so this only guards degenerate input.
+
+Corpus aggregation is **micro**: summed edit counts divided by summed reference lengths. It is not
+an unweighted mean of per-clip rates, which would let a three-word clip outweigh a two-minute one
+and yield a number that corresponds to no real error count. The macro mean is reported alongside
+purely so a skewed corpus is visible at a glance — never as the headline figure.
+
+Latency percentiles use **nearest rank** (`ceil(p * n)` on the sorted sample), so p50/p95 are
+always latencies that actually occurred rather than interpolated values that never happened.

--- a/app/src/test/resources/transcription_eval/manifest.json
+++ b/app/src/test/resources/transcription_eval/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "_comment": "PLACEHOLDER CORPUS - intentionally empty. No fixture entries are listed because no audio files are checked in (see README.md in this directory). Add entries only alongside the matching .wav file, its provenance, and its consent/licence terms.",
+  "fixtures": []
+}


### PR DESCRIPTION
Adds the offline-testable half of the production-path transcription benchmark: WER/CER scoring, a validating fixture manifest, WAV→PCM unwrapping, and a manual runner. No production code is touched and no default model changes.

## Why this shape

The benchmark drives the **real** `GeminiTranscriberClient.transcribe`, not a reimplementation of it. A benchmark that rebuilds the request path measures the benchmark, not the app.

Three decisions worth calling out, each of which is a way this could have silently produced plausible-but-wrong numbers:

**Aggregation is micro, not macro.** `microWer` divides summed edit counts by summed reference lengths. An unweighted mean of per-clip rates lets a three-word clip outweigh a two-minute one and yields a figure corresponding to no real error count. Macro is computed and reported alongside for contrast, never substituted.

**The WAV reader walks RIFF chunk headers.** `transcribe` consumes raw PCM and applies its own WAV header, so fixtures must be unwrapped first. The canonical 44-byte layout is an assumption, not a guarantee — writers routinely emit `LIST`/`fact`/`junk` chunks between `fmt ` and `data`. A fixed 44-byte skip feeds metadata bytes to the model as audio and surfaces as mysteriously bad WER rather than an error. The parser honours declared chunk sizes and RIFF's odd-size pad byte, and rejects anything that isn't 16 kHz mono s16le rather than silently resampling.

**An empty model list is a hard error.** It never falls back to `DEFAULT_MODEL`. A run that benchmarks the shipped default while the operator believes they configured something else is worse than a run that refuses to start.

## Verification

Full suite green, both flavors, `--rerun-tasks` with the results directory deleted first: **1,144 tests / 126 suites, 0 failures**. New tests: 83 (`TranscriptionEvalManifestTest` 36, `TranscriptionMetricsTest` 27, `WavPcmTest` 20).

Each of the three behaviors above was mutation-checked against a proven-green baseline — the mutation was applied, tests confirmed to fail *by name*, and the source restored:

| Mutation | Result |
|---|---|
| micro-aggregation → unweighted macro mean | FAILED `micro aggregation weights by reference length and differs from the macro mean` |
| RIFF chunk walk → fixed 44-byte skip | FAILED 3 tests, incl. `extracts pcm when an extra LIST chunk precedes the data chunk` |
| drop empty-model-list rejection | FAILED 3 tests, incl. `rejects an empty model list instead of falling back to the production default` |

`assembleGithubDebug` produces a valid APK; the test-only benchmark classes are confirmed absent from it.

## Scope and limits

- `runGeminiTranscriptionBenchmark` is deliberately **not** wired into `test`/`check`/`build`/CI. It uploads audio to Google and spends real credits.
- `manifest.json` ships with an **empty** fixture list. Real fixtures need consented voice recordings — biometric data, a human gate — so inventing entries with no audio would have been fabrication.
- Exact billed cost is not reported. `GeminiTranscriberClient.Result` discards `usageMetadata`, so per-call token counts aren't available; this is documented as a limitation rather than estimated.
- The API key is read from the environment and never printed or logged.

Until fixtures exist this scores nothing. That's the point: it makes any future "model X transcribes better" claim testable instead of asserted.

Refs #129
