### PR TITLE
Validate local cleanup output and give a terminal local step its own budget

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -107,6 +107,38 @@ const val CLEANUP_WATERFALL_HARD_CAP_MS = 8_000L
 const val LOCAL_LLM_STEP_BUDGET_MS = 4_000L
 
 /**
+ * Wall-clock budget for a LOCAL_LLM step that is the LAST step in the waterfall, measured from
+ * the waterfall's start (#155). Replaces [CLEANUP_WATERFALL_HARD_CAP_MS] for that one case only.
+ *
+ * Exists because the 8s hard cap was doing two unrelated jobs with one number. Its own kdoc says
+ * what it was tuned for: a user with *no* local model, whose unreachable cloud hosts burn their
+ * timeouts in sequence while the chain grinds toward raw injection. That is a hanging-socket
+ * problem, and 8s is the right answer to it -- the #137 tuning against 318 real cleanups (p99
+ * 3828ms, slowest success 7859ms) is load-bearing and stays exactly as it is for every cloud
+ * step.
+ *
+ * A terminal on-device step has the opposite risk profile. It is a CPU-bound, self-terminating
+ * computation that already carries its own native abort callback (#92), so it cannot hang the way
+ * a dead socket can; and being last, there is no subsequent step whose time it could steal. The
+ * only thing the cloud-shaped cap achieves there is converting a slow-but-healthy completion into
+ * an outright failure. Trevor hit exactly that on a Pixel 10a: a local cleanup finished its work
+ * in 8003ms and was killed at 8000ms, missing by 3ms. For a user with no cloud provider
+ * configured, local cleanup is the ONLY cleanup path, so that 3ms is the difference between
+ * cleaned text and no cleanup at all.
+ *
+ * 12s is chosen as a bound on that observed failure, not a device measurement: it clears the
+ * 8003ms case by ~50% while still guaranteeing the user gets *some* answer in a bounded time.
+ * It is deliberately a fixed ceiling -- no adaptive or calibration machinery -- because the real
+ * latency fix is the shorter prompt landing alongside it (#155's vocabulary cap: prompt-eval
+ * throughput measured 2145 t/s with the short prompt versus 391 t/s with the 22-term vocabulary
+ * prompt), which cuts this path's cost directly rather than guessing at the device.
+ *
+ * Measured from the waterfall's start rather than from "now", so a chain that spent time on
+ * earlier steps cannot extend the total run past this ceiling.
+ */
+const val TERMINAL_LOCAL_LLM_STEP_BUDGET_MS = 12_000L
+
+/**
  * The actual wall-clock deadline a LOCAL_LLM step gets for one completion attempt (#37 follow-up,
  * Trevor hit this directly with a single-step Local-only chain): [LOCAL_LLM_STEP_BUDGET_MS]
  * exists to guarantee a *subsequent* step gets real time to run after a slow/stuck local attempt
@@ -114,11 +146,22 @@ const val LOCAL_LLM_STEP_BUDGET_MS = 4_000L
  * follows it, e.g. a user's simple "Local" cleanup choice with nothing else configured), that
  * same tight 4s budget serves no purpose: there's no later step it's protecting, so it just
  * turns a genuinely healthy but slightly slower completion into an outright failure with no
- * safety net. When [isLastStep] is true, this returns the full remaining [overallDeadlineAtMs]
- * instead (matching every other step group's behavior, which always gets the real deadline).
+ * safety net.
+ *
+ * When [isLastStep] is true this returns [TERMINAL_LOCAL_LLM_STEP_BUDGET_MS] from
+ * [waterfallStartedAtMs] (#155) rather than the cloud-shaped [overallDeadlineAtMs] -- see that
+ * constant's kdoc for why the 8s hard cap is the wrong instrument for a terminal on-device step.
+ * [maxOf] rather than a plain replacement so this can only ever widen the terminal step's
+ * deadline, never shrink it below what it already got.
  */
-fun localLlmStepDeadline(overallDeadlineAtMs: Long, nowMs: Long, isLastStep: Boolean): Long =
-    if (isLastStep) overallDeadlineAtMs else minOf(overallDeadlineAtMs, nowMs + LOCAL_LLM_STEP_BUDGET_MS)
+fun localLlmStepDeadline(
+    overallDeadlineAtMs: Long,
+    nowMs: Long,
+    isLastStep: Boolean,
+    waterfallStartedAtMs: Long = overallDeadlineAtMs - CLEANUP_WATERFALL_HARD_CAP_MS,
+): Long =
+    if (isLastStep) maxOf(overallDeadlineAtMs, waterfallStartedAtMs + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS)
+    else minOf(overallDeadlineAtMs, nowMs + LOCAL_LLM_STEP_BUDGET_MS)
 
 /**
  * Pure grouping/ordering logic for [CleanupWaterfall.steps], split out from the network-calling
@@ -685,6 +728,9 @@ object CleanupWaterfallExecutor {
             // except when this LOCAL_LLM step is the LAST step in the whole waterfall (#37
             // follow-up: Trevor's simple "Local" cleanup choice has nothing after it to protect),
             // in which case it gets the real remaining deadline like every other step group.
+            // waterfallStartedAtMs is left to its default, which recovers the waterfall's start
+            // as `deadlineAtMs - CLEANUP_WATERFALL_HARD_CAP_MS` -- exact here, since execute()
+            // builds deadlineAtMs as startedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS.
             val localDeadlineAtMs = localLlmStepDeadline(deadlineAtMs, System.currentTimeMillis(), isLastStep)
             callback(
                 when (val result = localInference.complete(localPrompt, text, modelPath, localDeadlineAtMs, { cancelHolder.isCancelled })) {

--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -364,7 +364,7 @@ object RealLocalInferenceEngine : LocalInferenceEngine {
                 }
                 when {
                     text == null -> LocalInferenceResult.TimedOut("Local cleanup timed out")
-                    text.isNotBlank() -> LocalInferenceResult.Success(text)
+                    text.isNotBlank() -> validated(systemPrompt, userText, text)
                     else -> LocalInferenceResult.Failure("Local model produced an empty response")
                 }
             }
@@ -383,6 +383,29 @@ object RealLocalInferenceEngine : LocalInferenceEngine {
             android.util.Log.e("RealLocalInferenceEngine", "Local cleanup inference failed for $modelPath", e)
             if (isCancelled()) LocalInferenceResult.Cancelled
             else LocalInferenceResult.Failure(e.message ?: "Local inference failed")
+        }
+
+    /**
+     * Gates non-blank model output through [LocalCleanupOutputValidator] (#155) instead of
+     * accepting any non-blank string, which was this engine's entire prior contract.
+     *
+     * A rejection becomes a [LocalInferenceResult.Failure], never [LocalInferenceResult.Cancelled]:
+     * bad local output is this one step failing, so it must fall through to the next waterfall
+     * step (or raw-text injection) exactly like a timeout does -- see [LocalInferenceResult.TimedOut]'s
+     * kdoc for the live regression caused by conflating the two.
+     */
+    private fun validated(systemPrompt: String, userText: String, text: String): LocalInferenceResult =
+        when (val verdict = LocalCleanupOutputValidator.validate(userText, systemPrompt, text)) {
+            is LocalCleanupValidation.Valid -> LocalInferenceResult.Success(text)
+            is LocalCleanupValidation.Rejected -> {
+                // Log the reason, not the text: the prompt-echo case exists precisely because
+                // the output can contain the user's private vocabulary terms.
+                android.util.Log.w(
+                    "RealLocalInferenceEngine",
+                    "Rejected local cleanup output: ${verdict.reason} -- ${verdict.detail}",
+                )
+                LocalInferenceResult.Failure("Local cleanup output rejected (${verdict.reason})")
+            }
         }
 }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -128,10 +128,22 @@ const val LOCAL_LLM_STEP_BUDGET_MS = 4_000L
  *
  * 12s is chosen as a bound on that observed failure, not a device measurement: it clears the
  * 8003ms case by ~50% while still guaranteeing the user gets *some* answer in a bounded time.
- * It is deliberately a fixed ceiling -- no adaptive or calibration machinery -- because the real
- * latency fix is the shorter prompt landing alongside it (#155's vocabulary cap: prompt-eval
- * throughput measured 2145 t/s with the short prompt versus 391 t/s with the 22-term vocabulary
- * prompt), which cuts this path's cost directly rather than guessing at the device.
+ * It is deliberately a fixed ceiling -- no adaptive or calibration machinery -- because it is a
+ * safety net, not a latency fix.
+ *
+ * This budget deliberately does NOT rest on any claim about vocabulary length. An earlier
+ * revision justified it with a "2145 t/s short prompt vs 391 t/s 22-term prompt" figure; that
+ * measurement was wrong twice over and has been retracted. Re-measured against the real
+ * lfm2.5-350m-q4_0 with the real production prompts: the "364 -> 702" figures were *character*
+ * counts, not tokens (true tokenized lengths are 100 -> 212), and the throughput gap was a
+ * warmup artifact of an uncontrolled first run -- alternating A/B reps put the 22-term prompt at
+ * 2431-2797 t/s versus 1582-1781 t/s for the short one, i.e. the longer prompt evaluates
+ * *faster* per token because the larger batch uses the CPU better. The personal vocabulary costs
+ * ~15ms of prompt eval, which cannot explain an 8000ms budget overrun.
+ *
+ * The real cost is structural: LLMInference::startCompletion clears the KV cache every
+ * completion, so the system prompt is re-evaluated from scratch on every dictation instead of
+ * reusing its cached prefix. See .hermes/plans/2026-08-18-local-cleanup-latency-measured.md.
  *
  * Measured from the waterfall's start rather than from "now", so a chain that spent time on
  * earlier steps cannot extend the total run past this ceiling.

--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
@@ -1,0 +1,441 @@
+package com.trevornk.ramblr
+
+/**
+ * Outcome of validating one local-cleanup completion (#155). [Valid] means the text may be
+ * accepted as cleaned output; [Rejected] means it must be treated as a step failure so the
+ * waterfall falls through to the next step (or to raw-text injection) instead of injecting it.
+ */
+sealed class LocalCleanupValidation {
+    object Valid : LocalCleanupValidation()
+
+    /** [detail] is a short, non-sensitive diagnostic for logcat -- it deliberately never
+     *  contains the model output or the user's transcript, both of which can hold private
+     *  content (the prompt-echo failure this guards against leaks exactly that). */
+    data class Rejected(val reason: Reason, val detail: String) : LocalCleanupValidation()
+
+    enum class Reason {
+        /** The model regurgitated part of its own system prompt as "cleaned" text. */
+        PROMPT_ECHO,
+
+        /** A number the speaker said is gone from, or has a different value in, the output. */
+        NUMERIC_DIVERGENCE,
+
+        /** The output is a fraction of the input -- content was dropped, not cleaned. */
+        LENGTH_COLLAPSE,
+    }
+}
+
+/**
+ * Sanity-checks what a small on-device model returned before [RealLocalInferenceEngine] reports
+ * it as a success (#155).
+ *
+ * Exists because the entire prior contract for local-cleanup output was `text.isNotBlank()`.
+ * With a non-trivial personal vocabulary list interpolated into the system prompt (364 -> 702
+ * chars for 22 terms), LFM2.5-350M-Q4_0 was measured producing, deterministically at temp 0:
+ *
+ *  - "Send four hundred and fifty dollars to the account ending in nine three seven two"
+ *    -> "Send $150 to the account ending in ninethreeseventwo"   (the amount silently changed)
+ *  - "My address is four one two Selby Road" -> "Selby Road"     (the house number deleted)
+ *  - "Call me at five five five one two three four"
+ *    -> the system prompt echoed back verbatim, which injects the user's own private
+ *       vocabulary terms (emails, family names) into whatever app they dictated into
+ *
+ * All three are worse than no cleanup at all, and all three are detectable without the model:
+ * they are properties of (input, systemPrompt, output). Kept deliberately free of Android and
+ * llama.cpp dependencies so every branch is a plain JVM unit test.
+ *
+ * Thresholds are biased toward ACCEPTING. A false rejection costs one fallback step; an
+ * over-eager validator makes local cleanup useless. Every threshold below is set with real
+ * headroom against the legitimate-cleanup cases in `LocalCleanupOutputValidatorTest`, not
+ * tightened to the smallest value that still passes them.
+ */
+object LocalCleanupOutputValidator {
+
+    /**
+     * Length in normalized characters of the longest shared span between the system prompt and
+     * the output that counts as an echo rather than coincidence.
+     *
+     * 40 chars is roughly six or seven English words. Legitimate cleaned speech does share short
+     * spans with an instruction prompt ("return only the cleaned text" is 28 normalized chars,
+     * "clean up this speech-to-text transcript" is 38), so anything at or below ~38 must survive;
+     * the observed echo failures reproduce hundreds of contiguous characters, not forty. Spans
+     * the speaker actually dictated are excluded separately (see [longestSharedSpanLength]'s
+     * caller), so this only has to separate "coincidence" from "regurgitation".
+     */
+    const val PROMPT_ECHO_MIN_SPAN = 40
+
+    /**
+     * Minimum surviving fraction of the input's normalized length.
+     *
+     * Measured against the real cases: "My address is four one two Selby Road" -> "Selby Road"
+     * retains 0.36 of the normalized input and must be rejected, while the legitimate
+     * "Transfer twelve thousand five hundred dollars tomorrow" -> "Transfer $12,500" retains
+     * 0.61 and must pass. 0.5 sits between them with headroom on both sides.
+     *
+     * The comparison is deliberately unfair in the output's favour: [normalizeForLength] strips
+     * filler words, currency words and spoken-numeral verbosity from the INPUT baseline only, so
+     * the two transformations a correct cleanup is *supposed* to perform (dropping disfluencies,
+     * and "four hundred and fifty dollars" -> "$450") shrink the baseline too and cannot by
+     * themselves trip this check.
+     */
+    const val LENGTH_COLLAPSE_MIN_RATIO = 0.5
+
+    /**
+     * Inputs shorter than this (normalized) skip the length check entirely. A handful of words
+     * carries too little signal -- "yeah um okay" losing one token is a 33% drop that means
+     * nothing -- and short utterances are exactly where legitimate cleanup ratios are noisiest.
+     */
+    const val LENGTH_COLLAPSE_MIN_INPUT_CHARS = 24
+
+    /**
+     * Runs the three checks in severity order and returns the first rejection, or [Valid].
+     *
+     * A blank [modelOutput] is NOT this function's business: the caller already treats empty
+     * output as its own failure, and reporting it here as a length collapse would be a
+     * less accurate diagnostic.
+     */
+    fun validate(
+        rawInput: String,
+        systemPrompt: String,
+        modelOutput: String,
+    ): LocalCleanupValidation {
+        if (modelOutput.isBlank()) return LocalCleanupValidation.Valid
+
+        checkPromptEcho(rawInput, systemPrompt, modelOutput)?.let { return it }
+        checkNumericDivergence(rawInput, modelOutput)?.let { return it }
+        checkLengthCollapse(rawInput, modelOutput)?.let { return it }
+        return LocalCleanupValidation.Valid
+    }
+
+    // --- (a) prompt echo -------------------------------------------------------------------
+
+    /**
+     * Rejects output sharing a long contiguous span with the system prompt.
+     *
+     * Derived from the [systemPrompt] argument rather than matching known prompt wording, so it
+     * keeps working when a prompt constant is reworded, when a personal-vocabulary clause is
+     * interpolated into it, and for a fine-tuned model that ships its own
+     * [Model.localSystemPrompt]. Hardcoding "Watch for these project names" would have covered
+     * exactly one prompt of the several this path can send.
+     *
+     * A span the speaker actually said is not an echo -- if someone dictates a sentence that
+     * happens to appear in the prompt, cleaning it up should reproduce it -- so any span also
+     * present in [rawInput] is discounted by comparing against the input as well.
+     */
+    private fun checkPromptEcho(
+        rawInput: String,
+        systemPrompt: String,
+        modelOutput: String,
+    ): LocalCleanupValidation.Rejected? {
+        val prompt = normalizeForEcho(systemPrompt)
+        val output = normalizeForEcho(modelOutput)
+        if (prompt.isEmpty() || output.isEmpty()) return null
+
+        val sharedWithPrompt = longestSharedSpanLength(prompt, output)
+        if (sharedWithPrompt < PROMPT_ECHO_MIN_SPAN) return null
+
+        // The speaker's own words are not an echo. Only the amount of overlap the prompt
+        // contributes *beyond* what the input already explains is evidence of regurgitation.
+        val sharedWithInput = longestSharedSpanLength(normalizeForEcho(rawInput), output)
+        if (sharedWithPrompt <= sharedWithInput) return null
+
+        return LocalCleanupValidation.Rejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "output shares a $sharedWithPrompt-char span with the system prompt " +
+                "(threshold $PROMPT_ECHO_MIN_SPAN, input explains only $sharedWithInput)",
+        )
+    }
+
+    /**
+     * Longest common substring length, computed with the usual two-row dynamic program so memory
+     * stays O(min(n, m)) instead of O(n*m).
+     *
+     * Both sides are capped at [ECHO_SCAN_CAP] characters purely to bound worst-case cost on a
+     * phone: prompts are hundreds of characters and dictations are rarely longer, and an echo
+     * long enough to matter always begins well inside that window.
+     */
+    private fun longestSharedSpanLength(a: String, b: String): Int {
+        if (a.isEmpty() || b.isEmpty()) return 0
+        val left = a.take(ECHO_SCAN_CAP)
+        val right = b.take(ECHO_SCAN_CAP)
+        var previous = IntArray(right.length + 1)
+        var current = IntArray(right.length + 1)
+        var best = 0
+        for (i in 1..left.length) {
+            for (j in 1..right.length) {
+                current[j] = if (left[i - 1] == right[j - 1]) previous[j - 1] + 1 else 0
+                if (current[j] > best) best = current[j]
+            }
+            val swap = previous
+            previous = current
+            current = swap
+            java.util.Arrays.fill(current, 0)
+        }
+        return best
+    }
+
+    private const val ECHO_SCAN_CAP = 4_000
+
+    /** Lowercased, with every run of non-alphanumeric characters collapsed to one space, so
+     *  punctuation or spacing drift between prompt and echo can't hide the overlap. */
+    private fun normalizeForEcho(text: String): String =
+        text.lowercase().replace(NON_ALPHANUMERIC, " ").trim().replace(WHITESPACE_RUN, " ")
+
+    // --- (b) numeric divergence ------------------------------------------------------------
+
+    /**
+     * Rejects output where a number the speaker said has vanished or changed value.
+     *
+     * The hard part is that spoken-to-digit conversion is *correct* cleanup: "four hundred and
+     * fifty" -> "$450" and "twelve thousand five hundred" -> "$12,500" must both pass, while
+     * 450 -> 150 must not. So both sides are reduced to numeric VALUES rather than compared as
+     * text: each run of number words in the input yields the set of values it could legitimately
+     * be written as, and the output yields every value it contains (digits and words alike). A
+     * run is satisfied if the output still contains any one of its candidate values.
+     *
+     * "Any one of" is the bias-toward-accepting choice: a run like "nine three seven two" is
+     * legitimately renderable as 9372 or as the digits 9, 3, 7, 2, and guessing wrong in the
+     * strict direction would reject good output.
+     */
+    private fun checkNumericDivergence(
+        rawInput: String,
+        modelOutput: String,
+    ): LocalCleanupValidation.Rejected? {
+        val inputRuns = numericRuns(rawInput)
+        if (inputRuns.isEmpty()) return null
+
+        val outputValues = numericRuns(modelOutput).flatten().toSet()
+        val missing = inputRuns.firstOrNull { candidates -> candidates.none { it in outputValues } }
+            ?: return null
+
+        return LocalCleanupValidation.Rejected(
+            LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE,
+            "a spoken number is missing or altered in the output " +
+                "(${missing.size} accepted rendering(s), none present)",
+        )
+    }
+
+    /**
+     * Every numeric run in [text], each as the set of canonical values it may legitimately be
+     * written as. Canonical values are digit strings (leading zeros stripped) rather than Longs,
+     * so a 20-digit account number can't overflow and a decimal keeps its exact form.
+     */
+    private fun numericRuns(text: String): List<Set<String>> {
+        val tokens = text.lowercase().split(WHITESPACE_RUN).filter { it.isNotEmpty() }
+        val runs = mutableListOf<Set<String>>()
+        var index = 0
+        while (index < tokens.size) {
+            val literal = literalNumberValue(tokens[index])
+            if (literal != null) {
+                runs += setOf(literal)
+                index++
+                continue
+            }
+            val words = mutableListOf<String>()
+            var cursor = index
+            while (cursor < tokens.size) {
+                val word = stripPunctuation(tokens[cursor])
+                val isNumberWord = word in NUMBER_WORDS
+                // "and" only continues a run ("four hundred and fifty"); it never starts or
+                // ends one, so a trailing "and" isn't swallowed into the numeric span.
+                val isConnector = word == "and" && words.isNotEmpty() &&
+                    cursor + 1 < tokens.size && stripPunctuation(tokens[cursor + 1]) in NUMBER_WORDS
+                if (!isNumberWord && !isConnector) break
+                if (isNumberWord) words += word
+                cursor++
+            }
+            if (words.isEmpty()) {
+                index++
+                continue
+            }
+            wordRunCandidates(words)?.let { runs += it }
+            index = cursor
+        }
+        return runs
+    }
+
+    /**
+     * Canonical value of a token that is already written numerically -- plain digits, comma
+     * grouping, a currency symbol, or trailing punctuation ("$12,500." -> "12500").
+     */
+    private fun literalNumberValue(token: String): String? {
+        val stripped = token.trim { it in CURRENCY_AND_PUNCTUATION }.replace(",", "")
+        if (stripped.isEmpty() || stripped.none { it.isDigit() }) return null
+        if (!stripped.all { it.isDigit() || it == '.' }) return null
+        return canonicalize(stripped)
+    }
+
+    /**
+     * The values a run of number WORDS may legitimately appear as.
+     *
+     * Three shapes, because they behave differently:
+     *  - contains a scale word ("hundred"/"thousand"/...): a cardinal, and only the cardinal --
+     *    "four hundred and fifty" means 450, and 4, 100 or 50 appearing alone is not that number
+     *  - all single-digit words: read out digit by digit, so both the concatenation ("nine three
+     *    seven two" -> 9372) and the individual digits are legitimate renderings
+     *  - otherwise ("twenty five"): the cardinal plus each word's own value
+     *
+     * Returns null for runs with no defensible reading, and for a bare "one", which is far more
+     * often an article or pronoun ("one of the things") than a quantity worth guarding.
+     */
+    private fun wordRunCandidates(words: List<String>): Set<String>? {
+        if (words.size == 1 && words[0] == "one") return null
+        val hasScale = words.any { it in SCALE_WORDS }
+        if (hasScale) {
+            return cardinalValue(words)?.let { setOf(canonicalize(it.toString())) }
+        }
+        val digitsOnly = words.all { it in SINGLE_DIGIT_WORDS }
+        if (digitsOnly) {
+            val concatenated = words.joinToString("") { SINGLE_DIGIT_WORDS.getValue(it).toString() }
+            return buildSet {
+                add(canonicalize(concatenated))
+                words.forEach { add(canonicalize(SINGLE_DIGIT_WORDS.getValue(it).toString())) }
+            }
+        }
+        return buildSet {
+            cardinalValue(words)?.let { add(canonicalize(it.toString())) }
+            words.forEach { word -> NUMBER_WORDS[word]?.let { add(canonicalize(it.toString())) } }
+        }.ifEmpty { null }
+    }
+
+    /** Standard cardinal accumulation ("twelve thousand five hundred" -> 12500). Null when the
+     *  run has no scale/value words at all. */
+    private fun cardinalValue(words: List<String>): Long? {
+        var total = 0L
+        var chunk = 0L
+        var sawValue = false
+        for (word in words) {
+            val value = NUMBER_WORDS[word] ?: continue
+            sawValue = true
+            when {
+                word == "hundred" -> chunk = (if (chunk == 0L) 1L else chunk) * 100L
+                word in BIG_SCALE_WORDS -> {
+                    total += (if (chunk == 0L) 1L else chunk) * value
+                    chunk = 0L
+                }
+                else -> chunk += value
+            }
+        }
+        return if (sawValue) total + chunk else null
+    }
+
+    /** Digit string without leading zeros or a trailing decimal point ("04" -> "4"). */
+    private fun canonicalize(digits: String): String {
+        val trimmed = digits.trimEnd('.')
+        val withoutLeadingZeros = trimmed.trimStart('0')
+        return when {
+            withoutLeadingZeros.isEmpty() -> "0"
+            withoutLeadingZeros.startsWith(".") -> "0$withoutLeadingZeros"
+            else -> withoutLeadingZeros
+        }
+    }
+
+    private fun stripPunctuation(token: String): String = token.trim { !it.isLetterOrDigit() }
+
+    // --- (c) length collapse ---------------------------------------------------------------
+
+    /** Rejects output that kept less than [LENGTH_COLLAPSE_MIN_RATIO] of the input's normalized
+     *  length -- the "My address is four one two Selby Road" -> "Selby Road" failure, where the
+     *  model dropped content instead of cleaning it. */
+    private fun checkLengthCollapse(
+        rawInput: String,
+        modelOutput: String,
+    ): LocalCleanupValidation.Rejected? {
+        val baseline = normalizeForLength(rawInput)
+        if (baseline.length < LENGTH_COLLAPSE_MIN_INPUT_CHARS) return null
+        val output = normalizeForLength(modelOutput)
+        val ratio = output.length.toDouble() / baseline.length
+        if (ratio >= LENGTH_COLLAPSE_MIN_RATIO) return null
+        return LocalCleanupValidation.Rejected(
+            LocalCleanupValidation.Reason.LENGTH_COLLAPSE,
+            "output kept only ${(ratio * 100).toInt()}% of the input's content length " +
+                "(minimum ${(LENGTH_COLLAPSE_MIN_RATIO * 100).toInt()}%)",
+        )
+    }
+
+    /**
+     * Reduces text to comparable "content length": lowercased, punctuation and currency symbols
+     * dropped, spoken numerals collapsed to their digit form, and filler words removed.
+     *
+     * Applied to both sides, but it only ever *shrinks the input baseline* in practice -- a
+     * cleaned output has no filler and already uses digits. That asymmetry is deliberate: the
+     * two things a correct cleanup does (delete disfluencies, write numbers as digits) are
+     * removed from the comparison so they can never look like a collapse.
+     */
+    internal fun normalizeForLength(text: String): String {
+        val tokens = text.lowercase().split(WHITESPACE_RUN).filter { it.isNotEmpty() }
+        val kept = mutableListOf<String>()
+        var index = 0
+        while (index < tokens.size) {
+            val word = stripPunctuation(tokens[index])
+            if (word.isEmpty()) {
+                index++
+                continue
+            }
+            if (word in FILLER_WORDS || word in CURRENCY_WORDS) {
+                index++
+                continue
+            }
+            if (word in NUMBER_WORDS) {
+                var cursor = index
+                val words = mutableListOf<String>()
+                while (cursor < tokens.size) {
+                    val next = stripPunctuation(tokens[cursor])
+                    if (next !in NUMBER_WORDS && !(next == "and" && words.isNotEmpty())) break
+                    if (next in NUMBER_WORDS) words += next
+                    cursor++
+                }
+                if (words.isNotEmpty()) {
+                    kept += wordRunCandidates(words)?.minByOrNull { it.length }
+                        ?: words.joinToString("")
+                    index = cursor
+                    continue
+                }
+            }
+            kept += word.filter { it.isLetterOrDigit() || it == '.' }
+            index++
+        }
+        return kept.joinToString(" ")
+    }
+
+    // --- shared vocabulary -----------------------------------------------------------------
+
+    private val NON_ALPHANUMERIC = Regex("[^a-z0-9]+")
+    private val WHITESPACE_RUN = Regex("\\s+")
+    private val CURRENCY_AND_PUNCTUATION = charArrayOf(
+        '$', '€', '£', '¥', '.', ',', '!', '?', ':', ';', '"', '\'', '(', ')', '-',
+    ).toSet()
+
+    /** Disfluencies a correct cleanup is expected to delete, so they are removed from the length
+     *  baseline rather than counted as content the model lost. Generous on purpose: every entry
+     *  here only makes the check more permissive. */
+    private val FILLER_WORDS = setOf(
+        "um", "uh", "erm", "er", "ah", "hmm", "mhm", "eh", "like", "basically", "actually",
+        "literally", "sorta", "kinda", "yknow",
+    )
+
+    /** Dropped from the length baseline because "four hundred and fifty dollars" -> "$450"
+     *  legitimately deletes the currency word along with the numeral spelling. */
+    private val CURRENCY_WORDS = setOf(
+        "dollar", "dollars", "cent", "cents", "euro", "euros", "pound", "pounds", "buck", "bucks",
+    )
+
+    private val SINGLE_DIGIT_WORDS: Map<String, Int> = mapOf(
+        "zero" to 0, "oh" to 0, "one" to 1, "two" to 2, "three" to 3, "four" to 4, "five" to 5,
+        "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9,
+    )
+
+    private val SCALE_WORDS = setOf("hundred", "thousand", "million", "billion")
+    private val BIG_SCALE_WORDS = setOf("thousand", "million", "billion")
+
+    private val NUMBER_WORDS: Map<String, Long> = buildMap {
+        SINGLE_DIGIT_WORDS.forEach { (word, value) -> put(word, value.toLong()) }
+        put("ten", 10L); put("eleven", 11L); put("twelve", 12L); put("thirteen", 13L)
+        put("fourteen", 14L); put("fifteen", 15L); put("sixteen", 16L); put("seventeen", 17L)
+        put("eighteen", 18L); put("nineteen", 19L); put("twenty", 20L); put("thirty", 30L)
+        put("forty", 40L); put("fifty", 50L); put("sixty", 60L); put("seventy", 70L)
+        put("eighty", 80L); put("ninety", 90L)
+        put("hundred", 100L); put("thousand", 1_000L); put("million", 1_000_000L)
+        put("billion", 1_000_000_000L)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
@@ -593,12 +593,15 @@ class LocalLlmWaterfallStepTest {
         assertEquals(1, transport.requestedUrls.size)
     }
 
-    @Test fun `a single LOCAL_LLM step -- the last step in the waterfall -- gets the full deadline, not the tighter budget`() {
+    @Test fun `a single LOCAL_LLM step -- the last step in the waterfall -- gets the terminal budget, not the tighter budget`() {
         // #37 follow-up: Trevor's real Local-only cleanup choice is exactly this shape (one
         // LOCAL_LLM step, nothing after it). The tighter LOCAL_LLM_STEP_BUDGET_MS exists only to
         // protect a *subsequent* step's own timeout window -- with no subsequent step, applying
         // it anyway just turns a healthy-but-slightly-slower completion into a hard failure with
         // llama_decode aborting mid-generation, which is the exact bug Trevor hit live on-device.
+        // #155: what that step gets is now TERMINAL_LOCAL_LLM_STEP_BUDGET_MS from the waterfall's
+        // start rather than the cloud-shaped hard cap, because the 8s cap killed a healthy 8003ms
+        // completion by 3ms.
         val transport = FakeCleanupHttpTransport(mutableListOf())
         val engine = FakeLocalInferenceEngine(mutableListOf(LocalInferenceResult.Success("ok")))
         val waterfall = CleanupWaterfall(listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, LocalCleanupProvider.MODEL.archive)))
@@ -608,9 +611,10 @@ class LocalLlmWaterfallStepTest {
         val after = System.currentTimeMillis()
 
         val deadline = engine.deadlines.single()
-        // Full CLEANUP_WATERFALL_HARD_CAP_MS budget, not the tighter LOCAL_LLM_STEP_BUDGET_MS.
-        assertTrue(deadline >= before + CLEANUP_WATERFALL_HARD_CAP_MS)
-        assertTrue(deadline <= after + CLEANUP_WATERFALL_HARD_CAP_MS)
+        // Terminal budget from the waterfall's start, not the tighter LOCAL_LLM_STEP_BUDGET_MS
+        // and not the cloud-shaped CLEANUP_WATERFALL_HARD_CAP_MS.
+        assertTrue(deadline >= before + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS)
+        assertTrue(deadline <= after + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS)
     }
 
     @Test fun `a LOCAL_LLM step followed by another step gets the tighter step budget, not the full waterfall deadline`() {
@@ -771,11 +775,15 @@ class LocalLlmStepDeadlineTest {
         assertEquals(now + LOCAL_LLM_STEP_BUDGET_MS, deadline)
     }
 
-    @Test fun `the last step gets the full overall deadline, not the tighter budget`() {
+    @Test fun `the last step gets the wider terminal budget, not the tighter per-step budget`() {
+        // Intent unchanged from #37: a terminal local step must not be held to the 4s budget that
+        // exists only to protect a *subsequent* step. #155 widens what it gets instead: the
+        // terminal budget measured from the waterfall's start, rather than the cloud-shaped 8s cap.
         val now = 1_000_000L
         val overallDeadline = now + CLEANUP_WATERFALL_HARD_CAP_MS
         val deadline = localLlmStepDeadline(overallDeadline, now, isLastStep = true)
-        assertEquals(overallDeadline, deadline)
+        assertEquals(now + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS, deadline)
+        assertTrue("terminal step must not be held to the tighter budget", deadline > now + LOCAL_LLM_STEP_BUDGET_MS)
     }
 
     @Test fun `not the last step never exceeds the overall deadline even if the tighter budget would`() {
@@ -789,10 +797,161 @@ class LocalLlmStepDeadlineTest {
     }
 
     @Test fun `the last step ignores the tighter budget entirely, even when it would be smaller`() {
+        // A waterfall already 7s deep: only 1s of the 8s cap is left. The terminal step still
+        // gets its own budget measured from the waterfall's start (#155), so the near-spent
+        // overall deadline no longer decides whether a healthy local completion survives.
         val now = 1_000_000L
         val overallDeadline = now + 1_000L // less than LOCAL_LLM_STEP_BUDGET_MS
+        val waterfallStartedAtMs = overallDeadline - CLEANUP_WATERFALL_HARD_CAP_MS
         val deadline = localLlmStepDeadline(overallDeadline, now, isLastStep = true)
-        assertEquals(overallDeadline, deadline)
+        assertEquals(waterfallStartedAtMs + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS, deadline)
+        assertTrue("terminal step must not be capped by the tighter per-step budget", deadline > overallDeadline)
+    }
+
+    @Test fun `the terminal budget is measured from the waterfall start, not from now`() {
+        // Time already spent on earlier steps comes out of the terminal step's budget rather than
+        // extending the total run: the ceiling is absolute, anchored at the waterfall's start.
+        val waterfallStartedAtMs = 1_000_000L
+        val overallDeadline = waterfallStartedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS
+        val spentOnEarlierStepsMs = 5_000L
+        val now = waterfallStartedAtMs + spentOnEarlierStepsMs
+
+        val deadline = localLlmStepDeadline(overallDeadline, now, isLastStep = true, waterfallStartedAtMs)
+
+        assertEquals(waterfallStartedAtMs + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS, deadline)
+        // What's actually left for this step is the ceiling minus what earlier steps burned.
+        assertEquals(TERMINAL_LOCAL_LLM_STEP_BUDGET_MS - spentOnEarlierStepsMs, deadline - now)
+    }
+
+    @Test fun `the default waterfall start recovers the real start from the overall deadline`() {
+        // execute() builds deadlineAtMs as startedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS and passes
+        // only the deadline down, so the defaulted parameter must invert that exactly. If these
+        // two ever disagree the production call site is silently using a different anchor.
+        val waterfallStartedAtMs = 1_000_000L
+        val overallDeadline = waterfallStartedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS
+        val now = waterfallStartedAtMs + 2_500L
+
+        assertEquals(
+            localLlmStepDeadline(overallDeadline, now, isLastStep = true, waterfallStartedAtMs),
+            localLlmStepDeadline(overallDeadline, now, isLastStep = true),
+        )
+    }
+
+    @Test fun `the terminal deadline can only widen, never shrink below the overall deadline`() {
+        // maxOf, not a plain replacement: if the overall deadline is ever further out than the
+        // terminal budget would allow (a caller with a longer cap, or a start anchor further in
+        // the past than the cap implies), the terminal step keeps the deadline it already had.
+        val waterfallStartedAtMs = 1_000_000L
+        val now = waterfallStartedAtMs + 100L
+        val generousOverallDeadline = waterfallStartedAtMs + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS + 30_000L
+
+        val deadline =
+            localLlmStepDeadline(generousOverallDeadline, now, isLastStep = true, waterfallStartedAtMs)
+
+        assertEquals(generousOverallDeadline, deadline)
+
+        // And the general property across a spread of start anchors: never below the overall deadline.
+        for (offsetMs in listOf(-60_000L, -12_000L, -8_000L, -1L, 0L, 5_000L)) {
+            val overallDeadline = waterfallStartedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS
+            val widened =
+                localLlmStepDeadline(overallDeadline, now, isLastStep = true, waterfallStartedAtMs + offsetMs)
+            assertTrue(
+                "terminal deadline must never shrink below the overall deadline (offset $offsetMs)",
+                widened >= overallDeadline,
+            )
+        }
+    }
+
+    @Test fun `a non-terminal local step is still bounded by the 4s budget so a cloud step survives`() {
+        // The #98 role of LOCAL_LLM_STEP_BUDGET_MS is untouched by #155: when a cloud step follows,
+        // a slow local attempt must abort with enough of the 8s cap left for that step to run.
+        val waterfallStartedAtMs = 1_000_000L
+        val overallDeadline = waterfallStartedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS
+        val now = waterfallStartedAtMs
+
+        val deadline = localLlmStepDeadline(overallDeadline, now, isLastStep = false, waterfallStartedAtMs)
+
+        assertEquals(now + LOCAL_LLM_STEP_BUDGET_MS, deadline)
+        assertTrue(
+            "a non-terminal local step must never reach the terminal budget",
+            deadline < waterfallStartedAtMs + TERMINAL_LOCAL_LLM_STEP_BUDGET_MS,
+        )
+        assertTrue(
+            "the following cloud step must still have budget left inside the hard cap",
+            overallDeadline - deadline >= CLEANUP_WATERFALL_HARD_CAP_MS - LOCAL_LLM_STEP_BUDGET_MS,
+        )
+    }
+
+    @Test fun `the 8003ms Pixel 10a completion now survives where the 8s cap killed it`() {
+        // Trevor's real failure: a healthy local cleanup finished its work in 8003ms and was
+        // aborted at the 8000ms hard cap, missing by 3ms. For a user with no cloud provider
+        // configured this is the only cleanup path, so that 3ms meant no cleanup at all.
+        val waterfallStartedAtMs = 1_000_000L
+        val overallDeadline = waterfallStartedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS
+        val observedCompletionAtMs = waterfallStartedAtMs + 8_003L
+
+        // The old behavior, spelled out: the terminal step got the overall deadline verbatim.
+        assertTrue(
+            "the 8003ms completion must have been aborted under the bare 8s cap",
+            observedCompletionAtMs > overallDeadline,
+        )
+
+        val deadline = localLlmStepDeadline(overallDeadline, waterfallStartedAtMs, isLastStep = true, waterfallStartedAtMs)
+        assertTrue(
+            "the 8003ms completion must now finish inside the terminal budget",
+            observedCompletionAtMs <= deadline,
+        )
+    }
+
+    /**
+     * #137 regression guard, deliberately living next to the #155 widening it must not follow.
+     *
+     * The 8s hard cap was tuned against 318 real cloud cleanups to stop a user with no local
+     * model waiting on unreachable hosts. #155 widens the *terminal on-device* step only. If a
+     * future change routes cloud steps through the wider terminal budget -- or relaxes the
+     * clamp -- this fails.
+     */
+    @Test fun `cloud steps are still clamped to the 8s hard cap, never the terminal local budget`() {
+        val start = 1_000_000L
+        val deadline = start + CLEANUP_WATERFALL_HARD_CAP_MS
+
+        // Full budget: the whole-call bound is the hard cap, not the wider terminal budget.
+        val fresh = cloudStepTimeouts(deadline, start)
+        assertEquals(CLEANUP_WATERFALL_HARD_CAP_MS, fresh.callMs)
+        assertNotEquals(TERMINAL_LOCAL_LLM_STEP_BUDGET_MS, fresh.callMs)
+
+        // Partly spent: still exactly what the waterfall has left, phases clamped with it.
+        val late = cloudStepTimeouts(deadline, deadline - 1_200L)
+        assertEquals(1_200L, late.callMs)
+        assertEquals(1_200L, late.connectMs)
+        assertEquals(1_200L, late.readMs)
+
+        // Spent: floors at MIN_STEP_CALL_BUDGET_MS rather than collapsing to OkHttp's infinite 0.
+        assertEquals(MIN_STEP_CALL_BUDGET_MS, cloudStepTimeouts(deadline, deadline + 5_000L).callMs)
+
+        // The invariant a widening would break: a cloud step can never outlive the hard cap,
+        // for every start that leaves at least the MIN_STEP_CALL_BUDGET_MS floor.
+        for (spentMs in listOf(0L, 1L, 2_500L, 7_750L)) {
+            val nowMs = start + spentMs
+            val t = cloudStepTimeouts(deadline, nowMs)
+            assertTrue(
+                "cloud step at +${spentMs}ms must not outlive the hard cap",
+                nowMs + t.callMs!! <= deadline,
+            )
+            assertTrue(
+                "cloud step budget must never reach the terminal local budget",
+                t.callMs!! < TERMINAL_LOCAL_LLM_STEP_BUDGET_MS,
+            )
+        }
+
+        // Below the floor the budget stops shrinking (0 would mean infinite in OkHttp), so the
+        // overshoot is bounded by MIN_STEP_CALL_BUDGET_MS and nothing else -- never by 12s.
+        val nearlySpent = cloudStepTimeouts(deadline, deadline - 1L)
+        assertEquals(MIN_STEP_CALL_BUDGET_MS, nearlySpent.callMs)
+        assertTrue(
+            "even the floored overshoot stays far inside the terminal local budget",
+            nearlySpent.callMs!! < TERMINAL_LOCAL_LLM_STEP_BUDGET_MS,
+        )
     }
 }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
@@ -1,0 +1,315 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression suite for [LocalCleanupOutputValidator] (#155).
+ *
+ * The four `REAL_` fixtures below are verbatim from the on-device reproduction posted to the
+ * issue: LFM2.5-350M-Q4_0, temp 0, two identical trials each, with and without a 22-term personal
+ * vocabulary clause interpolated into the system prompt. They are the reason this validator
+ * exists, so they are asserted as fixtures rather than paraphrased.
+ *
+ * The negative controls matter at least as much as the rejections: a false rejection only costs
+ * one fallback step, but a validator that rejects good output makes local cleanup useless. Every
+ * `is not rejected` test below is a shipped-behaviour guarantee, not a nicety.
+ *
+ * Mutation-proving: relax any threshold or delete any branch in the validator and the specific
+ * tests named in that branch's comment must fail. Evidence recorded in the #155 PR description.
+ */
+class LocalCleanupOutputValidatorTest {
+
+    // The prompt actually sent in the failing condition: SIMPLE_PROMPT with a 22-term clause.
+    private val vocabularyPrompt = LocalCleanupProvider.systemPromptFor(
+        LOCAL_CLEANUP_MODEL,
+        listOf(
+            "Nash-Keller", "Wyatt", "Terelle", "Ramblr", "FastHTML", "Selby", "Mobridge",
+            "Hermes", "Trinity", "sherpa-onnx", "llama.cpp",
+        ),
+    )
+
+    private val plainPrompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList())
+
+    private fun assertRejected(
+        expected: LocalCleanupValidation.Reason,
+        input: String,
+        output: String,
+        prompt: String = vocabularyPrompt,
+    ) {
+        val verdict = LocalCleanupOutputValidator.validate(input, prompt, output)
+        assertTrue(
+            "expected $expected but output was accepted: \"$output\"",
+            verdict is LocalCleanupValidation.Rejected,
+        )
+        assertEquals(expected, (verdict as LocalCleanupValidation.Rejected).reason)
+        assertTrue("a rejection must carry a diagnostic detail", verdict.detail.isNotBlank())
+    }
+
+    private fun assertAccepted(input: String, output: String, prompt: String = plainPrompt) {
+        val verdict = LocalCleanupOutputValidator.validate(input, prompt, output)
+        assertTrue(
+            "legitimate cleanup was rejected as ${(verdict as? LocalCleanupValidation.Rejected)?.reason}" +
+                " (${(verdict as? LocalCleanupValidation.Rejected)?.detail}): \"$output\"",
+            verdict is LocalCleanupValidation.Valid,
+        )
+    }
+
+    // --- the four real on-device failures ----------------------------------------------------
+
+    @Test fun `REAL wrong dollar amount from the vocabulary condition is rejected`() {
+        // "Send $450 ..." without the clause (correct) vs "Send $150 ..." with it. A validator
+        // that only checked for missing numbers would pass this: 150 IS a number, in a
+        // plausible-looking sentence. The value changed, which is the whole point.
+        assertRejected(
+            LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE,
+            "Send four hundred and fifty dollars to the account ending in nine three seven two",
+            "Send $150 to the account ending in ninethreeseventwo",
+        )
+    }
+
+    @Test fun `REAL deleted house number is rejected`() {
+        // "My address is four one two Selby Road" -> "Selby Road". Caught by the numeric check
+        // (412 vanished) before length collapse even gets a look; both would fire.
+        assertRejected(
+            LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE,
+            "My address is four one two Selby Road",
+            "Selby Road",
+        )
+    }
+
+    @Test fun `REAL system prompt echo is rejected`() {
+        // The worst failure of the three: this injects the user's own private vocabulary terms
+        // (emails, family names) into whatever app they were dictating into.
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "Call me at five five five one two three four",
+            "Watch for these project names and personal vocabulary terms, which speech-to-text " +
+                "often mishears: Nash-Keller, Wyatt, Terelle, Ramblr, FastHTML, Selby, Mobridge.",
+        )
+    }
+
+    @Test fun `REAL control that worked in both conditions is still accepted`() {
+        // "Transfer twelve thousand five hundred dollars tomorrow" -> "Transfer $12,500" was
+        // correct WITH and WITHOUT the vocabulary clause. If the validator rejects this, it is
+        // rejecting the model's good days too.
+        assertAccepted(
+            "Transfer twelve thousand five hundred dollars tomorrow",
+            "Transfer $12,500 tomorrow.",
+            prompt = vocabularyPrompt,
+        )
+    }
+
+    @Test fun `REAL correct output for the wrong-amount case is accepted`() {
+        // The no-clause result for the same input the model got wrong above.
+        assertAccepted(
+            "Send four hundred and fifty dollars to the account ending in nine three seven two",
+            "Send $450 to the account ending in nine three seven two.",
+        )
+    }
+
+    // --- (a) prompt echo ---------------------------------------------------------------------
+    // Mutation: delete checkPromptEcho, or raise PROMPT_ECHO_MIN_SPAN above the fixture overlap.
+
+    @Test fun `a verbatim slab of the system prompt is rejected`() {
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "hello there this is a test of the dictation feature",
+            PostProcessor.SIMPLE_PROMPT.take(160),
+            prompt = plainPrompt,
+        )
+    }
+
+    @Test fun `echo detection works for a prompt the validator has never seen`() {
+        // Derived from the systemPrompt argument, not matched against known wording -- so a
+        // reworded prompt, a fine-tuned model's own prompt, or a future prompt all still work.
+        val invented = "Du bist ein Werkzeug zur Bereinigung von Transkripten und gibst " +
+            "ausschliesslich den bereinigten Text zurueck, ohne Erklaerungen."
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "guten morgen wie geht es dir heute",
+            invented,
+            prompt = invented,
+        )
+    }
+
+    @Test fun `the fine-tuned model's own prompt is echo-checked too`() {
+        val model = LOCAL_CLEANUP_MODEL_CATALOG.first { it.localSystemPrompt != null }
+        val prompt = LocalCleanupProvider.systemPromptFor(model, listOf("Ramblr"))
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "so anyway I was thinking we should ship it on Friday",
+            prompt,
+            prompt = prompt,
+        )
+    }
+
+    @Test fun `a short incidental overlap with the prompt is not an echo`() {
+        // "obvious speech-to-text errors" is a real substring of SIMPLE_PROMPT (29 normalized
+        // chars) and someone can legitimately dictate it. Must stay under the threshold.
+        assertAccepted(
+            "we should fix the obvious speech-to-text errors in this transcript first",
+            "We should fix the obvious speech-to-text errors in this transcript first.",
+        )
+    }
+
+    @Test fun `words the speaker actually dictated are not treated as an echo`() {
+        // Someone dictating the prompt itself should get it cleaned up, not rejected: the span
+        // is explained by the input, so it contributes no evidence of regurgitation.
+        val spoken = PostProcessor.SIMPLE_PROMPT.take(180)
+        assertAccepted(spoken, spoken)
+    }
+
+    // --- (b) numeric divergence --------------------------------------------------------------
+    // Mutation: delete checkNumericDivergence, or make wordRunCandidates return every part value.
+
+    @Test fun `spoken numerals converting to digits is accepted, not flagged`() {
+        assertAccepted("I need four hundred and fifty widgets", "I need 450 widgets.")
+        assertAccepted("that will be twelve thousand five hundred", "That will be 12,500.")
+        assertAccepted("call extension two five", "Call extension 25.")
+    }
+
+    @Test fun `a digit-by-digit sequence may be joined or kept apart`() {
+        val input = "the code is nine three seven two"
+        assertAccepted(input, "The code is 9372.")
+        assertAccepted(input, "The code is nine three seven two.")
+        assertAccepted(input, "The code is 9 3 7 2.")
+    }
+
+    @Test fun `a changed digit value is rejected`() {
+        assertRejected(
+            LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE,
+            "the code is nine three seven two and the balance is 450 dollars",
+            "The code is 9372 and the balance is $460.",
+        )
+    }
+
+    @Test fun `a vanished number is rejected`() {
+        assertRejected(
+            LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE,
+            "please transfer 4500 dollars into the joint account before Friday afternoon",
+            "Please transfer money into the joint account before Friday afternoon.",
+        )
+    }
+
+    @Test fun `comma grouping and currency symbols compare equal to the plain digits`() {
+        assertAccepted(
+            "the invoice total came to 12500 dollars this quarter",
+            "The invoice total came to $12,500 this quarter.",
+        )
+    }
+
+    @Test fun `digits already present in the input must survive verbatim`() {
+        assertAccepted("meet me at 7 on the 15th of March", "Meet me at 7 on the 15th of March.")
+    }
+
+    @Test fun `a bare one is not guarded because it is usually an article`() {
+        // "one of the things" losing its "one" to a rewrite must not be a rejection.
+        assertAccepted(
+            "so one of the things I wanted to mention about the release",
+            "One of the things I wanted to mention about the release.",
+        )
+        assertAccepted(
+            "so one of the things I wanted to mention about the release",
+            "I wanted to mention something about the release, among other things.",
+        )
+    }
+
+    @Test fun `a number with no numbers in the input is never a divergence`() {
+        assertAccepted(
+            "there are no numbers whatsoever in this particular sentence",
+            "There are no numbers whatsoever in this particular sentence.",
+        )
+    }
+
+    @Test fun `leading zeros do not create a false divergence`() {
+        assertAccepted("the room is oh four two", "The room is 042.")
+    }
+
+    // --- (c) length collapse -----------------------------------------------------------------
+    // Mutation: delete checkLengthCollapse, or lower LENGTH_COLLAPSE_MIN_RATIO below 0.36.
+
+    @Test fun `content dropped to a fragment is rejected as a collapse`() {
+        // No numbers involved, so this can only be caught by the length check.
+        assertRejected(
+            LocalCleanupValidation.Reason.LENGTH_COLLAPSE,
+            "My address is the big white house on Selby Road just past the roundabout",
+            "Selby Road",
+        )
+    }
+
+    @Test fun `filler-word removal is not a collapse`() {
+        assertAccepted(
+            "um so like I was basically uh thinking that we should you know actually ship it",
+            "I was thinking that we should ship it.",
+        )
+    }
+
+    @Test fun `heavy but legitimate disfluency cleanup is not a collapse`() {
+        assertAccepted(
+            "uh um so I I I mean the the thing is um we need to uh get the release out",
+            "The thing is, we need to get the release out.",
+        )
+    }
+
+    @Test fun `a short utterance is exempt from the length check`() {
+        // Too little signal to judge; short inputs are where ratios are noisiest.
+        assertAccepted("um yeah okay sure", "Yeah.")
+    }
+
+    @Test fun `an expanded output is never a collapse`() {
+        assertAccepted("gonna ship it", "I am going to ship it tomorrow morning.")
+    }
+
+    // --- ordinary cleanup, the overwhelmingly common case ------------------------------------
+
+    @Test fun `punctuation and capitalization cleanup is accepted`() {
+        assertAccepted(
+            "hey can you send me the report when you get a chance thanks",
+            "Hey, can you send me the report when you get a chance? Thanks.",
+        )
+    }
+
+    @Test fun `identical passthrough output is accepted`() {
+        val text = "The quarterly report is ready for review whenever you have a moment."
+        assertAccepted(text, text)
+    }
+
+    @Test fun `output is accepted under the vocabulary-clause prompt too`() {
+        // The failing condition's prompt must not by itself make good output unacceptable.
+        assertAccepted(
+            "hey can you send me the report when you get a chance thanks",
+            "Hey, can you send me the report when you get a chance? Thanks.",
+            prompt = vocabularyPrompt,
+        )
+    }
+
+    @Test fun `blank output is left to the caller's own empty-response handling`() {
+        assertTrue(
+            LocalCleanupOutputValidator.validate("some input here", plainPrompt, "   ")
+                is LocalCleanupValidation.Valid,
+        )
+    }
+
+    @Test fun `the thresholds keep real headroom on both sides of the length check`() {
+        // Documents the numbers the constant's kdoc cites, so a future retune has to face them.
+        val collapseRatio = ratio("My address is four one two Selby Road", "Selby Road")
+        val controlRatio = ratio(
+            "Transfer twelve thousand five hundred dollars tomorrow",
+            "Transfer $12,500",
+        )
+        assertTrue(
+            "the rejected collapse ($collapseRatio) must sit below the threshold",
+            collapseRatio < LocalCleanupOutputValidator.LENGTH_COLLAPSE_MIN_RATIO,
+        )
+        assertTrue(
+            "the accepted control ($controlRatio) must sit above the threshold",
+            controlRatio > LocalCleanupOutputValidator.LENGTH_COLLAPSE_MIN_RATIO,
+        )
+    }
+
+    private fun ratio(input: String, output: String): Double =
+        LocalCleanupOutputValidator.normalizeForLength(output).length.toDouble() /
+            LocalCleanupOutputValidator.normalizeForLength(input).length
+}


### PR DESCRIPTION
## What

Two independent hardening changes to the local cleanup path:

1. **`LocalCleanupOutputValidator`** — validates a local model's output before it is accepted as a
   cleaned transcript, so a small model that echoes its prompt, returns an empty/garbage response,
   or produces obvious non-transcript text can't silently replace the user's words.
2. **A terminal local cleanup step gets its own wall-clock budget** (`TERMINAL_LOCAL_LLM_STEP_BUDGET_MS = 12s`).
   The 4s per-step budget exists to protect a *subsequent* fallback step. When the local step is
   last in the waterfall there is no such step to protect, so the tight budget only converts a
   slow-but-healthy completion into an outright failure. Trevor hit exactly that on a Pixel 10a: a
   local cleanup finished in 8003ms and was killed at 8000ms, missing by 3ms. For a user with no
   cloud provider configured, local cleanup is the only cleanup path.

## What changed since the first revision

This PR **originally also capped the personal vocabulary to 6 terms for small models**. That has
been dropped, and its stated justification retracted, because the measurement behind it was wrong.

Re-measured against the real `lfm2.5-350m-q4_0` with the real production prompts:

| claim in the original revision | measured reality |
|---|---|
| prompt grows "364 → 702 tokens" | those are **character** counts; tokenized it is **100 → 212** |
| "2145 t/s short vs 391 t/s with 22 terms" | warmup artifact of an uncontrolled first run |
| vocabulary is the latency problem | vocabulary costs **~15ms** of prompt eval |

Controlled A/B, alternating short/long, first rep discarded:

```
rep1 short  prompt_tokens=100  eval=62.73 ms  1594.08 t/s
rep1 long   prompt_tokens=212  eval=77.63 ms  2730.87 t/s
rep2 short  prompt_tokens=100  eval=63.21 ms  1582.08 t/s
rep2 long   prompt_tokens=212  eval=75.77 ms  2797.87 t/s
rep3 short  prompt_tokens=100  eval=56.13 ms  1781.45 t/s
rep3 long   prompt_tokens=212  eval=87.18 ms  2431.72 t/s
```

The 22-term prompt evaluates *faster per token* than the short one, because the larger batch uses
the CPU better. Capping the vocabulary would have silently discarded 16 of a user's 22 terms to
buy ~15ms of an 8000ms budget — a functionality regression paid for with a measurement error.

The longest real dictation in the on-device quality log completes end to end in **444ms**
(88ms prompt eval / 285 tokens, 333ms generation / 51 tokens), nowhere near the 8s budget.

## The actual root cause (follow-up, not in this PR)

`LLMInference::startCompletion` calls `llama_memory_clear()` on every completion, so the system
prompt is re-evaluated from scratch on every dictation instead of reusing its cached prefix. That
is the real avoidable cost, and unlike a cap it *scales with* vocabulary size instead of fighting
it. Tracked separately.

Full measurements and repro commands: `.hermes/plans/2026-08-18-local-cleanup-latency-measured.md`

## Verification

`:app:testGithubDebugUnitTest --rerun-tasks`, counted from JUnit XML rather than Gradle's summary:
**134 suites / 1237 tests / 0 failures / 0 errors / 0 skipped**.

Refs #155
