### PR TITLE
Pin the measured #164 production echo as validator fixtures

### DIFF
--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
@@ -312,4 +312,84 @@ class LocalCleanupOutputValidatorTest {
     private fun ratio(input: String, output: String): Double =
         LocalCleanupOutputValidator.normalizeForLength(output).length.toDouble() /
             LocalCleanupOutputValidator.normalizeForLength(input).length
+
+    // --- #164: the full-length production echo, measured on device ---------------------------
+    //
+    // The fixtures above were captured with an 11-term vocabulary list. #164 reproduced the same
+    // failure class on real hardware (Pixel 10a, arm64 cross-build of tools/llama_cleanup_probe
+    // running production LLMInference.cpp) with the *full* 22-term list actually configured on
+    // the device, and the echo there is the entire clause -- 335 prompt tokens in, 111 generated
+    // tokens out, none of them the transcript. These assert that exact string, byte for byte,
+    // because the validator's whole job is to stop this specific output reaching a text field.
+    //
+    // Deliberately separate from the #155 fixtures rather than replacing them: the 11-term case
+    // proves a partial echo is caught, this proves the full-length one is, and the two have
+    // different overlap lengths.
+
+    /** The 22 terms read from `shared_prefs/ramblr.xml` on the device that reproduced #164. */
+    private val realDeviceVocabulary = listOf(
+        "Nash-Keller", "Wyatt", "Terelle", "Dyson", "Dys", "Adalyn", "Ady", "Emsley", "Emy",
+        "Londyn", "trevor@nashkellermedia.com", "assistant@nashkellermedia.com",
+        "trevornk@gmail.com", "trevor@nashkeller.com", "Selby", "Mobridge", "Affine",
+        "Unishell", "Pi", "Codex", "Claude", "Hetzner",
+    )
+
+    private val realDevicePrompt =
+        LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, realDeviceVocabulary)
+
+    /** Verbatim `rawText` from `dictation_history.jsonl` on the same device. */
+    private val realDeviceTranscript =
+        "I think I'm gonna go on a walk and then Probably see if there's any chip bunks hanging " +
+            "out down around the park If so, I'll maybe Play catch with Lily and see if she wants " +
+            "to chase after any of those chipmunks. Then after that, I think We'll probably just " +
+            "cruise around, maybe go have some ice cream Stop at the gas station Go to HVy, do a " +
+            "little bit of shopping. because I did see that there was some new Kinder Bueno ice " +
+            "cream that they have there and it looks really good. so I'm thinking I should " +
+            "probably try that out But anyways, I'm just wondering what you're doing tonight"
+
+    @Test fun `REAL 164 full 22-term production echo is rejected`() {
+        // Byte-for-byte what the model returned on device, three runs, deterministically at
+        // temp 0. Without this rejection the user's own email addresses and children's names are
+        // injected into whatever app they dictated into.
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            realDeviceTranscript,
+            "Watch for these project names and personal vocabulary terms, which speech-to-text " +
+                "often mishears: Nash-Keller, Wyatt, Terelle, Dyson, Dys, Adalyn, Ady, Emsley, " +
+                "Emy, Londyn, trevor@nashkellermedia.com, assistant@nashkellermedia.com, " +
+                "trevornk@gmail.com, trevor@nashkeller.com, Selby, Mobridge, Affine, Unishell, " +
+                "Pi, Codex, Claude, Hetzner",
+            prompt = realDevicePrompt,
+        )
+    }
+
+    @Test fun `REAL 164 no-vocabulary truncation is rejected as a length collapse`() {
+        // The no-clause control on the same transcript. Not an echo -- the model returned a
+        // grammatical sentence -- but it dropped ~95% of what was said, which is the failure
+        // mode a bare isNotBlank() check shipped for months.
+        assertRejected(
+            LocalCleanupValidation.Reason.LENGTH_COLLAPSE,
+            realDeviceTranscript,
+            "I think I'm going to the park tonight",
+            prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList()),
+        )
+    }
+
+    @Test fun `a correct cleanup of the 164 transcript survives the 22-term prompt`() {
+        // The negative control that keeps the two tests above honest: under the exact prompt and
+        // transcript that produced the failure, genuinely cleaned output must still be accepted.
+        // Without this, "reject everything" would pass the whole #164 suite.
+        assertAccepted(
+            realDeviceTranscript,
+            "I think I'm gonna go on a walk and then probably see if there are any chipmunks " +
+                "hanging out down around the park. If so, I'll maybe play catch with Lily and " +
+                "see if she wants to chase after any of those chipmunks. Then after that, I " +
+                "think we'll probably just cruise around, maybe go have some ice cream, stop at " +
+                "the gas station, go to HyVee, do a little bit of shopping, because I did see " +
+                "that there was some new Kinder Bueno ice cream that they have there and it " +
+                "looks really good. So I'm thinking I should probably try that out. But anyways, " +
+                "I'm just wondering what you're doing tonight.",
+            prompt = realDevicePrompt,
+        )
+    }
 }


### PR DESCRIPTION
Tests only. `app/src/main` is byte-identical to `origin/main` — `git diff --stat -- app/src/main/` is empty.

## Why

While measuring #163's telemetry on real hardware I reproduced the #164 failure and initially filed it as a user-facing exposure bug. That was wrong: `LocalCleanupOutputValidator.checkPromptEcho` (merged in #159 for #155) already rejects it, and it's correctly wired at `CleanupWaterfallExecutor.kt:453` receiving the *interpolated* prompt via `localPrompt` — so the vocabulary clause is present in the string it compares against, which is the one thing that could have made it miss.

So there's no fix to make here. What was missing is that the guard had never been pinned to the strings the failure actually produces on a device. This adds that.

## How the fixtures were obtained

Cross-compiled `tools/llama_cleanup_probe` for `arm64-v8a` (NDK 27.2.12479018) and ran production `LLMInference.cpp` directly on a Pixel 10a — no app, no UI, no emulator. Inputs are real, not synthetic: the 22 vocabulary terms come from `shared_prefs/ramblr.xml` on the device, and the transcript is a `rawText` from `dictation_history.jsonl`. Deterministic at temp 0, reproduced identically across three runs.

The existing `REAL_` fixtures used an 11-term list. The 22-term echo is longer and has a different overlap length against the prompt, so these are additive rather than a replacement.

## The three cases

| Test | Asserts |
|---|---|
| `REAL 164 full 22-term production echo is rejected` | the entire clause returned as the "cleaned" transcript → `PROMPT_ECHO` |
| `REAL 164 no-vocabulary truncation is rejected as a length collapse` | the no-clause control, which dropped ~95% of a 580-char transcript → `LENGTH_COLLAPSE` |
| `a correct cleanup of the 164 transcript survives the 22-term prompt` | genuinely cleaned output under the *same* prompt and transcript is still accepted |

The third is the one that matters most. Without it, a validator mutated to "reject everything" would pass the entire #164 suite. A false rejection costs one fallback step; an over-eager validator makes local cleanup useless.

## Mutation proof

Green baseline established first (32/32 pass on the unmodified validator), so a FAIL below is a caught mutation rather than a toolchain error:

```
MUTATION 1: disable checkPromptEcho        -> 5 failing
  - REAL 164 full 22-term production echo is rejected      <- new
  - REAL system prompt echo is rejected
  - a verbatim slab of the system prompt is rejected
  - echo detection works for a prompt the validator has never seen
  - the fine-tuned model's own prompt is echo-checked too

MUTATION 2: disable checkLengthCollapse    -> 2 failing
  - REAL 164 no-vocabulary truncation is rejected as a length collapse   <- new
  - content dropped to a fragment is rejected as a collapse
```

Source restored byte-for-byte after each mutation; `git diff` on the validator is empty.

## Scope note

This does not fix #164 — the model still fails to follow the prompt, so local cleanup with a vocabulary configured burns the full latency budget and falls through to raw text. That's a model-selection problem and belongs to #134. This just guarantees the failure keeps being caught.

Refs #164
