### PR TITLE
Type-to-fix: clean up selected text via the text-selection menu (#157 Option B)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -83,6 +83,21 @@ Ramblr uses Android Accessibility Service only to identify the currently focused
 
 Ramblr is not designed to monitor browsing, collect screen content for analytics, or perform background automation.
 
+## Text-selection menu ("Clean up with Ramblr")
+
+Ramblr registers an entry in Android's text-selection menu (the Copy/Paste/Share popup). It is
+invoked only when you select text yourself and then tap Ramblr in that menu; Android hands the
+selected text to Ramblr at that moment and at no other time. This entry point does not use the
+Accessibility Service at all and works whether or not the service is enabled — nothing above
+changes.
+
+The selected text is then treated exactly like a dictated transcript: it runs through the same
+cleanup providers you have configured, so if that configuration includes a cloud provider, the
+selected text is sent to that provider (turn "Use cloud for Cleanup" off to keep cleanup
+on-device). The cleaned result is placed on your clipboard and returned to the app you selected
+the text in; if that app reports the field as read-only, Ramblr copies the result to the
+clipboard and tells you, rather than changing anything.
+
 ## Data collection
 
 I do not run a backend for Ramblr and do not collect user accounts, analytics, or uploaded recordings myself.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,39 @@
         <activity android:name=".DataLogsActivity" android:exported="false"
             android:configChanges="screenLayout|smallestScreenSize|screenSize|orientation|keyboardHidden|uiMode" />
 
+        <!-- "Type to fix" selection-menu entry point (#157 Option B): the user selects text in
+             any app, taps Ramblr in the Copy/Paste popup, picks a style, and the cleaned text is
+             returned to the host for replacement (or copied to the clipboard when the host says
+             the field is read-only).
+
+             Necessarily exported="true" — the platform's text-selection menu is what starts it,
+             and it is only reachable through that explicit user gesture with the selection the
+             user made. It is the first newly-exported Activity since MainActivity; every other
+             Activity here stays exported="false".
+
+             Deliberately NOT accessibility-backed: this Activity never touches
+             WhisperAccessibilityService, which is the whole point of choosing this option in #157
+             (the service's onAccessibilityEvent stays empty, so PRIVACY.md's claims stay true).
+
+             android:label is what the selection menu shows, so it is the app name rather than a
+             verb; excludeFromRecents/noHistory keep a one-shot dialog out of the recents list.
+             configChanges mirrors the Settings Activities' Pixel Fold handling so an in-flight
+             cleanup dialog survives a fold/unfold instead of being destroyed mid-call. -->
+        <activity
+            android:name=".ProcessTextActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.PhoneWhisper.Transparent"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:configChanges="screenLayout|smallestScreenSize|screenSize|orientation|keyboardHidden|uiMode">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".WhisperAccessibilityService"
             android:exported="false"

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
@@ -1,0 +1,282 @@
+package com.trevornk.ramblr
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import java.util.concurrent.Executors
+
+/**
+ * "Type to fix" entry point (#157, Option B): the user selects text in any app, taps **Ramblr**
+ * in Android's text-selection menu, picks a style, and gets the cleaned text back in place.
+ *
+ * This is deliberately a plain, self-contained Activity with **no accessibility involvement at
+ * all**: [WhisperAccessibilityService] is not modified, not consulted, and does not even have to
+ * be enabled for this to work. `onAccessibilityEvent` stays empty, which is the load-bearing
+ * sentence of Ramblr's privacy posture (`PRIVACY.md`) — #157 rejects the inline-typed-trigger
+ * option precisely because it would delete it.
+ *
+ * Running the real cleanup pipeline from here needs no service refactor: [PostProcessor
+ * .processProviderChain], [ProviderChainStore], [CloudFeatureToggle], [PersonaRegistry] and
+ * [LocalCleanupModelHolder] are all `Context`-scoped, so this Activity assembles the same
+ * chain/waterfall/persona inputs [WhisperAccessibilityService]'s dictation call site assembles
+ * and calls the identical entry point. The pure parts of that assembly live in
+ * [ProcessTextRequest.kt] so they are unit-testable without Robolectric.
+ *
+ * Threading: the cleanup call is issued from [worker], never the main thread — the LOCAL_LLM step
+ * is synchronous on-device inference, and [CleanupWaterfallExecutor]'s cloud steps block on
+ * OkHttp. Every result is posted back to [handler] and dropped if the Activity is already gone
+ * (see [deliver]).
+ *
+ * Local-model contention with a concurrent dictation is safe by construction rather than by luck:
+ * [LocalCleanupModelHolder.withInference] is `@Synchronized` on a process-scoped singleton and
+ * checks [LocalCleanupModelSlot.needsReload] *inside* that monitor, so two callers can never
+ * double-load the model, and [RealLocalInferenceEngine] runs it through
+ * [BoundedBlockingCall.runWithDeadline] on one shared single-thread executor with a wall-clock
+ * deadline. A local step that loses the race therefore times out and falls through to the next
+ * waterfall step (or fails cleanly) instead of deadlocking.
+ */
+class ProcessTextActivity : Activity() {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val worker = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "process-text-cleanup").apply { isDaemon = true }
+    }
+    private val inFlightCall = InFlightCall()
+
+    /** Fresh per Activity instance, so a selection-menu cleanup never resumes at a step index
+     *  recorded for a different chain by a previous invocation. */
+    private val cursor = CleanupWaterfallCursor()
+
+    private var pickerDialog: android.app.AlertDialog? = null
+    private var progressDialog: android.app.AlertDialog? = null
+
+    /** Set once the user backs out or the Activity is destroyed: a callback that arrives after
+     *  this must not touch the window, or it leaks/crashes on a dead Activity. */
+    @Volatile private var abandoned = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (intent?.action != Intent.ACTION_PROCESS_TEXT) {
+            Log.w(TAG, "Started with unexpected action=${intent?.action}; finishing")
+            finish()
+            return
+        }
+
+        val parse = ProcessTextIntent.parse(
+            rawText = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT),
+            readOnly = intent.getBooleanExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, false),
+        )
+        val request = when (parse) {
+            is ProcessTextParse.EmptySelection -> {
+                Log.i(TAG, "Empty selection; nothing to clean up")
+                return failAndFinish("Nothing selected to clean up")
+            }
+            is ProcessTextParse.TooLong -> {
+                Log.i(TAG, "Selection of ${parse.length} chars exceeds limit ${parse.limit}")
+                return failAndFinish("Selection too long (${parse.length} characters, limit ${parse.limit})")
+            }
+            is ProcessTextParse.Accepted -> parse.request
+        }
+
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = ProviderChainStore.load(this),
+            cloudCleanupEnabled = CloudFeatureToggle.cleanupEnabled(this),
+            allowLocalFallback = DictationModeToggle.allowLocalFallback(this),
+            isCredentialConfigured = { kind -> ProviderCredentialStore.get(this, kind).isNotBlank() },
+        )
+        val ready = when (plan) {
+            is ProcessTextCleanupPlan.Unavailable -> {
+                Log.i(TAG, "Cleanup unavailable for selection: ${plan.reason}")
+                return failAndFinish(messageFor(plan.reason))
+            }
+            is ProcessTextCleanupPlan.Ready -> plan
+        }
+
+        showPersonaPicker(request, ready)
+    }
+
+    private fun messageFor(reason: ProcessTextUnavailableReason): String = when (reason) {
+        ProcessTextUnavailableReason.CLOUD_CLEANUP_DISABLED ->
+            "Cloud cleanup is turned off and no on-device cleanup model is configured"
+        ProcessTextUnavailableReason.NO_CLEANUP_CONFIGURED ->
+            "No cleanup provider is configured — set one up in Ramblr"
+        ProcessTextUnavailableReason.MISSING_OPENAI_KEY ->
+            "Cleanup needs an OpenAI API key"
+    }
+
+    private fun showPersonaPicker(request: ProcessTextRequest, plan: ProcessTextCleanupPlan.Ready) {
+        val personas = PersonaRegistry.all(this)
+        if (personas.isEmpty()) {
+            // Defensive only: BUILT_IN is non-empty by construction, so this cannot happen today.
+            return failAndFinish("No cleanup styles available")
+        }
+        val current = PersonaRegistry.currentPersona(
+            this,
+            prefs().getString(KEY_CLEANUP_STYLE, null),
+            prefs().getString(KEY_POST_PROCESSING_PROMPT, PostProcessor.DEFAULT_PROMPT) ?: PostProcessor.DEFAULT_PROMPT,
+        )
+        val checked = personas.indexOfFirst { it.key == current.key }.takeIf { it >= 0 } ?: 0
+
+        pickerDialog = android.app.AlertDialog.Builder(this)
+            .setTitle("Clean up with")
+            .setSingleChoiceItems(personas.map { it.title }.toTypedArray(), checked) { dialog, which ->
+                dialog.dismiss()
+                startCleanup(request, plan, personas[which])
+            }
+            .setNegativeButton("Cancel") { _, _ -> cancelAndFinish() }
+            .setOnCancelListener { cancelAndFinish() }
+            .show()
+    }
+
+    private fun startCleanup(
+        request: ProcessTextRequest,
+        plan: ProcessTextCleanupPlan.Ready,
+        persona: CleanupPersona,
+    ) {
+        val vocabulary = VocabularyTerms.parse(
+            prefs().getString(KEY_VOCABULARY_TERMS, VocabularyTerms.DEFAULT_SERIALIZED)
+        )
+        // An explicit pick in the dialog above is an explicit selection, so the persona's own
+        // prompt is used verbatim -- the same contract as the overlay's quick style menu.
+        val prompt = PostProcessor.interpolateVocabulary(
+            CleanupPersonas.promptForExplicitSelection(persona),
+            vocabulary,
+        )
+        val localModel = LocalCleanupProvider.selectedModel(this)
+        val localPrompt = LocalCleanupProvider.selectedSystemPrompt(this, vocabulary)
+        val localModelPath = ModelDownloader.localCleanupModelFile(this, localModel)?.absolutePath
+
+        progressDialog = android.app.AlertDialog.Builder(this)
+            .setTitle("Cleaning up…")
+            .setMessage("Ramblr is cleaning up ${request.text.length} characters.")
+            .setNegativeButton("Cancel") { _, _ -> cancelAndFinish() }
+            .setOnCancelListener { cancelAndFinish() }
+            .show()
+
+        Log.i(
+            TAG,
+            "Selection cleanup starting: chars=${request.text.length} readOnly=${request.readOnly} " +
+                "persona=${persona.key} steps=${plan.waterfall.steps.map { it.group }}",
+        )
+
+        worker.execute {
+            try {
+                PostProcessor.processProviderChain(
+                    text = request.text,
+                    prompt = prompt,
+                    chain = plan.chain,
+                    cursor = cursor,
+                    cancelHolder = inFlightCall,
+                    credentialLookup = { kind -> ProviderCredentialStore.get(this, kind) },
+                    localModelPath = { localModelPath },
+                    localPrompt = localPrompt,
+                    // Deliberately no benchmarkContext/correlationId: BenchmarkLogger and
+                    // QualityLogger exist to correlate a cleanup stage with the transcription
+                    // stage of the same dictation (#100/#105), and a selection-menu cleanup has
+                    // no transcription stage. QualityLogger additionally persists the actual text,
+                    // and text selected out of some other app is not this app's to record.
+                ) { result ->
+                    deliver(request, processTextOutcome(result.text, result.error))
+                }
+            } catch (t: Throwable) {
+                // processProviderChain's own steps report failures through the callback; anything
+                // escaping here is a programming/native error that would otherwise leave the
+                // Activity showing a spinner forever.
+                Log.e(TAG, "Selection cleanup threw", t)
+                deliver(request, ProcessTextOutcome.Failed(t.message ?: t.javaClass.simpleName))
+            }
+        }
+    }
+
+    private fun deliver(request: ProcessTextRequest, outcome: ProcessTextOutcome) {
+        handler.post {
+            if (abandoned || isFinishing || isDestroyed) {
+                Log.i(TAG, "Dropping cleanup result: activity already gone")
+                return@post
+            }
+            dismissDialogs()
+            when (outcome) {
+                is ProcessTextOutcome.Failed -> {
+                    Log.w(TAG, "Selection cleanup failed: ${outcome.reason}")
+                    failAndFinish("Cleanup failed (${outcome.reason})")
+                }
+                is ProcessTextOutcome.Cleaned -> {
+                    // Always copy first, matching the dictation path's copy-then-write order
+                    // (WhisperAccessibilityService.injectText). It is what makes the honest
+                    // fallback work for a host that accepts the selection but then ignores our
+                    // RESULT_OK: the cleaned text is already on the clipboard rather than lost.
+                    // #157 explicitly rules out SwiftSlate's alternative (a TTL handoff to the
+                    // accessibility service watching for the host's text-changed event), because
+                    // that re-introduces the entire privacy cost this option exists to avoid.
+                    ClipboardUtil.copy(this, outcome.text)
+                    when (deliveryFor(request.readOnly)) {
+                        ProcessTextDelivery.CLIPBOARD_ONLY -> {
+                            Log.i(TAG, "Read-only host: returning no replacement, ${outcome.text.length} chars copied")
+                            toast("Read-only field — cleaned text copied to clipboard")
+                            setResult(RESULT_CANCELED)
+                        }
+                        ProcessTextDelivery.REPLACE_IN_HOST -> {
+                            Log.i(TAG, "Returning cleaned selection: ${outcome.text.length} chars")
+                            setResult(
+                                RESULT_OK,
+                                Intent().putExtra(Intent.EXTRA_PROCESS_TEXT, outcome.text),
+                            )
+                        }
+                    }
+                    finish()
+                }
+            }
+        }
+    }
+
+    /** User dismissed the picker or the spinner: abort any in-flight provider call (a paid step
+     *  must never keep running after a cancel, #63) and return nothing to the host. */
+    private fun cancelAndFinish() {
+        abandoned = true
+        inFlightCall.cancel()
+        dismissDialogs()
+        setResult(RESULT_CANCELED)
+        finish()
+    }
+
+    private fun failAndFinish(message: String) {
+        toast(message)
+        setResult(RESULT_CANCELED)
+        finish()
+    }
+
+    private fun dismissDialogs() {
+        pickerDialog?.takeIf { it.isShowing }?.dismiss()
+        pickerDialog = null
+        progressDialog?.takeIf { it.isShowing }?.dismiss()
+        progressDialog = null
+    }
+
+    override fun onDestroy() {
+        abandoned = true
+        inFlightCall.cancel()
+        dismissDialogs()
+        handler.removeCallbacksAndMessages(null)
+        // The worker is not awaited: an abandoned local-inference call is already bounded by
+        // BoundedBlockingCall's deadline, and shutdown() lets the thread die once it drains.
+        worker.shutdown()
+        super.onDestroy()
+    }
+
+    private fun prefs() = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+
+    private fun toast(message: String) = Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+
+    private companion object {
+        const val TAG = "ProcessTextActivity"
+        const val PREFS_NAME = "ramblr"
+        const val KEY_CLEANUP_STYLE = "cleanup_style"
+        const val KEY_POST_PROCESSING_PROMPT = "post_processing_prompt"
+        const val KEY_VOCABULARY_TERMS = "custom_vocabulary_terms"
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextRequest.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextRequest.kt
@@ -1,0 +1,165 @@
+package com.trevornk.ramblr
+
+/**
+ * Context-free parsing and decision logic behind [ProcessTextActivity] (#157 Option B: clean up
+ * selected text from Android's text-selection menu via `ACTION_PROCESS_TEXT`).
+ *
+ * Everything here is a pure function over plain values, deliberately kept out of the Activity:
+ * this module has no Robolectric and `android.util.Log` is unmocked in plain-JVM tests, so
+ * anything that touches a framework class cannot be unit-tested at all. The same split the rest
+ * of the codebase already uses ([LocalCleanupProvider.systemPromptFor] vs. its Context wrapper,
+ * [CleanupWaterfallCursor] vs. its Android-owned reset triggers) applies here.
+ */
+
+/** A validated, non-blank selection handed to the Activity by [ProcessTextIntent.parse]. */
+data class ProcessTextRequest(
+    val text: String,
+    /** Mirrors `Intent.EXTRA_PROCESS_TEXT_READONLY`: the host is telling us it will ignore any
+     *  replacement we return, so the only honest delivery is the clipboard (see
+     *  [ProcessTextDelivery]). */
+    val readOnly: Boolean,
+)
+
+/** Outcome of reading the incoming `ACTION_PROCESS_TEXT` extras. */
+sealed class ProcessTextParse {
+    data class Accepted(val request: ProcessTextRequest) : ProcessTextParse()
+
+    /** No selection worth cleaning: the extra was absent, empty, or whitespace only. */
+    object EmptySelection : ProcessTextParse()
+
+    /** Selection past [ProcessTextIntent.MAX_SELECTION_CHARS]. */
+    data class TooLong(val length: Int, val limit: Int) : ProcessTextParse()
+}
+
+object ProcessTextIntent {
+    /**
+     * Upper bound on a selection this entry point will accept.
+     *
+     * Two independent reasons, either of which alone justifies a cap: (1) the cleaned string
+     * travels back to the host inside an Intent extra, and an oversized parcel is a
+     * `TransactionTooLargeException` in the *host's* process, not a catchable failure in ours;
+     * (2) [CLEANUP_WATERFALL_HARD_CAP_MS] is an 8s budget sized for a dictation-length
+     * transcript, so a book-length selection cannot complete anyway and would just burn paid
+     * cloud tokens before timing out. 20k characters is far above any realistic hand-selection
+     * and far below the binder limit.
+     */
+    const val MAX_SELECTION_CHARS = 20_000
+
+    /**
+     * Validates the incoming extras. [rawText] is `Intent.EXTRA_PROCESS_TEXT` (a `CharSequence`,
+     * possibly styled — the style is dropped deliberately, since the cleanup providers take and
+     * return plain text and re-applying spans to rewritten text is not well defined).
+     *
+     * The accepted text is trimmed: hosts routinely include the trailing space or newline the
+     * selection handle snapped to, and sending it to a model adds nothing.
+     */
+    fun parse(rawText: CharSequence?, readOnly: Boolean): ProcessTextParse {
+        val text = rawText?.toString()?.trim().orEmpty()
+        if (text.isEmpty()) return ProcessTextParse.EmptySelection
+        if (text.length > MAX_SELECTION_CHARS) {
+            return ProcessTextParse.TooLong(text.length, MAX_SELECTION_CHARS)
+        }
+        return ProcessTextParse.Accepted(ProcessTextRequest(text, readOnly))
+    }
+}
+
+/** How a cleaned result can be handed back to the user. */
+enum class ProcessTextDelivery {
+    /** Return it as `Intent.EXTRA_PROCESS_TEXT` with `RESULT_OK`; the host performs the replacement. */
+    REPLACE_IN_HOST,
+
+    /**
+     * Copy it to the clipboard and say so. Used when the host declared the field read-only, where
+     * returning a result is silently discarded.
+     *
+     * Note this is also the *fallback* for hosts that accept a non-read-only selection but then
+     * ignore `setResult` anyway: the Activity always copies before returning, so those hosts
+     * degrade to "it's on your clipboard" instead of losing the work. SwiftSlate solves that case
+     * with a TTL handoff to its accessibility service; #157 explicitly rejects that design,
+     * because watching for the host's text-changed event re-introduces the whole Option A privacy
+     * cost that this option exists to avoid.
+     */
+    CLIPBOARD_ONLY,
+}
+
+/** The read-only decision, isolated so it is testable and cannot drift into a silent no-op. */
+fun deliveryFor(readOnly: Boolean): ProcessTextDelivery =
+    if (readOnly) ProcessTextDelivery.CLIPBOARD_ONLY else ProcessTextDelivery.REPLACE_IN_HOST
+
+/** Why a selection cannot be cleaned up with the user's current provider configuration. */
+enum class ProcessTextUnavailableReason {
+    /** The chain has cleanup-capable cloud entries, but "Use cloud for Cleanup" is off and the
+     *  chain has no LOCAL entry to fall back to. Actionable: the user can flip the toggle. */
+    CLOUD_CLEANUP_DISABLED,
+
+    /** The chain has no executable cleanup step at all, toggle or no toggle. */
+    NO_CLEANUP_CONFIGURED,
+
+    /** A single-OpenAI chain with no key: there is no second step to fall through to, so this is
+     *  worth failing fast on before making a network call that can only fail. Mirrors
+     *  [WhisperAccessibilityService]'s identical pre-flight on the dictation path. */
+    MISSING_OPENAI_KEY,
+}
+
+sealed class ProcessTextCleanupPlan {
+    data class Ready(val chain: ProviderChain, val waterfall: CleanupWaterfall) : ProcessTextCleanupPlan()
+    data class Unavailable(val reason: ProcessTextUnavailableReason) : ProcessTextCleanupPlan()
+}
+
+/**
+ * Resolves which providers a selection-menu cleanup may use, applying exactly the same gates the
+ * dictation path applies at `WhisperAccessibilityService.handleTranscriptionResult`.
+ *
+ * The [CloudFeatureToggle] gate matters more here than it does for dictation (#157): the
+ * selection menu is a far cheaper gesture than speaking, so it can reach paid providers many more
+ * times per day. Honouring the existing toggle rather than inventing a second one means a user
+ * who has already said "no cloud for cleanup" is not silently opted back in by a new entry point.
+ */
+object ProcessTextCleanupPlanner {
+    fun plan(
+        chain: ProviderChain,
+        cloudCleanupEnabled: Boolean,
+        allowLocalFallback: Boolean,
+        isCredentialConfigured: (ProviderKind) -> Boolean,
+    ): ProcessTextCleanupPlan {
+        val effective = ProviderChainRuntime.effectiveChainForCleanup(chain, cloudCleanupEnabled, allowLocalFallback)
+        val waterfall = ProviderChainRuntime.cleanupWaterfallFor(effective)
+        if (waterfall.steps.isEmpty()) {
+            val cloudGateIsTheCause = !cloudCleanupEnabled &&
+                ProviderChainRuntime.cleanupWaterfallFor(chain).steps.isNotEmpty()
+            return ProcessTextCleanupPlan.Unavailable(
+                if (cloudGateIsTheCause) {
+                    ProcessTextUnavailableReason.CLOUD_CLEANUP_DISABLED
+                } else {
+                    ProcessTextUnavailableReason.NO_CLEANUP_CONFIGURED
+                }
+            )
+        }
+        if (!ProviderChainRuntime.shouldUseCleanupExecutor(effective) && !isCredentialConfigured(ProviderKind.OPENAI)) {
+            return ProcessTextCleanupPlan.Unavailable(ProcessTextUnavailableReason.MISSING_OPENAI_KEY)
+        }
+        return ProcessTextCleanupPlan.Ready(effective, waterfall)
+    }
+}
+
+/** What to do with a finished [PostProcessor.Result]. */
+sealed class ProcessTextOutcome {
+    data class Cleaned(val text: String) : ProcessTextOutcome()
+
+    /**
+     * Cleanup produced nothing usable. Unlike dictation — where injecting the raw transcript is
+     * strictly better than injecting nothing, because the user's speech would otherwise be lost —
+     * the selected text is still sitting in the host field, so writing it back unchanged would be
+     * an invisible no-op that reads as "Ramblr did nothing". [reason] carries the provider's own
+     * error so the failure is diagnosable instead of a generic "cleanup failed" (#98).
+     */
+    data class Failed(val reason: String) : ProcessTextOutcome()
+}
+
+/** Maps a [PostProcessor.Result]'s two nullable fields onto one exhaustive outcome. */
+fun processTextOutcome(cleanedText: String?, error: String?): ProcessTextOutcome =
+    if (cleanedText != null && cleanedText.isNotBlank()) {
+        ProcessTextOutcome.Cleaned(cleanedText)
+    } else {
+        ProcessTextOutcome.Failed(error?.takeIf { it.isNotBlank() } ?: "unknown error")
+    }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -25,4 +25,19 @@
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
+
+    <!-- ProcessTextActivity (#157): a dialog-only surface launched over whatever app the user
+         selected text in. It renders no content of its own, so the window itself must be
+         floating/transparent with no background dim beyond the dialog's own — otherwise the
+         selection-menu tap flashes a full-screen empty Activity over the host app before the
+         style picker appears. Inherits the app theme so the dialogs pick up the same Material3
+         colours as the Settings screens. -->
+    <style name="Theme.PhoneWhisper.Transparent" parent="Theme.PhoneWhisper">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
 </resources>

--- a/app/src/test/kotlin/com/trevornk/ramblr/ProcessTextRequestTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ProcessTextRequestTest.kt
@@ -1,0 +1,223 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the context-free logic behind [ProcessTextActivity] (#157 Option B): intent-extra
+ * parsing, the read-only/clipboard fallback decision, the cloud/credential gating decision, and
+ * the result mapping. The Activity itself is untestable here (no Robolectric in this module, and
+ * `android.util.Log` is unmocked in plain JVM tests), which is exactly why this logic lives
+ * outside it.
+ */
+class ProcessTextRequestTest {
+
+    // --- Intent extra parsing ---
+
+    @Test fun `a normal selection is accepted and trimmed`() {
+        val parse = ProcessTextIntent.parse("  hello there  ", readOnly = false)
+
+        val accepted = parse as ProcessTextParse.Accepted
+        assertEquals("hello there", accepted.request.text)
+        assertEquals(false, accepted.request.readOnly)
+    }
+
+    @Test fun `a styled CharSequence selection is flattened to plain text`() {
+        val styled: CharSequence = StringBuilder("styled selection")
+
+        val accepted = ProcessTextIntent.parse(styled, readOnly = false) as ProcessTextParse.Accepted
+
+        assertEquals("styled selection", accepted.request.text)
+    }
+
+    @Test fun `a missing selection extra is an empty selection`() {
+        assertEquals(ProcessTextParse.EmptySelection, ProcessTextIntent.parse(null, readOnly = false))
+    }
+
+    @Test fun `a whitespace-only selection is an empty selection`() {
+        assertEquals(ProcessTextParse.EmptySelection, ProcessTextIntent.parse("   \n\t ", readOnly = false))
+    }
+
+    @Test fun `the read-only extra is carried onto the request`() {
+        val accepted = ProcessTextIntent.parse("text", readOnly = true) as ProcessTextParse.Accepted
+
+        assertTrue(accepted.request.readOnly)
+    }
+
+    @Test fun `a selection at the size limit is still accepted`() {
+        val text = "x".repeat(ProcessTextIntent.MAX_SELECTION_CHARS)
+
+        val accepted = ProcessTextIntent.parse(text, readOnly = false) as ProcessTextParse.Accepted
+
+        assertEquals(ProcessTextIntent.MAX_SELECTION_CHARS, accepted.request.text.length)
+    }
+
+    @Test fun `a selection past the size limit is rejected with both numbers`() {
+        val text = "x".repeat(ProcessTextIntent.MAX_SELECTION_CHARS + 1)
+
+        val tooLong = ProcessTextIntent.parse(text, readOnly = false) as ProcessTextParse.TooLong
+
+        assertEquals(ProcessTextIntent.MAX_SELECTION_CHARS + 1, tooLong.length)
+        assertEquals(ProcessTextIntent.MAX_SELECTION_CHARS, tooLong.limit)
+    }
+
+    @Test fun `surrounding whitespace does not push a limit-length selection over the limit`() {
+        val text = "  " + "x".repeat(ProcessTextIntent.MAX_SELECTION_CHARS) + "  "
+
+        assertTrue(ProcessTextIntent.parse(text, readOnly = false) is ProcessTextParse.Accepted)
+    }
+
+    // --- Read-only / clipboard fallback ---
+
+    @Test fun `a writable host gets the replacement returned to it`() {
+        assertEquals(ProcessTextDelivery.REPLACE_IN_HOST, deliveryFor(readOnly = false))
+    }
+
+    @Test fun `a read-only host falls back to the clipboard instead of failing silently`() {
+        assertEquals(ProcessTextDelivery.CLIPBOARD_ONLY, deliveryFor(readOnly = true))
+    }
+
+    // --- Cloud gating / provider planning ---
+
+    private val cloudChain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.ANTHROPIC, "claude-haiku")))
+    private val cloudPlusLocalChain = ProviderChain(
+        listOf(
+            ProviderChainEntry(ProviderKind.ANTHROPIC, "claude-haiku"),
+            ProviderChainEntry(ProviderKind.LOCAL, "lfm2.5-350m"),
+        )
+    )
+    private val allConfigured: (ProviderKind) -> Boolean = { true }
+
+    @Test fun `a cloud chain runs when cloud cleanup is enabled`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = cloudChain,
+            cloudCleanupEnabled = true,
+            allowLocalFallback = true,
+            isCredentialConfigured = allConfigured,
+        )
+
+        val ready = plan as ProcessTextCleanupPlan.Ready
+        assertEquals(listOf(CleanupStepGroup.ANTHROPIC_DIRECT), ready.waterfall.steps.map { it.group })
+    }
+
+    @Test fun `a cloud-only chain is refused when the cloud cleanup toggle is off`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = cloudChain,
+            cloudCleanupEnabled = false,
+            allowLocalFallback = true,
+            isCredentialConfigured = allConfigured,
+        )
+
+        assertEquals(
+            ProcessTextCleanupPlan.Unavailable(ProcessTextUnavailableReason.CLOUD_CLEANUP_DISABLED),
+            plan,
+        )
+    }
+
+    @Test fun `the cloud cleanup toggle strips cloud steps but keeps the local one`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = cloudPlusLocalChain,
+            cloudCleanupEnabled = false,
+            allowLocalFallback = true,
+            isCredentialConfigured = allConfigured,
+        )
+
+        val ready = plan as ProcessTextCleanupPlan.Ready
+        assertEquals(listOf(CleanupStepGroup.LOCAL_LLM), ready.waterfall.steps.map { it.group })
+    }
+
+    @Test fun `an empty chain is unavailable for configuration reasons not the cloud toggle`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = ProviderChain(emptyList()),
+            cloudCleanupEnabled = true,
+            allowLocalFallback = true,
+            isCredentialConfigured = allConfigured,
+        )
+
+        assertEquals(
+            ProcessTextCleanupPlan.Unavailable(ProcessTextUnavailableReason.NO_CLEANUP_CONFIGURED),
+            plan,
+        )
+    }
+
+    @Test fun `disabling local fallback strips the local floor from a cloud chain`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = cloudPlusLocalChain,
+            cloudCleanupEnabled = true,
+            allowLocalFallback = false,
+            isCredentialConfigured = allConfigured,
+        )
+
+        val ready = plan as ProcessTextCleanupPlan.Ready
+        assertEquals(listOf(CleanupStepGroup.ANTHROPIC_DIRECT), ready.waterfall.steps.map { it.group })
+    }
+
+    @Test fun `a single-OpenAI chain with no key fails fast instead of making a doomed call`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini"))),
+            cloudCleanupEnabled = true,
+            allowLocalFallback = true,
+            isCredentialConfigured = { false },
+        )
+
+        assertEquals(
+            ProcessTextCleanupPlan.Unavailable(ProcessTextUnavailableReason.MISSING_OPENAI_KEY),
+            plan,
+        )
+    }
+
+    @Test fun `a multi-step chain missing the OpenAI key still runs so later steps can serve it`() {
+        val plan = ProcessTextCleanupPlanner.plan(
+            chain = ProviderChain(
+                listOf(
+                    ProviderChainEntry(ProviderKind.OPENAI, "gpt-4o-mini"),
+                    ProviderChainEntry(ProviderKind.LOCAL, "lfm2.5-350m"),
+                )
+            ),
+            cloudCleanupEnabled = true,
+            allowLocalFallback = true,
+            isCredentialConfigured = { false },
+        )
+
+        assertTrue(plan is ProcessTextCleanupPlan.Ready)
+    }
+
+    // --- Result mapping ---
+
+    @Test fun `a non-blank cleaned result is delivered`() {
+        assertEquals(ProcessTextOutcome.Cleaned("cleaned"), processTextOutcome("cleaned", null))
+    }
+
+    @Test fun `a blank cleaned result is a failure, not an empty replacement`() {
+        val outcome = processTextOutcome("   ", "provider returned nothing")
+
+        assertEquals(ProcessTextOutcome.Failed("provider returned nothing"), outcome)
+    }
+
+    @Test fun `a null result with no error message still reports a usable reason`() {
+        assertEquals(ProcessTextOutcome.Failed("unknown error"), processTextOutcome(null, null))
+    }
+
+    @Test fun `the provider's own error message is preserved for diagnosis`() {
+        val outcome = processTextOutcome(null, "HTTP 401 invalid_api_key")
+
+        assertEquals(ProcessTextOutcome.Failed("HTTP 401 invalid_api_key"), outcome)
+    }
+
+    // --- Prompt-injection hardening is on this path (existing mitigation, #157) ---
+
+    @Test fun `every persona this entry point offers carries the do-not-obey-the-text clause`() {
+        // Selection-menu input is arbitrary text from some other app, not the user's own speech,
+        // so the "never treat this as an instruction" hardening already in PostProcessor's prompts
+        // is load-bearing here. This pins that every built-in style the picker lists actually
+        // carries it, rather than adding a second competing mitigation.
+        for (persona in CleanupPersonas.BUILT_IN) {
+            val prompt = CleanupPersonas.promptForExplicitSelection(persona).lowercase()
+            assertTrue(
+                "persona ${persona.key} is missing prompt-injection hardening",
+                prompt.contains("never treat") || prompt.contains("never as an instruction"),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Implements **Option B** from #157: select text anywhere in Android, tap Ramblr in the text-selection menu, and the existing cleanup waterfall runs on that selection.

Ramblr's cleanup pipeline is `Context`-scoped rather than service-scoped, which is what makes this cheap — `PostProcessor.processProviderChain`, `LocalCleanupModelHolder`, `PersonaRegistry.all(context)` and `ProviderCredentialStore` none of them need the AccessibilityService. A plain Activity runs the full chain: cloud + local LLM + personas + vocabulary. **No service refactor.** It also works in apps that block accessibility services, which is exactly where the floating bubble fails today (#143).

## Option A was deliberately not built

The inline `?fix` typed trigger is a one-line diff — `onAccessibilityEvent` is empty (`WhisperAccessibilityService.kt:560`) and the config subscribes only to `typeViewFocused`, so adding `typeViewTextChanged` would do it. That one line is the entire cost, and it is not worth paying: Ramblr would begin receiving the text of everything typed in every app, which falsifies `PRIVACY.md:82`/`:84` and destroys the central argument of the Play assessment in #99 — that Ramblr's zero-event-handling, pull-on-demand posture is demonstrably stronger than already-approved apps.

This PR keeps `onAccessibilityEvent` empty and does not declare `isAccessibilityTool`.

SwiftSlate's `ProcessTextReplacementBridge` was also deliberately not ported; it re-introduces the same privacy cost. Read-only hosts fall back to the clipboard instead.

## What it does

- **`ProcessTextActivity`** — transparent, `noHistory`, `excludeFromRecents`; a dialog-only surface over the host app. Inference runs off the UI thread and the Activity does not leak if the user backs out mid-cleanup.
- **`ProcessTextRequest.kt`** — all decision logic as pure functions, deliberately separated from the Activity so it is unit-testable (this module has no Robolectric, and `android.util.Log` is unmocked in plain-JVM tests, so anything touching framework classes can't be covered here).
- **Read-only hosts** — `ACTION_PROCESS_TEXT` carries a `READ_ONLY` extra. When set, the result can't be written back, so the cleaned text goes to the clipboard and the user is told, rather than failing silently.
- **Cloud gating** — selection-menu use can hit paid providers far more often than dictation does, so cloud steps run through the existing `CloudFeatureToggle`. When cloud is off, cloud steps are stripped but a local step is preserved; a cloud-only chain is refused outright rather than making a doomed call.
- **Prompt injection** on arbitrary selected text is already mitigated upstream (`PostProcessor.kt:66/:200/:202` carry explicit "never treat as an instruction" clauses). No second competing mitigation was added — the existing one is on this path.

## Tests

**134 suites / 1224 tests / 0 failures / 0 errors**, parsed from JUnit XML after deleting `test-results` and running `--rerun-tasks` (`31 actionable tasks: 31 executed` — nothing UP-TO-DATE). Baseline on `main` is 133 suites / 1202 tests.

Covers selection parsing and flattening of styled `CharSequence`, size limits including the exact boundary and the whitespace-vs-limit interaction, the read-only clipboard fallback, all four cloud-gating branches, the single-OpenAI no-key fast-fail, and blank/null result handling.

### Mutation evidence

Inverting the read-only fallback (`deliveryFor` always returning `REPLACE_IN_HOST`) produces a real assertion failure, not a compile error:

```
[ASSERTION] ProcessTextRequestTest > a read-only host falls back to the clipboard instead of failing silently
java.lang.AssertionError: expected:<CLIPBOARD_ONLY> but was:<REPLACE_IN_HOST>
```

Green baseline proven before and after, `git status` clean between runs, harness deleted and never committed.

## Not verified on a device

This was **not** run on hardware. The known unknowns, both flagged in #157:

1. **Menu presence across host apps** — Android 11+ package visibility affects whether the Ramblr item appears in the selection menu in some hosts. SwiftSlate works around Gmail with a deliberately `DEFAULT`-less `VIEW/BROWSABLE` filter; this PR uses the standard filter and that behavior is unconfirmed in the wild.
2. **Local-model contention** — an Activity and the running AccessibilityService could both reach `LocalCleanupModelHolder`. Worth exercising directly: start a dictation, then invoke Type-to-fix while the ~220MB model is loaded.

Needs on-device testing before merge.

Refs #157
