### PR TITLE
Reuse the cached prompt prefix and restore llama perf attribution

### DIFF
--- a/app/src/main/cpp/llama_cleanup/LLMInference.cpp
+++ b/app/src/main/cpp/llama_cleanup/LLMInference.cpp
@@ -69,7 +69,14 @@ LLMInference::loadModel(const char *model_path, float minP, float temperature, b
     ctx_params.n_ctx = contextSize;
     ctx_params.n_batch = contextSize;
     ctx_params.n_threads = nThreads;
-    ctx_params.no_perf = true; // disable performance metrics
+    // Keep llama's own perf counters live. They are what separates model load from prompt
+    // evaluation from token generation; without them a slow completion on-device is a single
+    // opaque wall-clock number, which is exactly why an 8s local cleanup failure was originally
+    // misattributed to prompt length (see
+    // .hermes/plans/2026-08-18-local-cleanup-latency-measured.md). The counters are a few
+    // integer accumulators around calls that already cost milliseconds -- immeasurable next to
+    // the decode itself -- and logPerfMetrics() below emits the breakdown once per completion.
+    ctx_params.no_perf = false;
     _ctx = llama_init_from_model(_model, ctx_params);
     if (!_ctx) {
         LOGe("llama_new_context_with_model() returned null)");
@@ -144,6 +151,26 @@ LLMInference::getContextSizeUsed() const {
 size_t
 LLMInference::getReusedPrefixLen() const {
     return _reusedPrefixLen;
+}
+
+void
+LLMInference::logPerfMetrics() const {
+    if (!_ctx) {
+        return;
+    }
+    // llama_perf_context reports cumulative counters for this context, split into the three
+    // phases that actually matter when a completion is slow: t_load_ms (one-off model load),
+    // t_p_eval_ms/n_p_eval (prompt evaluation) and t_eval_ms/n_eval (token generation). Logging
+    // the split per completion is the difference between "local cleanup took 8s" and knowing
+    // which phase to go fix -- the ambiguity that made a vocabulary cap look like the answer.
+    const llama_perf_context_data perf = llama_perf_context(_ctx);
+    LOGi("perf: load %.2fms | prompt eval %.2fms / %d tokens (%.2f t/s) | gen %.2fms / %d tokens (%.2f t/s) | prefix reused %zu",
+         perf.t_load_ms,
+         perf.t_p_eval_ms, perf.n_p_eval,
+         perf.n_p_eval > 0 && perf.t_p_eval_ms > 0 ? perf.n_p_eval / (perf.t_p_eval_ms / 1000.0) : 0.0,
+         perf.t_eval_ms, perf.n_eval,
+         perf.n_eval > 0 && perf.t_eval_ms > 0 ? perf.n_eval / (perf.t_eval_ms / 1000.0) : 0.0,
+         _reusedPrefixLen);
 }
 
 bool
@@ -389,6 +416,9 @@ LLMInference::stopCompletion() {
     // Disarm the wall-clock deadline so it can't carry into the next completion on a reused
     // instance before that call re-arms it (#92). setInferenceBudgetMs re-arms per completion.
     _abortAtUs.store(0, std::memory_order_relaxed);
+    // One line per completion with the load/prompt-eval/generation split, so a slow local cleanup
+    // in the field can be attributed to a phase instead of guessed at.
+    logPerfMetrics();
 }
 
 LLMInference::~LLMInference() {

--- a/app/src/main/cpp/llama_cleanup/LLMInference.cpp
+++ b/app/src/main/cpp/llama_cleanup/LLMInference.cpp
@@ -141,18 +141,25 @@ LLMInference::getContextSizeUsed() const {
     return _nCtxUsed;
 }
 
+size_t
+LLMInference::getReusedPrefixLen() const {
+    return _reusedPrefixLen;
+}
+
 bool
 LLMInference::startCompletion(const char *query) {
     if (!_storeChats) {
         _formattedMessages.clear();
         _formattedMessages = std::vector<char>(llama_n_ctx(_ctx));
         // One-shot mode on a reused instance (#74): the batch below carries no positions, so
-        // llama_decode appends after llama_memory_seq_pos_max -- without this clear, a second
+        // llama_decode appends after llama_memory_seq_pos_max -- without a clear, a second
         // completion's prompt would be decoded after (and attend to) the previous completion's
         // tokens, and _nCtxUsed would grow across turns until "context size reached". _messages
         // itself is cleared in stopCompletion, not here: the caller has already added this
         // turn's system message by the time startCompletion runs (see LlamaCppInference.complete).
-        llama_memory_clear(llama_get_memory(_ctx), false);
+        //
+        // The clear is deferred until after tokenization below, because the previous turn's KV
+        // is exactly what prefix reuse needs to keep. See _cachedTokens.
     }
     _responseGenerationTime = 0;
     _responseNumTokens = 0;
@@ -188,15 +195,74 @@ LLMInference::startCompletion(const char *query) {
     }
     _promptTokens = common_tokenize(llama_model_get_vocab(_model), prompt, true, true);
 
+    // Prefix reuse (#155 follow-up). Ramblr's cleanup prompt is a *stable prefix by
+    // construction*: the system prompt (task instructions + the user's personal vocabulary) is
+    // rendered first and is byte-identical across dictations, while only the transcript at the
+    // tail varies. Re-decoding that shared prefix on every completion is pure waste -- it is the
+    // single largest avoidable cost on the local cleanup path, and it grows with the user's
+    // vocabulary, which is why it previously looked like "long vocabularies are slow".
+    //
+    // This is the same optimization llama.cpp's own server performs for `cache_prompt`: find the
+    // longest common prefix between what is already in the KV cache and the new prompt, keep that
+    // much, and evaluate only the divergent tail. We hold a single sequence (id 0), so trimming
+    // is one llama_memory_seq_rm call.
+    //
+    // Correctness: the reused span must match the new prompt token-for-token, so we compare the
+    // actual token ids from the previous turn (_cachedTokens), never a hash or a length. We also
+    // stop one token short of a full match (see below) because llama_decode needs at least one
+    // token to produce logits to sample from.
+    size_t reuse = 0;
+    if (!_storeChats) {
+        const size_t maxReuse = std::min(_cachedTokens.size(), _promptTokens.size());
+        while (reuse < maxReuse && _cachedTokens[reuse] == _promptTokens[reuse]) {
+            reuse++;
+        }
+        // Never reuse the entire new prompt: llama_decode must evaluate >=1 token this turn to
+        // produce the logits completionLoop() samples from. Backing off by one keeps the
+        // invariant that the batch is non-empty even when a dictation repeats verbatim.
+        if (reuse == _promptTokens.size() && reuse > 0) {
+            reuse--;
+        }
+
+        // Drop everything at/after the divergence point, keep [0, reuse). Passing p1 = -1 means
+        // "to the end".
+        //
+        // llama_memory_seq_rm returns false when a PARTIAL removal is impossible -- notably for
+        // recurrent/hybrid memory (LFM2 is a conv+attention hybrid), where per-position eviction
+        // isn't representable. Ignoring that return would leave the cache holding the previous
+        // turn's tokens while we decoded only a short tail against it, silently corrupting the
+        // model's view of the conversation. On failure we fall back to the old unconditional
+        // full clear and reuse nothing, which is exactly the pre-optimization behaviour.
+        const bool trimmed =
+            reuse == 0 ? false
+                       : llama_memory_seq_rm(llama_get_memory(_ctx), 0, (llama_pos) reuse, -1);
+        if (!trimmed) {
+            llama_memory_clear(llama_get_memory(_ctx), false);
+            reuse = 0;
+        }
+
+        LOGi("prefix reuse: %zu/%zu prompt tokens cached, evaluating %zu",
+             reuse, _promptTokens.size(), _promptTokens.size() - reuse);
+    }
+    _reusedPrefixLen = reuse;
+    // The cache now holds exactly [0, reuse) from the previous turn plus the tail we are about to
+    // decode. Record that, and completionLoop appends each generated token as it decodes it, so
+    // _cachedTokens always mirrors the real KV contents at the next diff.
+    _cachedTokens.assign(_promptTokens.begin(), _promptTokens.end());
+
     // create a llama_batch containing a single sequence
     // see llama_batch_init for more details
     delete _batch; // a previous completion's batch would otherwise leak on reuse (#87 item 2)
     _batch = new llama_batch();
-    _batch->token = _promptTokens.data();
-    _batch->n_tokens = _promptTokens.size();
+    // Only the divergent tail is decoded; the reused prefix already sits in the KV cache at
+    // positions [0, reuse). llama_decode appends after llama_memory_seq_pos_max, so the tail
+    // lands at exactly the right positions without us assigning them by hand.
+    _batch->token = _promptTokens.data() + reuse;
+    _batch->n_tokens = (int32_t) (_promptTokens.size() - reuse);
 
     return usedJinja;
 }
+
 
 // taken from:
 // https://github.com/ggerganov/llama.cpp/blob/master/examples/llama.android/llama/src/main/cpp/llama-android.cpp#L38
@@ -277,6 +343,13 @@ LLMInference::completionLoop() {
     _responseGenerationTime += (end - start);
     _responseNumTokens += 1;
     _cacheResponseTokens += piece;
+
+    // Every sampled token is fed back through llama_decode below, so it occupies a KV position
+    // just like a prompt token does. _cachedTokens must therefore mirror the *whole* cache
+    // contents (prompt + generated response), not just the prompt: the next completion trims at
+    // the first divergence, and anything we failed to record would survive past that point and
+    // silently attend to the next turn (#155 follow-up).
+    _cachedTokens.push_back(_currToken);
 
     // re-init the batch with the newly predicted token
     // key, value pairs of all previous tokens have been cached

--- a/app/src/main/cpp/llama_cleanup/LLMInference.h
+++ b/app/src/main/cpp/llama_cleanup/LLMInference.h
@@ -34,6 +34,18 @@ class LLMInference {
     // stores the tokens for the last query
     // appended to `_messages`
     std::vector<llama_token> _promptTokens;
+
+    // The exact prompt-token sequence whose keys/values are currently resident in the KV cache,
+    // i.e. what the *previous* completion decoded. startCompletion diffs the incoming prompt
+    // against this to find the longest reusable prefix, so it must hold real token ids rather
+    // than a length or a hash -- a length alone cannot prove the cached tokens still match after
+    // the user edits their personal vocabulary or switches prompts (#155 follow-up).
+    std::vector<llama_token> _cachedTokens;
+
+    // How many leading prompt tokens the last startCompletion reused from the KV cache instead of
+    // re-decoding. Diagnostics only (exposed via getReusedPrefixLen for the host probe and
+    // instrumentation); the decode path derives everything it needs from `_batch`.
+    size_t _reusedPrefixLen = 0;
     const char*              _chatTemplate = nullptr;
     // true when `_chatTemplate` was strdup'ed by loadModel (caller-supplied template) and must
     // be freed by the destructor; false when it points at model-owned memory (#87).
@@ -90,6 +102,12 @@ class LLMInference {
     float getResponseGenerationTime() const;
 
     int getContextSizeUsed() const;
+
+    // How many leading prompt tokens the most recent startCompletion() served from the KV cache
+    // instead of re-decoding. 0 on the first completion after a load (nothing cached yet) and
+    // whenever the prompt's prefix changed. Used by tools/llama_cleanup_probe to *prove* the
+    // reuse actually happens rather than inferring it from wall-clock timings.
+    size_t getReusedPrefixLen() const;
 
     // Returns true if Jinja template was used, false if legacy fallback was needed.
     bool startCompletion(const char* query);

--- a/app/src/main/cpp/llama_cleanup/LLMInference.h
+++ b/app/src/main/cpp/llama_cleanup/LLMInference.h
@@ -109,6 +109,10 @@ class LLMInference {
     // reuse actually happens rather than inferring it from wall-clock timings.
     size_t getReusedPrefixLen() const;
 
+    // Logs llama's own load / prompt-eval / generation split for this context. Only meaningful
+    // because loadModel leaves `no_perf` off; see the comment there for why that matters.
+    void logPerfMetrics() const;
+
     // Returns true if Jinja template was used, false if legacy fallback was needed.
     bool startCompletion(const char* query);
 

--- a/tools/llama_cleanup_probe/probe.cpp
+++ b/tools/llama_cleanup_probe/probe.cpp
@@ -30,7 +30,7 @@ static const int kMaxPieces = 512;
 
 int main(int argc, char** argv) {
     if (argc < 4) {
-        fprintf(stderr, "usage: %s <model.gguf> <system_prompt> <user_text> [runs] [budget_ms]\n", argv[0]);
+        fprintf(stderr, "usage: %s <model.gguf> <system_prompt> <user_text> [runs] [budget_ms] [vary_text]\n", argv[0]);
         return 1;
     }
     const std::string modelPath = argv[1];
@@ -43,6 +43,9 @@ int main(int argc, char** argv) {
     }
     // 0 (default) = no deadline, matching LlamaCppInference.complete()'s Long.MAX_VALUE case.
     const long budgetMs = argc > 5 ? atol(argv[5]) : 0;
+    // When 1, each run after the first appends a distinct suffix to the transcript, so the system
+    // prompt stays byte-identical while the user text changes -- the actual dictation pattern.
+    const bool varyText = argc > 6 ? atoi(argv[6]) != 0 : false;
 
     LLMInference llm;
     fprintf(stderr, "loading model...\n");
@@ -67,8 +70,18 @@ int main(int argc, char** argv) {
         auto genStart = std::chrono::steady_clock::now();
         std::string response;
         int numPieces = 0;
+        // Vary the transcript per run so this exercises the real dictation pattern -- identical
+        // system prompt, different user text -- which is exactly the case prefix reuse targets.
+        // Without the suffix every run would be byte-identical and reuse would look artificially
+        // perfect (#155 follow-up).
+        std::string thisRunText = userText;
+        if (varyText && run > 1) {
+            thisRunText += " take " + std::to_string(run);
+        }
+        size_t reused = 0;
         try {
-            llm.startCompletion(userText.c_str());
+            llm.startCompletion(thisRunText.c_str());
+            reused = llm.getReusedPrefixLen();
             // Mirrors complete()'s call order: arm the budget after startCompletion, before the
             // first completionLoop decode it bounds (#92).
             llm.setInferenceBudgetMs(budgetMs);
@@ -93,8 +106,8 @@ int main(int argc, char** argv) {
         double genSecs = std::chrono::duration<double>(genEnd - genStart).count();
 
         printf("=== RESPONSE (run %d of %d) ===\n%s\n=== END ===\n", run, numRuns, response.c_str());
-        fprintf(stderr, "run %d: generated %d pieces in %.2fs (%.1f tok/s), context used: %d\n",
-                run, numPieces, genSecs, numPieces / genSecs, llm.getContextSizeUsed());
+        fprintf(stderr, "run %d: generated %d pieces in %.2fs (%.1f tok/s), context used: %d, prefix reused: %zu tokens\n",
+                run, numPieces, genSecs, numPieces / genSecs, llm.getContextSizeUsed(), reused);
     }
     return 0;
 }


### PR DESCRIPTION
## What

Two changes to the local cleanup native path, both aimed at the real cost of a dictation rather
than at the prompt's length.

### 1. Reuse the cached prompt prefix

`LLMInference::startCompletion` called `llama_memory_clear()` on every completion, so the system
prompt — instructions plus the user's personal vocabulary, byte-identical across dictations — was
re-evaluated from scratch every single time. Only the transcript at the tail actually varies.

This diffs the incoming prompt against the tokens already resident in the KV cache, drops only the
divergent tail, and decodes just what changed. Same optimization llama.cpp's server does for
`cache_prompt` ([discussion #8947](https://github.com/ggml-org/llama.cpp/discussions/8947)).

Measured with `tools/llama_cleanup_probe`, which compiles the production `LLMInference.cpp`
verbatim. Four runs sharing one system prompt with a varying transcript:

**Qwen2.5-based (mumble-cleanup-2stage-q4_0), pure attention:**
```
run 1: context used: 173, prefix reused:   0 tokens
run 2: context used: 179, prefix reused: 155 tokens
run 3: context used: 179, prefix reused: 157 tokens
run 4: context used: 179, prefix reused: 157 tokens
```
~90% of the prompt served from cache after the first dictation, `context used` flat.

**LFM2.5-350m (current default), conv+attention hybrid — reuses nothing:**
`llama_memory_seq_rm` returns **false**. llama.cpp's `src/llama-memory-recurrent.cpp:170`
explains: *"models like Mamba or RWKV can't have a state partially erased at the end."* A
recurrent state isn't per-position addressable, so the cache can't be trimmed at an arbitrary
token boundary. The change is a safe no-op there — hybrids take exactly the path they took before.

Two real bugs surfaced while verifying this, both fixed here:

- **`llama_memory_seq_rm`'s return value was being ignored.** It returns false when partial
  removal is impossible. Ignoring it would leave the previous turn's tokens resident while we
  decoded a short tail against them — silent context corruption, not a slowdown. We now fall back
  to a full clear and reuse nothing.
- **`_cachedTokens` must include generated tokens.** Every sampled token is fed back through
  `llama_decode` and occupies a KV position. Tracking only the prompt made `context used` climb
  289 → 329 → 362 → 485 across runs; it is now flat.

### 2. Turn llama's perf counters back on

The context was built with `no_perf = true`, so a slow completion on-device was one opaque
wall-clock number — no way to separate model load from prompt eval from generation. That ambiguity
is exactly how an 8s local cleanup failure got blamed on prompt length when the prompt accounted
for ~15ms of it. Now one line per completion:

```
perf: load 1326.61ms | prompt eval 134.86ms / 81 tokens (600.64 t/s) | gen 107.11ms / 12 tokens (112.03 t/s) | prefix reused 0
```

## Why this matters for the default model

The prompt-length cost is fully solvable by prefix reuse — but **only on attention models**.
LFM2.5 structurally cannot benefit. If mumble-cleanup (Qwen2.5) holds up on quality in the #134
A/B, it also unlocks ~90% prompt-eval savings per dictation that LFM2.5 can never get. Worth
weighing in that decision.

## Verification

Host probe compiles the production `LLMInference.cpp` verbatim and now reports per-run reuse, so
the behaviour is proven rather than inferred from wall-clock timings. Numbers above are from that
probe against both real catalog models.

Not yet exercised on-device — the native library needs an NDK build and a device smoke test before
this ships.

Refs #155
