### PR TITLE
Host mumble-cleanup Q4_0 so it downloads instead of needing adb push (#134)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
@@ -331,12 +331,15 @@ const val MUMBLE_CLEANUP_SYSTEM_PROMPT = "You are a transcript cleanup tool. You
  * i8mm/dotprod dot-product kernels llama.cpp ships for this legacy quant type, where Q4_K_M does
  * not benefit from the same path.
  *
- * `sourceUrl = null`: unlike every other catalog entry, this file has no direct HF download URL --
- * it exists only because it was quantized locally from `mumble-cleanup-2stage-f16.gguf`
- * (verified via the same shasum -a 256 discipline before quantizing: f16 source hash
- * `7659e5dc4df164b50be3dce70d80b191fe7ac378a9e8e44b92e5e4313ef9ff82`). If this ends up being kept
- * long-term, it should be re-hosted (e.g. uploaded back to a HF repo Trevor controls) so
- * [sourceUrl]/[fileName] work like every other entry instead of requiring manual `adb push`.
+ * `sourceUrl`: quantized locally from `mumble-cleanup-2stage-f16.gguf` (f16 source hash
+ * `7659e5dc4df164b50be3dce70d80b191fe7ac378a9e8e44b92e5e4313ef9ff82`, verified with the same
+ * shasum -a 256 discipline before quantizing), then re-hosted at
+ * `trevornk/mumble-cleanup-2stage-GGUF` so this entry downloads like every other one instead of
+ * requiring a manual `adb push`. The uploaded file was verified by downloading it back
+ * anonymously (no auth token, proving the repo is genuinely public) and confirming 352,154,912
+ * bytes hashing to the [sha256] below. That repo carries Apache-2.0, attribution to
+ * `amitashwini/mumble-cleanup-2stage` and `Qwen/Qwen2.5-0.5B-Instruct`, both source hashes, and
+ * the exact llama-quantize command needed to reproduce the file.
  */
 val MUMBLE_CLEANUP_Q4_0_MODEL = Model(
     name = "Mumble Cleanup 2-Stage (Q4_0)",
@@ -351,7 +354,7 @@ val MUMBLE_CLEANUP_Q4_0_MODEL = Model(
     recommended = false,
     sha256 = "000efc700d74636bc3885afe1d8f32dbb3fe813b8198dea79d8fd73efcc2c711",
     isLocalCleanup = true,
-    sourceUrl = null,
+    sourceUrl = "https://huggingface.co/trevornk/mumble-cleanup-2stage-GGUF/resolve/main/mumble-cleanup-2stage-q4_0.gguf",
     fileName = "mumble-cleanup-2stage-q4_0.gguf",
     localSystemPrompt = MUMBLE_CLEANUP_SYSTEM_PROMPT,
     // Apache-2.0 covers both the LoRA fine-tune and its Qwen2.5-0.5B-Instruct base.

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
@@ -177,11 +177,18 @@ class ModelDownloaderTest {
         assertEquals(LOCAL_CLEANUP_MODEL, LOCAL_CLEANUP_MODEL_CATALOG.first { it.recommended })
     }
 
-    @Test fun `mumble-cleanup Q4_0 speed-test model has no source URL (locally quantized, not downloadable) but is still checksummed`() {
-        // No prebuilt Q4_0 GGUF exists on amitashwini/mumble-cleanup-2stage (only f16 and
-        // Q4_K_M are published) -- this entry only exists because it was quantized locally from
-        // the f16 GGUF, so unlike every other catalog entry it has no sourceUrl to download from.
-        assertEquals(null, MUMBLE_CLEANUP_Q4_0_MODEL.sourceUrl)
+    @Test fun `mumble-cleanup Q4_0 speed-test model is downloadable from a pinned HF URL and checksummed`() {
+        // No prebuilt Q4_0 GGUF exists on amitashwini/mumble-cleanup-2stage (only f16 and Q4_K_M
+        // are published), so this entry was quantized locally and then re-hosted under an account
+        // Trevor controls. It downloads like every other entry now -- see the kdoc on
+        // MUMBLE_CLEANUP_Q4_0_MODEL for the upload's verification trail.
+        val url = MUMBLE_CLEANUP_Q4_0_MODEL.sourceUrl
+        assertNotNull("re-hosted: must have a real download URL, not sideload-only", url)
+        assertTrue(url!!.startsWith("https://huggingface.co/"))
+        assertTrue(url.endsWith(".gguf"))
+        // The URL must serve the exact file this entry is checksummed against; a mismatch between
+        // fileName and the URL's basename would download the right bytes to the wrong path.
+        assertTrue(url.endsWith("/${MUMBLE_CLEANUP_Q4_0_MODEL.fileName}"))
         assertFalse(MUMBLE_CLEANUP_Q4_0_MODEL.recommended)
         assertNotEquals(LOCAL_CLEANUP_MODEL.archive, MUMBLE_CLEANUP_Q4_0_MODEL.archive)
         assertNotEquals(LOCAL_CLEANUP_MODEL.fileName, MUMBLE_CLEANUP_Q4_0_MODEL.fileName)
@@ -191,7 +198,19 @@ class ModelDownloaderTest {
     // -- sideload-only classification (#H7) --
 
     @Test fun `a local-cleanup model with no sourceUrl is sideload-only`() {
-        assertTrue(ModelDownloader.isSideloadOnly(MUMBLE_CLEANUP_Q4_0_MODEL))
+        // Uses a synthetic entry rather than a catalog one: every shipping local-cleanup model is
+        // now hosted, but the classifier still has to hold for any future locally-quantized entry
+        // that lands in the catalog before it has somewhere to be downloaded from.
+        val sideloaded = LOCAL_CLEANUP_MODEL.copy(sourceUrl = null)
+        assertTrue(ModelDownloader.isSideloadOnly(sideloaded))
+    }
+
+    @Test fun `every shipping local-cleanup model is downloadable, not sideload-only`() {
+        // Guards the #134 regression directly: a local-cleanup entry with no host silently becomes
+        // un-installable for anyone who cannot adb push it.
+        LOCAL_CLEANUP_MODEL_CATALOG.forEach {
+            assertFalse("${it.name} has no sourceUrl", ModelDownloader.isSideloadOnly(it))
+        }
     }
 
     @Test fun `a local-cleanup model with a real sourceUrl is downloadable, not sideload-only`() {

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelLicenseTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelLicenseTest.kt
@@ -50,14 +50,14 @@ class ModelLicenseTest {
      * optional-cleanup-only (never a core transcription path) and consent-gated.
      *
      * LFM2.5-350M is the one known exception and is still `recommended`. That is not ideal --
-     * the F-Droid-correct end state is a *free* default -- but the free alternative
-     * ([MUMBLE_CLEANUP_Q4_0_MODEL], Apache-2.0, measurably faster on-device at ~2.9s) has
-     * `sourceUrl = null`: it was quantized locally and never hosted anywhere, so it physically
-     * cannot be downloaded, and promoting it to default today would leave on-device cleanup
-     * broken for every user who can't `adb push` a 336 MB file. Hosting it is the actual fix and
-     * is tracked separately; until then the non-free default is disclosed in the store
-     * description, declared as a NonFreeAssets anti-feature, and gated behind explicit license
-     * consent at [ModelDownloadWorker.enqueue].
+     * the F-Droid-correct end state is a *free* default -- but it is no longer blocked on hosting:
+     * [MUMBLE_CLEANUP_Q4_0_MODEL] (Apache-2.0, measurably faster on-device at ~2.9s, and ahead on
+     * the offline cleanup-quality A/B) is now downloadable from a pinned Hugging Face URL like
+     * every other entry. Flipping which model is `recommended` is a user-visible default change
+     * that needs on-device confirmation of the winner first, so it is deliberately NOT bundled
+     * with the hosting work and remains tracked in #134. Until that flip, the non-free default is
+     * disclosed in the store description, declared as a NonFreeAssets anti-feature, and gated
+     * behind explicit license consent at [ModelDownloadWorker.enqueue].
      */
     @Test fun `the only non-free model is the known optional cleanup exception`() {
         val all = MODEL_CATALOG + STREAMING_MODEL_CATALOG + LOCAL_CLEANUP_MODEL_CATALOG + VAD_MODEL_CATALOG


### PR DESCRIPTION
## What

The `mumble-cleanup` Q4_0 entry was **sideload-only** — `sourceUrl = null`, installable only by someone who could `adb push` a 352 MB file. This hosts it and pins the download URL, so it installs like every other catalog entry.

## Why it mattered

That null URL wasn't just an inconvenience. `ModelDownloader.isSideloadOnly()` returned true for it, which made `CleanupActivity` **hide its download button entirely**. The model was effectively unreachable for normal users, which in turn blocked it from ever becoming the on-device cleanup default — the F-Droid-correct end state, since it's Apache-2.0 and the current default (LFM2.5-350M) is not free.

## Verification of the upload

Hosted at [`trevornk/mumble-cleanup-2stage-GGUF`](https://huggingface.co/trevornk/mumble-cleanup-2stage-GGUF). I verified it by downloading the file back **with no auth token** — proving the repo is genuinely public, not just public-to-me:

- `352,154,912` bytes
- SHA-256 `000efc700d74636bc3885afe1d8f32dbb3fe813b8198dea79d8fd73efcc2c711` — exactly the hash this catalog entry already pinned
- `GGUF` magic bytes confirmed

The repo carries Apache-2.0, attribution to `amitashwini/mumble-cleanup-2stage` and `Qwen/Qwen2.5-0.5B-Instruct`, both source hashes, and the exact `llama-quantize` command to reproduce the file.

## Test changes — read these, they're the non-obvious part

Wiring a real URL flips `isSideloadOnly()` to false, which **invalidated two tests that asserted the old behaviour**. I did not simply delete them:

- `a local-cleanup model with no sourceUrl is sideload-only` now builds a **synthetic** null-URL entry via `.copy(sourceUrl = null)` instead of reaching for a catalog model. The classifier mechanism keeps its coverage for any future locally-quantized entry that lands before it's hosted.
- Added the inverse guard: **every shipping local-cleanup model must be downloadable**. That's the actual #134 regression stated directly, so this can't silently regress.

## What this deliberately does NOT do

It does not flip `recommended`. Making the free model the default is a user-visible behaviour change that needs on-device confirmation of the quality A/B winner first. Bundling it here would hide a default change inside a hosting fix. Still tracked in #134.

The `ModelLicenseTest` kdoc is updated to reflect that hosting is no longer the blocker for that flip — previously it documented the null URL as the reason the non-free default persisted.

## Verification

Full unit suite on this branch, `--rerun-tasks` (no UP-TO-DATE masking):

```
BUILD SUCCESSFUL — 28 actionable tasks: 28 executed
128 suites / 1155 tests / 0 failures / 0 errors / 0 skipped
  ModelDownloaderTest  tests=65 failures=0 errors=0
  ModelLicenseTest     tests=6  failures=0 errors=0
```

Counted from the generated JUnit XML, not scraped from console output.

Refs #134
