### PR TITLE
Send the production prompt and apply the production size gate in the #129 benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,8 +389,25 @@ export GEMINI_API_KEY=AIza...                                     # never commit
 ./gradlew runGeminiTranscriptionBenchmark                          # defaults to the catalog's Gemini models
 GEMINI_TRANSCRIPTION_MODELS=gemini-3.5-flash ./gradlew runGeminiTranscriptionBenchmark
 GEMINI_TRANSCRIPTION_REPETITIONS=3 ./gradlew runGeminiTranscriptionBenchmark   # expose run-to-run variance
+GEMINI_TRANSCRIPTION_VOCABULARY= ./gradlew runGeminiTranscriptionBenchmark     # measure without vocab biasing
 TRANSCRIPTION_EVAL_DIR=/path/to/private/corpus ./gradlew runGeminiTranscriptionBenchmark
 ```
+
+**Production fidelity.** The benchmark sends the same *prompt* a real dictation sends, not just the
+same transport. Production interpolates the user's personal vocabulary into the transcription
+prompt (`GeminiTranscriberClient.transcribePrompt`, #114 part 2) and prefs are seeded with
+`VocabularyTerms.DEFAULTS` on first run, so the benchmark uses those defaults unless
+`GEMINI_TRANSCRIPTION_VOCABULARY` is set — setting it to the empty string explicitly disables
+vocabulary biasing (a legitimate experiment), and both choices are recorded in the report header.
+It also applies production's pre-flight `canInlineAudio` size gate: a fixture whose PCM exceeds
+`GeminiTranscriberClient.MAX_INLINE_PCM_BYTES` is skipped and bucketed separately, because on a
+real device that recording falls through to the next transcription candidate instead of reaching
+Gemini at all.
+
+Remaining known divergences from a real dictation, none of them fixable offline: the app runs on
+Android with a device-resident recording (this runs on the JVM from a `.wav` fixture), the
+compressed-upload path (#109) sends `audio/aac` from a `MediaCodec` encode rather than
+`audio/wav`, and cost is not reported at all (see above).
 
 Each run writes a Markdown and a JSON report to the gitignored `eval-reports/`, recording the
 commit SHA, UTC timestamp, exact model ids, repetition count, call timeout, manifest checksum,

--- a/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionBenchmarkFidelityTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionBenchmarkFidelityTest.kt
@@ -1,0 +1,209 @@
+package com.trevornk.ramblr
+
+import com.trevornk.ramblr.tools.BenchmarkArgs
+import com.trevornk.ramblr.tools.BenchmarkReport
+import com.trevornk.ramblr.tools.CallOutcome
+import com.trevornk.ramblr.tools.categorizeFailure
+import com.trevornk.ramblr.tools.inlineAudioRejection
+import com.trevornk.ramblr.tools.renderJson
+import com.trevornk.ramblr.tools.renderMarkdown
+import com.trevornk.ramblr.tools.resolveConfig
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Tests for the #129 benchmark's **production fidelity** — the ways its request can silently
+ * diverge from what a real dictation sends, and the report fields that make that divergence
+ * auditable after the fact.
+ *
+ * The danger these guard against is specific: a benchmark that calls the real client but with a
+ * different *prompt* or without production's pre-flight gates produces numbers that look like
+ * production numbers and are not. Each assertion below pins one such divergence shut.
+ */
+class TranscriptionBenchmarkFidelityTest {
+
+    @get:Rule val temp = TemporaryFolder()
+
+    private fun writeCorpus(): File {
+        File(temp.root, "f1.wav").writeBytes(byteArrayOf(1, 2, 3, 4))
+        File(temp.root, "manifest.json").writeText(
+            """
+            {"version":1,"fixtures":[{"id":"f1","audioPath":"f1.wav","referenceText":"hello world",
+             "durationMs":1000,"language":"en-US","scenarios":["short_command"],
+             "source":"synthetic-tts","consent":"CC0-1.0"}]}
+            """.trimIndent()
+        )
+        return temp.root
+    }
+
+    // ---------------------------------------------------------------- vocabulary in the prompt
+
+    // Production interpolates the user's personal vocabulary into the transcription prompt itself
+    // (GeminiTranscriberClient.transcribePrompt, #114 part 2), and prefs are seeded with
+    // VocabularyTerms.DEFAULTS on first run. Benchmarking with an empty vocabulary would measure a
+    // prompt no shipped build ever sends.
+    @Test fun `an unset vocabulary override uses the same defaults prefs are seeded with`() {
+        val config = resolveConfig(BenchmarkArgs(true, null, null, writeCorpus().path, null))
+        assertEquals(VocabularyTerms.DEFAULTS, config.vocabularyTerms)
+        assertTrue(config.vocabularyTerms.isNotEmpty())
+    }
+
+    @Test fun `the resolved vocabulary actually changes the production prompt`() {
+        val config = resolveConfig(BenchmarkArgs(true, null, null, writeCorpus().path, null))
+        val prompt = GeminiTranscriberClient.transcribePrompt(config.vocabularyTerms)
+        assertFalse(
+            "default vocabulary must alter the shipped prompt, or the benchmark is measuring a bare one",
+            prompt == GeminiTranscriberClient.TRANSCRIBE_PROMPT
+        )
+        VocabularyTerms.DEFAULTS.forEach { term ->
+            assertTrue("prompt must carry '$term'", prompt.contains(term))
+        }
+    }
+
+    // An explicitly empty override is a legitimate experiment ("what is vocabulary biasing worth?"),
+    // distinct from an unset one. It must disable terms, not fall back to the defaults.
+    @Test fun `an explicitly empty vocabulary override disables terms rather than falling back`() {
+        val config = resolveConfig(BenchmarkArgs(true, null, null, writeCorpus().path, ""))
+        assertEquals(emptyList<String>(), config.vocabularyTerms)
+        assertEquals(
+            GeminiTranscriberClient.TRANSCRIBE_PROMPT,
+            GeminiTranscriberClient.transcribePrompt(config.vocabularyTerms)
+        )
+    }
+
+    // Parsing is delegated to the production VocabularyTerms parser rather than reimplemented, so
+    // trimming, blank-dropping and case-insensitive dedupe match the app exactly.
+    @Test fun `a vocabulary override is parsed with production trimming and dedupe rules`() {
+        val config = resolveConfig(
+            BenchmarkArgs(true, null, null, writeCorpus().path, " Ramblr , , nbdev ,RAMBLR, Hetzner ")
+        )
+        assertEquals(listOf("Ramblr", "nbdev", "Hetzner"), config.vocabularyTerms)
+    }
+
+    // ---------------------------------------------------------------- production inline-audio gate
+
+    // On a real device the GEMINI branch checks canInlineAudio(pcm.length()) BEFORE calling Gemini
+    // and falls through to the next candidate when it fails. A benchmark without that gate would
+    // report accuracy for a call production refuses to make.
+    @Test fun `clips within the inline budget are not rejected`() {
+        assertNull(inlineAudioRejection(0))
+        assertNull(inlineAudioRejection(1_024))
+        assertNull(inlineAudioRejection(GeminiTranscriberClient.MAX_INLINE_PCM_BYTES))
+    }
+
+    @Test fun `a clip over the inline budget is rejected exactly where production rejects it`() {
+        val overBy1 = GeminiTranscriberClient.MAX_INLINE_PCM_BYTES + 1
+        // The gate boundary is inherited from production, never restated as a literal here: a
+        // hardcoded 10MB would keep passing after production changed its threshold.
+        assertFalse(GeminiTranscriberClient.canInlineAudio(overBy1))
+        val rejection = inlineAudioRejection(overBy1)
+        assertNotNull("a clip production would skip must be rejected by the benchmark too", rejection)
+        assertTrue(rejection!!, rejection.contains(overBy1.toString()))
+        assertTrue(rejection, rejection.contains(GeminiTranscriberClient.MAX_INLINE_PCM_BYTES.toString()))
+    }
+
+    // The gate failure is produced locally, not by the API, so it must not pollute the transport
+    // failure buckets that a reader uses to judge Gemini's reliability.
+    @Test fun `a size-gate skip is categorized apart from transport failures`() {
+        val rejection = inlineAudioRejection(GeminiTranscriberClient.MAX_INLINE_PCM_BYTES + 1)!!
+        val category = categorizeFailure(rejection)
+        assertEquals("skipped: exceeds inline audio limit", category)
+        assertFalse(category == "other")
+        assertFalse(category == "network")
+        assertFalse(category == "timeout")
+    }
+
+    // ---------------------------------------------------------------- report auditability
+
+    private fun sampleReport(vocabularyRaw: String?): BenchmarkReport {
+        val config = resolveConfig(BenchmarkArgs(true, "gemini-3.5-flash", null, writeCorpus().path, vocabularyRaw))
+        return BenchmarkReport(
+            commitSha = "abc123",
+            timestampUtc = "2026-01-01T00:00:00Z",
+            config = config,
+            outcomes = listOf(
+                CallOutcome("f1", "gemini-3.5-flash", 1, "hello world", null, 120),
+            ),
+        )
+    }
+
+    // A report that doesn't record the prompt vocabulary can't be compared against a later run:
+    // the same corpus and model with different terms is a different experiment.
+    @Test fun `the markdown report records the exact vocabulary sent in the prompt`() {
+        val md = renderMarkdown(sampleReport(null))
+        assertTrue(md, md.contains("Vocabulary terms in prompt: ${VocabularyTerms.DEFAULTS.size}"))
+        VocabularyTerms.DEFAULTS.forEach { assertTrue(md, md.contains(it)) }
+        assertTrue(md, md.contains(GeminiTranscriberClient.MAX_INLINE_PCM_BYTES.toString()))
+    }
+
+    @Test fun `the markdown report states plainly when vocabulary was disabled`() {
+        val md = renderMarkdown(sampleReport(""))
+        assertTrue(md, md.contains("Vocabulary terms in prompt: 0 (explicitly disabled)"))
+    }
+
+    @Test fun `the json report carries the vocabulary and the inline limit as structured fields`() {
+        val root = JSONObject(renderJson(sampleReport(null)))
+        val terms = root.getJSONArray("vocabularyTerms")
+        assertEquals(VocabularyTerms.DEFAULTS.size, terms.length())
+        assertEquals(VocabularyTerms.DEFAULTS, (0 until terms.length()).map { terms.getString(it) })
+        assertEquals(GeminiTranscriberClient.MAX_INLINE_PCM_BYTES, root.getLong("inlineAudioLimitBytes"))
+    }
+
+    // Guards the scoring wiring end to end: a perfect transcript must land as WER 0 with a
+    // recorded latency, asserted on the parsed JSON structure rather than a substring of prose.
+    @Test fun `the json report scores a perfect transcript as zero error`() {
+        val root = JSONObject(renderJson(sampleReport(null)))
+        val perModel = root.getJSONArray("perModel")
+        assertEquals(1, perModel.length())
+        val model = perModel.getJSONObject(0)
+        assertEquals("gemini-3.5-flash", model.getString("model"))
+        assertEquals(1, model.getInt("calls"))
+        assertEquals(1, model.getInt("successes"))
+        assertEquals(1.0, model.getDouble("successRate"), 1e-9)
+        assertEquals(0.0, model.getDouble("microWer"), 1e-9)
+        assertEquals(0.0, model.getDouble("microCer"), 1e-9)
+        assertEquals(1.0, model.getDouble("strictExactMatchRate"), 1e-9)
+        assertEquals(120L, model.getLong("latencyP50Ms"))
+
+        val call = root.getJSONArray("calls").getJSONObject(0)
+        assertEquals("f1", call.getString("fixtureId"))
+        assertEquals("hello world", call.getString("reference"))
+        assertEquals("hello world", call.getString("transcript"))
+        assertEquals(0.0, call.getDouble("wer"), 1e-9)
+        assertTrue(call.getBoolean("strictExactMatch"))
+        assertEquals("none", call.getString("failureCategory"))
+    }
+
+    // Failed calls must not be silently scored as successes: a report where every call errored
+    // must show a 0% success rate, not a flattering 100%.
+    @Test fun `a failed call is reported as a failure and never scored`() {
+        val config = resolveConfig(BenchmarkArgs(true, "gemini-3.5-flash", null, writeCorpus().path, null))
+        val report = BenchmarkReport(
+            commitSha = "abc123",
+            timestampUtc = "2026-01-01T00:00:00Z",
+            config = config,
+            outcomes = listOf(
+                CallOutcome("f1", "gemini-3.5-flash", 1, null, "Unable to resolve host generativelanguage.googleapis.com", 30),
+            ),
+        )
+        val root = JSONObject(renderJson(report))
+        val model = root.getJSONArray("perModel").getJSONObject(0)
+        assertEquals(0, model.getInt("successes"))
+        assertEquals(0.0, model.getDouble("successRate"), 1e-9)
+        assertEquals(JSONObject.NULL, model.get("latencyP50Ms"))
+
+        val call = root.getJSONArray("calls").getJSONObject(0)
+        assertEquals("network", call.getString("failureCategory"))
+        assertEquals(JSONObject.NULL, call.get("transcript"))
+        assertFalse("a failed call must carry no accuracy score", call.has("wer"))
+        assertEquals(1, root.getJSONObject("failureCategories").getInt("network"))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/GeminiTranscriptionBenchmark.kt
@@ -2,6 +2,7 @@ package com.trevornk.ramblr.tools
 
 import com.trevornk.ramblr.GeminiTranscriberClient
 import com.trevornk.ramblr.InFlightCall
+import com.trevornk.ramblr.VocabularyTerms
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -50,6 +51,19 @@ private const val REPETITIONS_ENV = "GEMINI_TRANSCRIPTION_REPETITIONS"
 /** Corpus directory override, for keeping a private fixture corpus outside the repo. */
 private const val EVAL_DIR_ENV = "TRANSCRIPTION_EVAL_DIR"
 
+/**
+ * Comma-separated personal-vocabulary override. Production interpolates the user's vocabulary
+ * into the transcription prompt itself ([GeminiTranscriberClient.transcribePrompt], #114 part 2),
+ * so a benchmark that omitted it would measure a prompt no shipped build ever sends.
+ *
+ * Unset  -> [VocabularyTerms.DEFAULTS], the exact list prefs are seeded with on first run
+ *           ([VocabularyTerms.DEFAULT_SERIALIZED]), i.e. what a real user actually has.
+ * Set to "" -> explicitly no terms, for measuring what vocabulary biasing is worth.
+ *
+ * Both are explicit and both are recorded in the report header; neither is a silent substitution.
+ */
+private const val VOCABULARY_ENV = "GEMINI_TRANSCRIPTION_VOCABULARY"
+
 private const val DEFAULT_EVAL_DIR = "app/src/test/resources/transcription_eval"
 
 /**
@@ -74,6 +88,8 @@ data class BenchmarkConfig(
     val modelIds: List<String>,
     val repetitions: Int,
     val callTimeoutSeconds: Long,
+    /** Vocabulary terms interpolated into the production transcription prompt (see [VOCABULARY_ENV]). */
+    val vocabularyTerms: List<String> = emptyList(),
 ) {
     val totalCalls: Int get() = fixtures.size * modelIds.size * repetitions
 }
@@ -88,6 +104,7 @@ data class BenchmarkArgs(
     val modelsRaw: String?,
     val repetitionsRaw: String?,
     val evalDirRaw: String?,
+    val vocabularyRaw: String? = null,
 )
 
 /**
@@ -119,6 +136,17 @@ fun resolveConfig(args: BenchmarkArgs): BenchmarkConfig {
         else -> raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }
     }
     problems.addAll(TranscriptionEvalManifest.validateModelIds(modelIds))
+
+    // Production always sends the user's personal vocabulary in the transcription prompt when
+    // prefs hold any terms, and prefs are seeded with VocabularyTerms.DEFAULTS on first run. An
+    // unset override therefore means "what a real user actually has", not "no terms" — omitting
+    // them would benchmark a prompt no shipped build ever sends. The comma-separated env value is
+    // routed through the production parser (via its newline wire format) so trimming, blank-drop
+    // and case-insensitive dedupe match the app exactly rather than being reimplemented here.
+    val vocabularyTerms: List<String> = when (val raw = args.vocabularyRaw) {
+        null -> VocabularyTerms.DEFAULTS
+        else -> VocabularyTerms.parse(raw.split(",").joinToString("\n"))
+    }
 
     val evalDir = File(args.evalDirRaw?.trim()?.takeIf { it.isNotEmpty() } ?: DEFAULT_EVAL_DIR)
     val manifestFile = File(evalDir, "manifest.json")
@@ -159,6 +187,7 @@ fun resolveConfig(args: BenchmarkArgs): BenchmarkConfig {
         modelIds = modelIds,
         repetitions = repetitions,
         callTimeoutSeconds = CALL_TIMEOUT_SECONDS,
+        vocabularyTerms = vocabularyTerms,
     )
 }
 
@@ -180,6 +209,9 @@ data class CallOutcome(
  *  text because that's all the production Result type exposes — no status code survives it. */
 fun categorizeFailure(error: String?): String = when {
     error == null -> "none"
+    // Checked before the generic buckets: this one is produced locally by the production size
+    // gate, not by the API, so it must never be lumped in with a transport failure.
+    error.contains("too large for Gemini", ignoreCase = true) -> "skipped: exceeds inline audio limit"
     error.contains("timeout", ignoreCase = true) || error.contains("timed out", ignoreCase = true) -> "timeout"
     error.contains("quota", ignoreCase = true) || error.contains("rate limit", ignoreCase = true) ||
         error.contains("RESOURCE_EXHAUSTED", ignoreCase = true) -> "quota/rate-limit"
@@ -192,6 +224,21 @@ fun categorizeFailure(error: String?): String = when {
     else -> "other"
 }
 
+/**
+ * Mirrors production's pre-flight inline-audio size gate
+ * ([WhisperAccessibilityService]'s `ProviderKind.GEMINI` branch, which calls
+ * [GeminiTranscriberClient.canInlineAudio] on the PCM length and falls through to the next
+ * transcription candidate above the threshold). A fixture larger than
+ * [GeminiTranscriberClient.MAX_INLINE_PCM_BYTES] would never reach Gemini on a real device, so
+ * scoring it here would report accuracy for a call production refuses to make. Returns the
+ * production-shaped rejection reason, or null when the clip is within the inline budget.
+ */
+fun inlineAudioRejection(pcmBytes: Long): String? =
+    if (GeminiTranscriberClient.canInlineAudio(pcmBytes)) null
+    else "Recording too large for Gemini transcription ($pcmBytes bytes > " +
+        "${GeminiTranscriberClient.MAX_INLINE_PCM_BYTES} inline limit); production would fall " +
+        "through to the next transcription candidate rather than call Gemini"
+
 /** Blocking wrapper around the async production client: enqueues the real call and waits on a
  *  latch with a hard bound, so one hung callback can't stall a whole benchmark run. */
 private fun transcribeBlocking(
@@ -199,6 +246,7 @@ private fun transcribeBlocking(
     apiKey: String,
     model: String,
     timeoutSeconds: Long,
+    vocabularyTerms: List<String>,
 ): Pair<GeminiTranscriberClient.Result, Long> {
     val latch = CountDownLatch(1)
     // AtomicReference rather than a plain var: the callback runs on an OkHttp dispatcher thread,
@@ -212,6 +260,9 @@ private fun transcribeBlocking(
         apiKey = apiKey,
         model = model,
         cancelHolder = holder,
+        // Production interpolates the user's vocabulary into the transcription prompt (#114
+        // part 2); passing it here keeps the benchmarked prompt byte-identical to the shipped one.
+        vocabularyTerms = vocabularyTerms,
         callback = { r ->
             result.set(r)
             latch.countDown()
@@ -271,7 +322,13 @@ fun renderMarkdown(report: BenchmarkReport): String {
     sb.append("- Repetitions per fixture/model: ${cfg.repetitions}\n")
     sb.append("- Per-call timeout: ${cfg.callTimeoutSeconds}s (plus the production OkHttp client's own timeouts)\n")
     sb.append("- Manifest: `${cfg.manifestFile.path}` (sha256 `${cfg.manifestChecksum}`)\n")
-    sb.append("- Fixtures: ${cfg.fixtures.size}, total calls: ${cfg.totalCalls}\n\n")
+    sb.append("- Fixtures: ${cfg.fixtures.size}, total calls: ${cfg.totalCalls}\n")
+    sb.append(
+        "- Vocabulary terms in prompt: ${cfg.vocabularyTerms.size}" +
+            if (cfg.vocabularyTerms.isEmpty()) " (explicitly disabled)\n"
+            else " — ${cfg.vocabularyTerms.joinToString(", ")}\n"
+    )
+    sb.append("- Inline-audio gate: fixtures over ${GeminiTranscriberClient.MAX_INLINE_PCM_BYTES} PCM bytes are skipped, as production does\n\n")
     sb.append(
         "> Cost accounting is unavailable: `GeminiTranscriberClient.Result` discards the response's " +
             "`usageMetadata`, so token counts are not observable from the production path. No cost " +
@@ -352,6 +409,8 @@ fun renderJson(report: BenchmarkReport): String {
     root.put("manifestSha256", cfg.manifestChecksum)
     root.put("fixtureCount", cfg.fixtures.size)
     root.put("totalCalls", cfg.totalCalls)
+    root.put("vocabularyTerms", JSONArray(cfg.vocabularyTerms))
+    root.put("inlineAudioLimitBytes", GeminiTranscriberClient.MAX_INLINE_PCM_BYTES)
     root.put("costAccounting", "unavailable: GeminiTranscriberClient.Result discards usageMetadata")
 
     val perModel = JSONArray()
@@ -433,6 +492,7 @@ fun main() {
                 modelsRaw = System.getenv(MODELS_ENV),
                 repetitionsRaw = System.getenv(REPETITIONS_ENV),
                 evalDirRaw = System.getenv(EVAL_DIR_ENV),
+                vocabularyRaw = System.getenv(VOCABULARY_ENV),
             )
         )
     } catch (e: TranscriptionEvalManifest.ManifestException) {
@@ -446,6 +506,11 @@ fun main() {
         "Running ${config.fixtures.size} fixture(s) x ${config.modelIds.size} model(s) x " +
             "${config.repetitions} repetition(s) = ${config.totalCalls} call(s) against the real " +
             "Gemini API. This uploads audio to Google and spends real credits."
+    )
+    println(
+        "Prompt vocabulary: ${config.vocabularyTerms.size} term(s)" +
+            if (config.vocabularyTerms.isEmpty()) " (explicitly disabled via $VOCABULARY_ENV)."
+            else " — ${config.vocabularyTerms.joinToString(", ")}"
     )
 
     val outcomes = mutableListOf<CallOutcome>()
@@ -463,10 +528,22 @@ fun main() {
             continue
         }
         try {
+            // Production's size gate runs on the raw PCM, before any Gemini call is made.
+            val rejection = inlineAudioRejection(pcmFile.length())
+            if (rejection != null) {
+                System.err.println("Skipping fixture '${fixture.id}': $rejection")
+                config.modelIds.forEach { model ->
+                    for (rep in 1..config.repetitions) {
+                        outcomes.add(CallOutcome(fixture.id, model, rep, null, rejection, 0))
+                    }
+                }
+                continue
+            }
             for (model in config.modelIds) {
                 for (rep in 1..config.repetitions) {
                     print("  ${fixture.id} x $model rep $rep ... ")
-                    val (result, latencyMs) = transcribeBlocking(pcmFile, key, model, config.callTimeoutSeconds)
+                    val (result, latencyMs) =
+                        transcribeBlocking(pcmFile, key, model, config.callTimeoutSeconds, config.vocabularyTerms)
                     println(if (result.error == null) "ok (${latencyMs}ms)" else "error: ${result.error} (${latencyMs}ms)")
                     outcomes.add(CallOutcome(fixture.id, model, rep, result.text, result.error, latencyMs))
                 }


### PR DESCRIPTION
Follow-up to #147. Refs #129 — **does not close it**; see "What this does not do" below.

## The gap this closes

#147's harness calls the real `GeminiTranscriberClient.transcribe`, so transport, headers, OkHttp client and callback contract already match production. The **request** did not. Two divergences, each of which silently yields numbers that look like production numbers and aren't:

**1. The prompt.** Production interpolates the user's personal vocabulary into the transcription prompt itself (`GeminiTranscriberClient.transcribePrompt`, #114 part 2) and prefs are seeded with `VocabularyTerms.DEFAULTS` on first run — so *every* real dictation sends a vocabulary-biased prompt. The benchmark omitted the argument and took the bare `TRANSCRIBE_PROMPT` default, benchmarking a prompt no shipped build ever sends. Vocabulary biasing is precisely what moves WER on proper nouns and jargon, so this isn't cosmetic.

Now passes `VocabularyTerms.DEFAULTS`, overridable via `GEMINI_TRANSCRIPTION_VOCABULARY`. An explicitly empty value **disables** terms rather than falling back to the defaults — a legitimate experiment ("what is vocabulary biasing worth?"), and the same explicit-empty-is-not-a-fallback rule the model list already follows. Parsing delegates to production's `VocabularyTerms.parse` so trimming, blank-drop and case-insensitive dedupe match the app rather than being reimplemented.

**2. The pre-flight size gate.** On a real device the `ProviderKind.GEMINI` branch checks `canInlineAudio()` on the PCM length *before* calling Gemini and falls through to the next transcription candidate above the limit. The benchmark had no gate, so an oversized fixture would report accuracy for a call production refuses to make. Now applies the same gate, **inheriting** `MAX_INLINE_PCM_BYTES` rather than restating the threshold (a hardcoded 10MB would keep passing after production moved it), and buckets the skip separately from transport failures so it can't be misread as Gemini unreliability.

Both choices are recorded in the Markdown and JSON report headers. A run whose prompt vocabulary isn't recorded can't be compared against a later run: same corpus, same model, different terms is a different experiment.

## Tests

12 new tests, including the **first coverage of `renderMarkdown`/`renderJson`** — previously entirely untested despite being how every number reaches a human.

Mutation-checked against a proven-green baseline: reverting the vocabulary default to `emptyList()` and neutering the size gate to `if (true) null` each failed tests by name (6 failures), then the source was restored and re-verified green.

```
./gradlew testGithubDebugUnitTest --offline --rerun-tasks   # BUILD SUCCESSFUL
1202 tests, 0 failures, 0 errors, 0 skipped   (was 1190 on main; +12)
```

Counts parsed from the JUnit XML after clearing `test-results` and forcing `--rerun-tasks`, not inferred from a green exit code.

## What this does NOT do — #129 stays open

- **No benchmark has been run and this PR contains no numbers.** Running one needs a live `GEMINI_API_KEY` (real credits, uploads audio to Google) — a human gate, not something to work around.
- **The corpus still ships empty.** Fixtures require consented voice recordings, which are biometric data. Inventing manifest entries with no audio would be fabrication.
- Production dictation sources are untouched; every change is under `app/src/test/` (plus README).
- Remaining divergences are documented in the README rather than papered over: JVM-from-`.wav` vs Android-with-device-recording, the #109 compressed-upload `audio/aac` path, and absent cost accounting (`Result` discards `usageMetadata`).

**To actually close #129** a human must supply consented or synthetic-TTS fixtures and run the benchmark with a real key across the model matrix.