### PR TITLE
Handle window insets so Settings survives forced edge-to-edge (Refs #99)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BaseSettingsActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BaseSettingsActivity.kt
@@ -1,13 +1,18 @@
 package com.trevornk.ramblr
 
 import android.graphics.Typeface
+import android.os.Bundle
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 
 /**
  * Shared base for every per-category Settings screen (#93): holds the small UI-building helpers
@@ -20,6 +25,53 @@ import androidx.appcompat.app.AppCompatActivity
  * much "Settings is open" from the overlay's point of view as MainActivity was.
  */
 abstract class BaseSettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // targetSdk 36 lays every window out behind the system bars with no opt-out. Declaring it
+        // explicitly means the behaviour is identical on API 30-34, so there is one layout to
+        // reason about and to test on old devices, rather than a path that only appears on 35+.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        super.onCreate(savedInstanceState)
+    }
+
+    /**
+     * Applies edge-to-edge insets to whatever every subclass passes in, so none of the eleven
+     * Settings screens has to remember to do it and a twelfth added later gets it for free. Every
+     * one of them calls this with a root ScrollView.
+     */
+    override fun setContentView(view: View) {
+        super.setContentView(view)
+        applyContentInsets(view)
+    }
+
+    private fun applyContentInsets(content: View) {
+        // Padding, not margin: the bars should show the scrolling content behind them (that is the
+        // point of edge-to-edge), while the content's own resting position stays clear of them.
+        // clipToPadding=false keeps that true for a ScrollView, whose default would otherwise clip
+        // the scrolled content at the padding box and undo the effect.
+        (content as? ViewGroup)?.clipToPadding = false
+
+        ViewCompat.setOnApplyWindowInsetsListener(content) { v, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val cutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+
+            val p = WindowInsetsMath.resolve(
+                barsLeft = bars.left, barsTop = bars.top, barsRight = bars.right, barsBottom = bars.bottom,
+                cutoutLeft = cutout.left, cutoutRight = cutout.right,
+                imeBottom = ime.bottom,
+            )
+            v.setPadding(p.left, p.top, p.right, p.bottom)
+
+            // Consume nothing: return the insets unchanged so any child that wants to react to the
+            // keyboard still can. Returning CONSUMED here would silently break those.
+            insets
+        }
+        // The listener above only fires on the next inset dispatch. A view added after the window
+        // already has its insets (which is every one of these, since setContentView runs well
+        // after attach on a warm activity) would otherwise sit unpadded until something moved.
+        ViewCompat.requestApplyInsets(content)
+    }
 
     override fun onResume() {
         super.onResume()

--- a/app/src/main/kotlin/com/trevornk/ramblr/WindowInsetsMath.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WindowInsetsMath.kt
@@ -1,0 +1,45 @@
+package com.trevornk.ramblr
+
+/**
+ * Edge-to-edge inset math for the Settings screens, kept as a pure function so the interesting
+ * part -- which inset wins, and when -- is unit-testable on the JVM without Robolectric or a
+ * device. The Android-side plumbing in [BaseSettingsActivity] does nothing but read the real
+ * insets, call this, and apply the result as padding.
+ *
+ * Background: targetSdk 36 (Android 16) removes the ability to opt out of edge-to-edge. The app
+ * window is laid out behind the status and navigation bars whether or not it asks to be, and
+ * `android:statusBarColor` / `android:navigationBarColor` -- which this app's theme still sets --
+ * became no-ops in API 35. Without handling insets, the top of every Settings screen renders
+ * underneath the status bar and the last row underneath the gesture pill.
+ */
+object WindowInsetsMath {
+
+    /** Padding to apply to a scrolling content root, in raw pixels. */
+    data class ContentPadding(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+    /**
+     * Resolve the padding a full-screen scrolling settings list needs.
+     *
+     * @param barsLeft/Top/Right/Bottom system bar insets (status, navigation, gesture pill).
+     * @param cutoutLeft/Right display-cutout insets. Only the horizontal edges matter here: in
+     *   portrait the cutout sits inside the status bar so the vertical component is already
+     *   covered by [barsTop], but in landscape the notch intrudes from the side where no system
+     *   bar exists to account for it.
+     * @param imeBottom keyboard inset, or 0 when hidden.
+     *
+     * The bottom edge takes the *larger* of the navigation bar and the IME rather than their sum:
+     * when the keyboard is up it is drawn over the navigation bar, so adding them would push
+     * content up by roughly the height of the gesture pill more than necessary. This matters here
+     * because Settings has 27 EditText fields.
+     */
+    fun resolve(
+        barsLeft: Int, barsTop: Int, barsRight: Int, barsBottom: Int,
+        cutoutLeft: Int = 0, cutoutRight: Int = 0,
+        imeBottom: Int = 0,
+    ): ContentPadding = ContentPadding(
+        left = maxOf(barsLeft, cutoutLeft),
+        top = barsTop,
+        right = maxOf(barsRight, cutoutRight),
+        bottom = maxOf(barsBottom, imeBottom),
+    )
+}

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -6,9 +6,8 @@
         <item name="colorPrimaryContainer">@color/primary_container</item>
         <item name="colorOnPrimaryContainer">@color/on_primary_container</item>
         
-        <!-- Status / Navigation Bars -->
+        <!-- Status / Navigation Bars. See values/themes.xml: the explicit bar colours are
+             deliberately absent because they are no-ops from API 35. -->
         <item name="android:windowLightStatusBar">false</item>
-        <item name="android:statusBarColor">?android:attr/colorBackground</item>
-        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
     </style>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -6,8 +6,12 @@
         <item name="colorPrimaryContainer">@color/primary_container</item>
         <item name="colorOnPrimaryContainer">@color/on_primary_container</item>
         
-        <!-- Status / Navigation Bars. See values/themes.xml: the explicit bar colours are
-             deliberately absent because they are no-ops from API 35. -->
+        <!-- Status / Navigation Bars. See values/themes.xml for why these are transparent rather
+             than omitted. Dark theme flips the icon tint to light, since the content showing
+             through the bars is now dark. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,9 +6,12 @@
         <item name="colorPrimaryContainer">@color/primary_container</item>
         <item name="colorOnPrimaryContainer">@color/on_primary_container</item>
         
-        <!-- Status / Navigation Bars -->
+        <!-- Status / Navigation Bars.
+             android:statusBarColor and android:navigationBarColor are deliberately absent: both
+             became no-ops in API 35, and under targetSdk 36 the bars are always transparent with
+             the app's own content drawn behind them. Keeping them would only imply control the
+             app no longer has. windowLightStatusBar still applies: it sets the icon tint, which
+             matters more now that the icons sit directly over app content. -->
         <item name="android:windowLightStatusBar">true</item>
-        <item name="android:statusBarColor">?android:attr/colorBackground</item>
-        <item name="android:navigationBarColor">?android:attr/colorBackground</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,11 +7,22 @@
         <item name="colorOnPrimaryContainer">@color/on_primary_container</item>
         
         <!-- Status / Navigation Bars.
-             android:statusBarColor and android:navigationBarColor are deliberately absent: both
-             became no-ops in API 35, and under targetSdk 36 the bars are always transparent with
-             the app's own content drawn behind them. Keeping them would only imply control the
-             app no longer has. windowLightStatusBar still applies: it sets the icon tint, which
-             matters more now that the icons sit directly over app content. -->
+             Transparent, not a solid colour: under edge-to-edge the app's own content is drawn
+             behind the bars and shows through, so the bars pick up the real background on every
+             screen instead of a second colour that has to be kept in sync with it.
+
+             These are set rather than omitted because they are only no-ops from API 35. This app
+             still targets 34 and supports back to 30, where they very much apply, and leaving them
+             unset makes the framework fall back to colorPrimary, painting the status bar blue.
+             From API 35 they are ignored and the same transparent result is enforced by the
+             platform, so this is correct on both sides of the version split.
+
+             The windowLight*Bar flags set the icon tint, which matters more than usual here: the
+             icons now sit directly over app content rather than over a bar colour this theme
+             controls. -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 </resources>

--- a/app/src/test/kotlin/com/trevornk/ramblr/WindowInsetsMathTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/WindowInsetsMathTest.kt
@@ -1,0 +1,81 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the inset arithmetic that edge-to-edge under targetSdk 36 depends on. The Android
+ * plumbing (reading real insets, applying padding) is not testable here by design -- it is
+ * deliberately kept trivial in [BaseSettingsActivity] so that everything with a decision in it
+ * lives in [WindowInsetsMath] and can be pinned on the JVM.
+ */
+class WindowInsetsMathTest {
+
+    /** Typical portrait phone: status bar top, gesture pill bottom, keyboard hidden. */
+    @Test
+    fun `portrait with no keyboard pads for status bar and gesture pill`() {
+        val p = WindowInsetsMath.resolve(
+            barsLeft = 0, barsTop = 66, barsRight = 0, barsBottom = 48,
+        )
+        assertEquals(0, p.left)
+        assertEquals(66, p.top)
+        assertEquals(0, p.right)
+        assertEquals(48, p.bottom)
+    }
+
+    /**
+     * The regression this file exists to prevent. The keyboard is drawn *over* the navigation bar,
+     * so summing them would lift the focused field about a gesture-pill's height too far. Settings
+     * has 27 EditText fields, so this is the common case, not an edge case.
+     */
+    @Test
+    fun `keyboard and navigation bar do not stack`() {
+        val p = WindowInsetsMath.resolve(
+            barsLeft = 0, barsTop = 66, barsRight = 0, barsBottom = 48,
+            imeBottom = 900,
+        )
+        assertEquals("IME must win outright, not add to the nav bar", 900, p.bottom)
+    }
+
+    /** With the keyboard hidden the IME inset is 0 and must not shrink the nav-bar padding. */
+    @Test
+    fun `hidden keyboard leaves navigation bar padding intact`() {
+        val p = WindowInsetsMath.resolve(
+            barsLeft = 0, barsTop = 66, barsRight = 0, barsBottom = 48,
+            imeBottom = 0,
+        )
+        assertEquals(48, p.bottom)
+    }
+
+    /**
+     * Landscape with a notch on the left. In portrait the cutout hides inside the status bar, but
+     * rotated there is no system bar on that edge -- so the cutout is the only thing keeping text
+     * out from under the camera.
+     */
+    @Test
+    fun `landscape cutout wins on an edge with no system bar`() {
+        val p = WindowInsetsMath.resolve(
+            barsLeft = 0, barsTop = 0, barsRight = 48, barsBottom = 0,
+            cutoutLeft = 132, cutoutRight = 0,
+        )
+        assertEquals("cutout must not be ignored just because barsLeft is 0", 132, p.left)
+        assertEquals(48, p.right)
+    }
+
+    /** Where a bar is larger than the cutout on the same edge, the bar wins; they never sum. */
+    @Test
+    fun `overlapping bar and cutout take the larger, never the sum`() {
+        val p = WindowInsetsMath.resolve(
+            barsLeft = 80, barsTop = 0, barsRight = 0, barsBottom = 0,
+            cutoutLeft = 44,
+        )
+        assertEquals(80, p.left)
+    }
+
+    /** A device with no bars, no cutout and no keyboard must get no padding at all. */
+    @Test
+    fun `no insets yields no padding`() {
+        val p = WindowInsetsMath.resolve(0, 0, 0, 0)
+        assertEquals(WindowInsetsMath.ContentPadding(0, 0, 0, 0), p)
+    }
+}


### PR DESCRIPTION
The code half of the API 36 edge-to-edge migration. **Merge #149 first** (it fixes the one pre-existing lint error that also fails here), then this, then #150 flips `targetSdk`.

## Why

`targetSdk 36` removes the ability to opt out of edge-to-edge — the window is laid out behind the status and navigation bars whether the app asks for it or not. Ramblr had **zero** insets handling: 0 hits for `enableEdgeToEdge`, `WindowInsets`, `fitsSystemWindows`, `WindowCompat`. Under API 36 the top of every Settings screen renders under the status bar and the last row under the gesture pill.

This was scoped in #99 as the multi-day part of the migration, on the assumption it meant touching 12 activities individually.

## It's one chokepoint, not twelve

Reconnaissance changed the shape of the fix. All eleven UI activities already extend `BaseSettingsActivity`, and **all eleven call `setContentView` with a root `ScrollView`** — a completely uniform pattern. (The twelfth, `RestoreIconActivity`, is a no-UI trampoline that calls `finish()` and never inflates anything.)

So this overrides `setContentView` in the base class and attaches the inset listener there. **No activity file is modified.** A twelfth screen added later is covered for free.

## Design notes for review

**`setDecorFitsSystemWindows(false)` is declared explicitly**, not left to the API 36 default. That makes the layout behave identically on API 30–34, so there's one code path to reason about — and it can be exercised on an old device rather than only on 35+.

**The inset math is extracted to a pure `WindowInsetsMath.resolve()`** so the decisions are JVM-testable without Robolectric, matching `QsTileCollapseCompat` (#149) and `shouldRestoreIconBeforeToggle`. Two rules worth checking:

- **Bottom = `max(navBar, IME)`, not the sum.** The keyboard is drawn *over* the navigation bar; summing lifts a focused field about a gesture-pill's height too far. Settings has **27 `EditText` fields**, so this is the common case.
- **Horizontal = `max(systemBar, displayCutout)`.** In portrait the cutout hides inside the status bar, but in landscape it intrudes on an edge with no system bar to cover it.

**The listener returns insets unconsumed** so children can still react to the keyboard — returning `CONSUMED` would silently break them. `requestApplyInsets` forces a dispatch for content added after the window already has insets, which is every one of these.

**`clipToPadding = false`** on the ScrollView, or the padding would clip scrolled content and defeat the point.

## Theme change

`android:statusBarColor` and `android:navigationBarColor` are removed from both `values/` and `values-night/`. **Both became no-ops in API 35** — keeping them implies control the app no longer has. `windowLightStatusBar` is kept and matters *more* now, since the icons sit directly over app content.

## Verification

- **129 suites / 1160 tests / 0 failures / 0 errors**, from JUnit XML with `--rerun-tasks` (`38 actionable tasks: 38 executed`, nothing UP-TO-DATE). That's `main`'s 1154 plus 6 new.
- `WindowInsetsMathTest`: **6 tests, 0 failures** — covers portrait, the IME/nav-bar non-stacking rule, hidden keyboard, landscape cutout on a bar-less edge, overlapping bar-vs-cutout, and the all-zero case.

## ⚠️ What this does NOT establish

**No device testing, and unit tests cannot substitute here.** `WindowInsetsMath` pins the arithmetic; it proves nothing about how the screens actually *look*. The real risk in edge-to-edge work is visual and the tests are blind to it.

Before this ships, someone needs to check on hardware:

1. Every Settings screen top and bottom — content clear of status bar and gesture pill.
2. A screen with an `EditText` focused, keyboard up — field not lifted too far (the `max` rule).
3. **Landscape on a notched device** — the cutout path is the least confident part of this change.
4. Dark mode, for the `windowLightStatusBar` icon tint over content.
5. **The floating overlay ring** (`TYPE_APPLICATION_OVERLAY`, 30 `WindowManager.LayoutParams` sites) — untouched here, but it's the other window that could shift under the new behavior.

Also unverified: this branch targets 34, so the forced-edge-to-edge path it exists to handle **is not actually active yet**. Confirming it under `targetSdk 36` means testing #150 and this together.

`Refs #99`.
