### PR TITLE
Guard the QS tile's startActivityAndCollapse overload by SDK level (Refs #136)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/QsTileCollapseCompat.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/QsTileCollapseCompat.kt
@@ -1,0 +1,32 @@
+package com.trevornk.ramblr
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+
+/**
+ * Which `TileService.startActivityAndCollapse` overload is safe to call on [sdkInt].
+ *
+ * Both overloads are traps, in opposite directions, and the safe window for each is disjoint:
+ *
+ *  - `startActivityAndCollapse(Intent)` exists from API 24 but was deprecated in API 34, where it
+ *    throws [UnsupportedOperationException] *unconditionally*. Safe only below 34.
+ *  - `startActivityAndCollapse(PendingIntent)` was *added* in API 34. Calling it below that throws
+ *    [NoSuchMethodError]. Safe only from 34 up.
+ *
+ * With `minSdk 30` the app spans both regimes, so the branch is mandatory. #136 fixed the first
+ * trap by switching wholesale to the PendingIntent overload, which silently introduced the second:
+ * the quick-settings "tap to enable" affordance then crashed on Android 11-13 instead of Android
+ * 14+. Lint only surfaced it once the project moved to a toolchain that could see the API-34
+ * floor (`NewApi`, reported against the unguarded call).
+ *
+ * Extracted as a pure function of the SDK int -- rather than reading [Build.VERSION.SDK_INT]
+ * inline -- purely so the boundary is unit-testable on the JVM without Robolectric, matching
+ * [shouldRestoreIconBeforeToggle]'s approach in this same feature.
+ *
+ * [ChecksSdkIntAtLeast] is what keeps that extraction free: lint's `NewApi` check only recognises
+ * an *inline* `SDK_INT` comparison as a guard, so without this annotation it cannot see through
+ * the helper and re-reports the API-34 call as unguarded. The annotation tells lint that a `true`
+ * return means "SDK_INT >= 34", restoring the analysis at the call site.
+ */
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+fun shouldUsePendingIntentCollapse(sdkInt: Int): Boolean = sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE

--- a/app/src/main/kotlin/com/trevornk/ramblr/RamblrQsTileService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/RamblrQsTileService.kt
@@ -63,12 +63,31 @@ class RamblrQsTileService : TileService() {
             // the exact permanent silent no-op it was written to prevent. FLAG_IMMUTABLE mirrors
             // IconVisibilityNotifications' PendingIntent; the intent is already explicit
             // (a platform settings action), so nothing here is mutable-by-design.
+            //
+            // The overload split is load-bearing and neither branch is optional: the PendingIntent
+            // overload was only ADDED in API 34, while minSdk is 30. Calling it unguarded throws
+            // NoSuchMethodError on API 30-33, so the #136 fix as originally shipped merely moved
+            // the crash from "Android 14 and up" to "Android 11 through 13" -- the deprecated
+            // Intent overload is still the only one that exists down there, and it does not throw
+            // below 34. Keep both paths until minSdk reaches 34.
             val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            val pending = PendingIntent.getActivity(
-                this, 0, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            startActivityAndCollapse(pending)
+            if (shouldUsePendingIntentCollapse(android.os.Build.VERSION.SDK_INT)) {
+                val pending = PendingIntent.getActivity(
+                    this, 0, intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                startActivityAndCollapse(pending)
+            } else {
+                // Lint's StartActivityAndCollapseDeprecated fires here unconditionally: it argues
+                // for the PendingIntent overload, which is exactly what the branch above does. It
+                // has no notion of a minSdk-30 app that must still serve API 30-33, where the
+                // PendingIntent overload does not exist at all. This deprecated call is the only
+                // one that works below 34, and it does not throw there -- so the warning is
+                // correct in general and wrong in this specific branch. Remove along with the
+                // branch when minSdk reaches 34.
+                @Suppress("DEPRECATION", "StartActivityAndCollapseDeprecated")
+                startActivityAndCollapse(intent)
+            }
             return
         }
         WhisperAccessibilityService.requestToggleRecording()

--- a/app/src/test/kotlin/com/trevornk/ramblr/QsTileCollapseCompatTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/QsTileCollapseCompatTest.kt
@@ -1,0 +1,38 @@
+package com.trevornk.ramblr
+
+import android.os.Build
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the `startActivityAndCollapse` overload split. Both overloads throw outside their own
+ * API window, and `minSdk 30` straddles the boundary, so an off-by-one here is a hard crash on
+ * real devices rather than a degraded affordance. See [shouldUsePendingIntentCollapse].
+ */
+class QsTileCollapseCompatTest {
+
+    @Test fun `API 34 takes the PendingIntent overload -- the version that added it`() {
+        assertTrue(shouldUsePendingIntentCollapse(Build.VERSION_CODES.UPSIDE_DOWN_CAKE))
+    }
+
+    @Test fun `API 33 takes the Intent overload -- PendingIntent does not exist yet`() {
+        assertFalse(shouldUsePendingIntentCollapse(Build.VERSION_CODES.TIRAMISU))
+    }
+
+    /**
+     * The regression #136 actually shipped: minSdk is 30, and the unguarded PendingIntent call
+     * threw NoSuchMethodError on every device in the 30..33 band.
+     */
+    @Test fun `every API level from minSdk 30 up to 33 uses the Intent overload`() {
+        for (sdk in 30..33) {
+            assertFalse("API $sdk must not call the API-34-only PendingIntent overload", shouldUsePendingIntentCollapse(sdk))
+        }
+    }
+
+    @Test fun `API 34 and above always use the PendingIntent overload`() {
+        for (sdk in 34..36) {
+            assertTrue("API $sdk must not call the Intent overload, which throws from 34", shouldUsePendingIntentCollapse(sdk))
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`RamblrQsTileService` calls `startActivityAndCollapse(PendingIntent)` unguarded, but that overload **was only added in API 34** — and `minSdk` is **30**. On Android 11–13 the quick-settings "tap to enable" deep-link throws `NoSuchMethodError`.

This came from the #136 fix (`0350f74`). That fix was right about the problem it set out to solve: `startActivityAndCollapse(Intent)` is deprecated and throws `UnsupportedOperationException` unconditionally from API 34, so the tile was broken on Android 14+. But switching wholesale to the `PendingIntent` overload **moved the crash rather than removing it** — from Android 14+ to Android 11–13.

Both overloads are unsafe outside their own API window, and the safe ranges are disjoint:

| Overload | Safe range | Outside it |
|---|---|---|
| `startActivityAndCollapse(Intent)` | API 24–33 | throws `UnsupportedOperationException` from 34 |
| `startActivityAndCollapse(PendingIntent)` | API 34+ | throws `NoSuchMethodError` below 34 |

With `minSdk 30` the app spans both, so the branch is mandatory — neither overload alone is correct.

## The fix

Branch on `SDK_INT` so each API level calls the only overload that exists there.

The predicate is extracted to `shouldUsePendingIntentCollapse(sdkInt)` so the boundary is unit-testable on the JVM without adding Robolectric, matching how `shouldRestoreIconBeforeToggle` is handled in this same feature.

Two lint interactions worth flagging for review:

- The helper carries **`@ChecksSdkIntAtLeast`**. Without it, `NewApi` cannot see through the extraction — it only recognises *inline* `SDK_INT` comparisons as guards — and re-reports the API-34 call as unguarded. `androidx.annotation` resolves transitively via `core-ktx`/`appcompat`; the annotation is `CLASS`-retention, so no runtime cost and no new dependency.
- The legacy branch suppresses **`StartActivityAndCollapseDeprecated`**, which fires unconditionally and argues for the `PendingIntent` overload — exactly what the other branch does. That check has no notion of a `minSdk 30` app that must still serve API 30–33. Correct in general, wrong in this specific branch.

## Verification

- **129 suites / 1158 tests / 0 failures / 0 errors**, counted from JUnit XML on disk (`--rerun-tasks`, `28 actionable tasks: 28 executed` — nothing UP-TO-DATE). That's `main`'s 1154 plus the 4 added here.
- `QsTileCollapseCompatTest`: 4 tests, 0 failures. Covers both sides of the boundary and asserts every level in the **30..33 band that actually regressed**.
- **`lintGithubDebug` passes on this branch (`LINT_EXIT=0`)**. It **fails on `main`** with this `NewApi` error — so this also unblocks lint in CI.

## How this was found

Fell out of the API 36 toolchain spike. The current AGP 8.7.3 lint never flagged it; the newer toolchain's lint did. The bug is present on `main` today and is **independent of the API 36 work** — it's a live crash on Android 11–13 regardless of target SDK, which is why it's split into its own PR.

## Not verified

**No device testing.** This is a crash on API 30–33 and the test device (Pixel 10a) is API 36, so the regressed path cannot be exercised on available hardware — it needs an API 30–33 emulator to confirm end-to-end. The unit tests pin the branch decision; they do not prove the platform call succeeds on an old device.

`Refs #136` rather than `Closes` — #136 is already closed as completed, and this is a follow-up regression fix.
