### PR TITLE
Gate cleanup-model selection on license consent; stop advertising updates on storefront (Refs #153)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/AdvancedActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/AdvancedActivity.kt
@@ -122,8 +122,23 @@ class AdvancedActivity : BaseSettingsActivity() {
         /** Category subtitle for MainActivity's Advanced row (#93, updated #104) -- unlike the
          *  other four categories there's no single on/off/mode signal worth summarizing here
          *  (this screen is redo-setup + four subsections), so this just names what's inside
-         *  rather than picking one value. */
+         *  rather than picking one value.
+         *
+         *  The "updates" item is github-flavor-only and must be gated by the same
+         *  Class.forName check that hides the row itself (#153): the storefront/F-Droid build
+         *  compiles in no self-updater, so advertising an Updates screen it doesn't have was a
+         *  slip caught in F-Droid review (fdroiddata!42401). */
         fun subtitle(context: android.content.Context): String =
-            "Redo setup, overlay appearance, behavior, updates, data & logs"
+            advancedSubtitleText(hasSelfUpdate = hasSelfUpdateSettings())
+
+        /** Whether the self-updater is compiled into this flavor. Mirrors the instance-level
+         *  [selfUpdateSettingsActivityClass] lookup that gates the Updates row, so the row and
+         *  the subtitle that advertises it can never disagree (#153). */
+        private fun hasSelfUpdateSettings(): Boolean = try {
+            Class.forName("com.trevornk.ramblr.SelfUpdateSettingsActivity")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        }
     }
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupActivity.kt
@@ -307,11 +307,7 @@ class CleanupActivity : BaseSettingsActivity() {
             layoutParams = LinearLayout.LayoutParams(LP_MATCH, dp(4)).apply { topMargin = dp(8) }
         }
 
-        // License is shown in the row subtitle, not only inside the consent dialog: a user
-        // choosing between cleanup models should be able to see that one of them isn't
-        // free/open-source before tapping anything (F-Droid review).
-        val licenseNote = if (model.license.isFree) "" else " · ${model.license.name} (not FOSS)"
-        val row = settingsRow(model.name, "${model.quality} · ${model.sizeMb} MB$licenseNote", rightContainer) {
+        val row = settingsRow(model.name, cleanupModelSubtitle(model), rightContainer) {
             onCleanupModelAction(model)
         }
         val textContainer = row.getChildAt(0) as LinearLayout
@@ -468,13 +464,32 @@ class CleanupActivity : BaseSettingsActivity() {
         views.deleteBtn.visibility = if (installed) View.VISIBLE else View.GONE
 
         if (views.progress.visibility == View.GONE) {
-            views.subtitle.text = if (!installed && sideloadOnly) {
-                "${model.quality} · ${model.sizeMb} MB · sideload only"
-            } else {
-                "${model.quality} · ${model.sizeMb} MB"
-            }
+            views.subtitle.text = cleanupModelSubtitle(model, installed = installed)
         }
     }
+
+    /**
+     * The single source of truth for a cleanup model row's subtitle.
+     *
+     * Both the row builder and [refreshCleanupModelRow] must produce the same string, or whichever
+     * runs last silently wins. That is exactly what went wrong in #153: the builder appended the
+     * non-FOSS license note and the refresh -- which runs immediately afterwards and again on every
+     * download/selection change -- rebuilt the subtitle without it, so the note was never visible
+     * for more than a frame. Keeping the formatting here means a future edit can't reintroduce
+     * that drift.
+     *
+     * The license is surfaced in the row rather than only inside the consent dialog so a user
+     * comparing cleanup models can see that one isn't free/open-source before tapping anything
+     * (F-Droid review, fdroiddata!42401).
+     */
+    private fun cleanupModelSubtitle(
+        model: Model,
+        installed: Boolean = ModelDownloader.isInstalled(this, model),
+    ): String = cleanupModelSubtitleText(
+        model = model,
+        installed = installed,
+        sideloadOnly = ModelDownloader.isSideloadOnly(model),
+    )
 
     private fun refreshAllCleanupRows() = LOCAL_CLEANUP_MODEL_CATALOG.forEach { refreshCleanupModelRow(it) }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -610,6 +610,28 @@ class MainActivity : BaseSettingsActivity() {
     }
 
     private fun enableOnboardingCleanupLocal(model: Model) {
+        // Ordering matters (#153): a non-free model must not be *selected* until its license is
+        // accepted. This used to write the selection first and prompt afterwards, so cancelling
+        // the license dialog left cleanup enabled and pointed at a model that was never
+        // installed -- the exact slip F-Droid review caught in fdroiddata!42401.
+        //
+        // downloadModelWithLicenseConsent invokes onStarted only when a download was actually
+        // enqueued, and for an already-installed or freely-licensed model it does so
+        // synchronously, so the non-download paths still commit immediately.
+        if (ModelDownloader.isInstalled(this, model)) {
+            commitOnboardingCleanupLocal(model)
+            return
+        }
+        downloadModelWithLicenseConsent(model) {
+            commitOnboardingCleanupLocal(model)
+            toast("Downloading ${model.name}...")
+            refresh()
+        }
+    }
+
+    /** Persists the local-cleanup selection for [model]. Split out of
+     *  [enableOnboardingCleanupLocal] so it can be gated behind license consent (#153). */
+    private fun commitOnboardingCleanupLocal(model: Model) {
         prefs().edit()
             .putBoolean("use_post_processing", true)
             .putString(KEY_LOCAL_CLEANUP_MODEL_NAME, model.archive)
@@ -619,13 +641,6 @@ class MainActivity : BaseSettingsActivity() {
         // live applies here too, even though onboarding usually runs on a fresh chain).
         ProviderChainStore.save(this, ProviderChainStore.load(this).withLocalFloor(model.archive))
         CloudFeatureToggle.setCleanupEnabled(this, false)
-        if (!ModelDownloader.isInstalled(this, model)) {
-            // The recommended cleanup model is non-free (LFM2.5-350M), and this onboarding tap
-            // was previously the single action that downloaded it with no license disclosure at
-            // all -- the exact F-Droid consent problem. Prompt here too, and only claim the
-            // download started if it actually did.
-            downloadModelWithLicenseConsent(model) { toast("Downloading ${model.name}...") }
-        }
         refresh()
     }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
@@ -1,0 +1,47 @@
+package com.trevornk.ramblr
+
+/**
+ * Pure formatting for a cleanup-model row's subtitle, and the flavor gate for the Advanced
+ * screen's subtitle.
+ *
+ * Both exist as free functions with no Android dependency so they can be unit-tested. The bugs
+ * they encode (#153, from F-Droid review fdroiddata!42401) were invisible in unit tests precisely
+ * because the logic lived inside Activity code that the JVM suite can't construct:
+ *
+ *  - the license note was appended when the row was built and then silently overwritten by the
+ *    refresh that ran immediately afterwards, so a user comparing cleanup models never saw that
+ *    one of them isn't FOSS;
+ *  - the Advanced subtitle hardcoded "updates" even on the storefront/F-Droid build, which
+ *    compiles in no self-updater at all.
+ */
+
+/**
+ * The subtitle shown under a cleanup model's name, e.g.
+ * `"Good · 352 MB"` or `"Best · 250 MB · LFM Open License v1.0 (not FOSS)"`.
+ *
+ * There is exactly one of these so the row builder and the row refresh can't disagree; when they
+ * did, whichever ran last won and the license note vanished.
+ *
+ * @param installed whether the model's files are already on disk.
+ * @param sideloadOnly whether the model has no download URL (#H7) and must be pushed manually.
+ */
+fun cleanupModelSubtitleText(
+    model: Model,
+    installed: Boolean,
+    sideloadOnly: Boolean,
+): String {
+    val licenseNote = if (model.license.isFree) "" else " · ${model.license.name} (not FOSS)"
+    // Only meaningful before the file exists: once installed, the row is usable like any other.
+    val sideloadNote = if (!installed && sideloadOnly) " · sideload only" else ""
+    return "${model.quality} · ${model.sizeMb} MB$licenseNote$sideloadNote"
+}
+
+/**
+ * The Advanced category subtitle. [hasSelfUpdate] must reflect whether the self-updater is
+ * compiled into this flavor -- the github flavor has it, storefront/F-Droid does not, and
+ * advertising an Updates screen that isn't there was flagged in F-Droid review.
+ */
+fun advancedSubtitleText(hasSelfUpdate: Boolean): String {
+    val updates = if (hasSelfUpdate) "updates, " else ""
+    return "Redo setup, overlay appearance, behavior, ${updates}data & logs"
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/SettingsSubtitlesTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/SettingsSubtitlesTest.kt
@@ -1,0 +1,131 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Regression tests for the F-Droid review follow-ups in #153 (fdroiddata!42401).
+ *
+ * Both bugs lived in Activity code the JVM suite can't construct, which is exactly why neither
+ * was caught before a human reviewer ran the app on a phone. The formatting is now pure, so the
+ * behaviour is pinned here instead of relying on a device pass.
+ */
+class SettingsSubtitlesTest {
+
+    private fun model(
+        name: String = "Test model",
+        sizeMb: Int = 250,
+        quality: String = "Good",
+        license: ModelLicense = APACHE_2_0,
+    ) = Model(
+        name = name,
+        archive = "$name.zip",
+        sizeMb = sizeMb,
+        quality = quality,
+        license = license,
+    )
+
+    // --- cleanup model subtitle -------------------------------------------------------------
+
+    @Test fun `non-free model shows its license in the row subtitle`() {
+        val subtitle = cleanupModelSubtitleText(
+            model = model(license = LFM_OPEN_LICENSE_1_0),
+            installed = false,
+            sideloadOnly = false,
+        )
+        // The whole point of the F-Droid finding: a user comparing cleanup models must be able to
+        // see this without opening the consent dialog.
+        assertTrue(
+            "expected the license name in: $subtitle",
+            subtitle.contains(LFM_OPEN_LICENSE_1_0.name),
+        )
+        assertTrue("expected a not-FOSS marker in: $subtitle", subtitle.contains("not FOSS"))
+    }
+
+    @Test fun `freely licensed model shows no license note`() {
+        val subtitle = cleanupModelSubtitleText(
+            model = model(license = APACHE_2_0),
+            installed = true,
+            sideloadOnly = false,
+        )
+        assertFalse(subtitle.contains("not FOSS"))
+        assertFalse(subtitle.contains(APACHE_2_0.name))
+        assertEquals("Good · 250 MB", subtitle)
+    }
+
+    /**
+     * The actual #153 bug: the builder produced the license note and the refresh dropped it. Both
+     * call sites now go through this function, so identical inputs must give identical output --
+     * if a future edit reintroduces a second formatting site, this is the test that fails.
+     */
+    @Test fun `subtitle is stable across repeated refreshes of the same state`() {
+        val m = model(license = LFM_OPEN_LICENSE_1_0)
+        val first = cleanupModelSubtitleText(m, installed = false, sideloadOnly = false)
+        val second = cleanupModelSubtitleText(m, installed = false, sideloadOnly = false)
+        assertEquals(first, second)
+    }
+
+    @Test fun `installing a non-free model does not drop its license note`() {
+        val m = model(license = LFM_OPEN_LICENSE_1_0)
+        val before = cleanupModelSubtitleText(m, installed = false, sideloadOnly = false)
+        val after = cleanupModelSubtitleText(m, installed = true, sideloadOnly = false)
+        assertTrue(before.contains("not FOSS"))
+        assertTrue("license note must survive installation: $after", after.contains("not FOSS"))
+    }
+
+    @Test fun `sideload-only note appears only before installation`() {
+        val m = model()
+        assertTrue(
+            cleanupModelSubtitleText(m, installed = false, sideloadOnly = true)
+                .contains("sideload only"),
+        )
+        assertFalse(
+            cleanupModelSubtitleText(m, installed = true, sideloadOnly = true)
+                .contains("sideload only"),
+        )
+    }
+
+    @Test fun `a non-free sideload-only model shows both notes`() {
+        val subtitle = cleanupModelSubtitleText(
+            model = model(license = LFM_OPEN_LICENSE_1_0),
+            installed = false,
+            sideloadOnly = true,
+        )
+        assertTrue(subtitle.contains("not FOSS"))
+        assertTrue(subtitle.contains("sideload only"))
+    }
+
+    @Test fun `subtitle always leads with quality and size`() {
+        val subtitle = cleanupModelSubtitleText(
+            model = model(quality = "Best", sizeMb = 352, license = LFM_OPEN_LICENSE_1_0),
+            installed = false,
+            sideloadOnly = true,
+        )
+        assertTrue("expected 'Best · 352 MB' prefix in: $subtitle", subtitle.startsWith("Best · 352 MB"))
+    }
+
+    // --- advanced subtitle ------------------------------------------------------------------
+
+    @Test fun `storefront build does not advertise updates`() {
+        val subtitle = advancedSubtitleText(hasSelfUpdate = false)
+        // The storefront/F-Droid flavor compiles in no self-updater, so naming it is a lie.
+        assertFalse("storefront must not mention updates: $subtitle", subtitle.contains("updates"))
+        assertTrue(subtitle.contains("data & logs"))
+        assertTrue(subtitle.contains("Redo setup"))
+    }
+
+    @Test fun `github build still advertises updates`() {
+        val subtitle = advancedSubtitleText(hasSelfUpdate = true)
+        assertTrue("github must mention updates: $subtitle", subtitle.contains("updates"))
+        assertTrue(subtitle.contains("data & logs"))
+    }
+
+    @Test fun `advanced subtitle stays well formed in both flavors`() {
+        for (hasSelfUpdate in listOf(true, false)) {
+            val subtitle = advancedSubtitleText(hasSelfUpdate)
+            assertFalse("double comma in: $subtitle", subtitle.contains(",,"))
+            assertFalse("double space in: $subtitle", subtitle.contains("  "))
+            assertFalse("dangling comma in: $subtitle", subtitle.trim().endsWith(","))
+        }
+    }
+}


### PR DESCRIPTION
Closes the last open point from F-Droid review ([fdroiddata!42401](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/42401)). The reviewer cleared 1.0.23 on a Redmi Note 8T — build matches the reference binary, install permissions gone, no `SelfUpdate*` in either dex — with three cosmetic slips left. All three were confirmed in code, not taken on report. Details and evidence in #153.

## 1. Cancelling the license dialog still switched Cleanup to the non-free model

`enableOnboardingCleanupLocal` wrote the selection, the provider chain and the cleanup toggle **before** prompting for consent. `downloadModelWithLicenseConsent`'s `Cancel` is correctly a no-op, so nothing rolled those writes back — declining left cleanup enabled and pointed at a model that was never installed.

The writes now live in `commitOnboardingCleanupLocal`, invoked only from the accepted path (or immediately when the model is already installed, which is the pre-existing free/installed behaviour). This is the one finding with real user impact.

## 2. The picker row never showed the license note

`createCleanupModelRow` built a subtitle including the non-FOSS note, then called `refreshCleanupModelRow` on the very next line, which rebuilt it **without** the note. It was visible for at most one frame, and every later refresh (download progress, selection change) dropped it again.

Both paths now go through a single formatter, so they can't drift apart again.

## 3. Storefront advertised "updates"

`AdvancedActivity.subtitle` was a hardcoded string naming "updates". The Updates **row** was already flavor-gated by `Class.forName("...SelfUpdateSettingsActivity")`; the subtitle advertising it wasn't — so the F-Droid build named a screen it doesn't have. It now derives from the same gate.

## Why there are new pure functions

Both bugs were invisible to the JVM suite because the logic sat inside Activity code the tests can't construct — which is exactly why a human reviewer found them and CI didn't. Formatting moved to `SettingsSubtitles.kt` as pure functions so the behaviour can actually be pinned.

## Verification

- **131 suites / 1175 tests / 0 failures**, 31 tasks executed (`--rerun-tasks`, results dir wiped first)
- 10 new tests in `SettingsSubtitlesTest`
- **Mutation-proven** rather than assumed green:

| state | result |
|---|---|
| baseline | 10 tests, **0 failures** |
| drop the license note (reintroduce bug 2) | **3 failures** |
| always advertise updates (reintroduce bug 3) | **1 failure** |
| restored | 10 tests, **0 failures**, source byte-identical |

A green suite that passes against the buggy code would have proved nothing, so each bug was reintroduced to confirm the tests actually catch it.

## Not covered

Bug 1 is an Activity ordering fix and is **not** unit-tested — it needs `ModelDownloader`/`ProviderChainStore` against a real `Context`. Worth a manual check: onboarding → Local cleanup → **Cancel** at the license dialog, then confirm Cleanup did not switch to LFM2.5-350M.
