### PR TITLE
Protect numeric spans during local cleanup

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -412,14 +412,15 @@ object RealLocalInferenceEngine : LocalInferenceEngine {
             if (isCancelled()) {
                 LocalInferenceResult.Cancelled
             } else {
+                val masking = NumericSpanProtector.mask(userText)
                 val text = BoundedBlockingCall.runWithDeadline(deadlineAtMs) {
                     LocalCleanupModelHolder.withInference(modelPath) { inference ->
-                        inference.complete(systemPrompt, userText, deadlineAtMs, isCancelled)
+                        inference.complete(systemPrompt, masking.maskedText, deadlineAtMs, isCancelled)
                     }
                 }
                 when {
                     text == null -> LocalInferenceResult.TimedOut("Local cleanup timed out")
-                    text.isNotBlank() -> validated(systemPrompt, userText, text)
+                    text.isNotBlank() -> validated(systemPrompt, userText, masking, text)
                     else -> LocalInferenceResult.Failure("Local model produced an empty response")
                 }
             }
@@ -441,25 +442,35 @@ object RealLocalInferenceEngine : LocalInferenceEngine {
         }
 
     /**
-     * Gates non-blank model output through [LocalCleanupOutputValidator] (#155) instead of
-     * accepting any non-blank string, which was this engine's entire prior contract.
+     * Restores the numeric spans masked before inference (#155) and gates the result through
+     * [LocalCleanupOutputValidator], instead of accepting any non-blank string, which was this
+     * engine's entire prior contract.
+     *
+     * Both halves live in [protectedLocalCleanupOutcome] so their ordering -- restore first, then
+     * validate the RESTORED text against the ORIGINAL transcript -- is unit-testable; this engine
+     * is not constructible from the JVM suite.
      *
      * A rejection becomes a [LocalInferenceResult.Failure], never [LocalInferenceResult.Cancelled]:
      * bad local output is this one step failing, so it must fall through to the next waterfall
      * step (or raw-text injection) exactly like a timeout does -- see [LocalInferenceResult.TimedOut]'s
      * kdoc for the live regression caused by conflating the two.
      */
-    private fun validated(systemPrompt: String, userText: String, text: String): LocalInferenceResult =
-        when (val verdict = LocalCleanupOutputValidator.validate(userText, systemPrompt, text)) {
-            is LocalCleanupValidation.Valid -> LocalInferenceResult.Success(text)
-            is LocalCleanupValidation.Rejected -> {
+    private fun validated(
+        systemPrompt: String,
+        userText: String,
+        masking: NumericMasking,
+        text: String,
+    ): LocalInferenceResult =
+        when (val outcome = protectedLocalCleanupOutcome(userText, systemPrompt, masking, text)) {
+            is ProtectedCleanupOutcome.Accepted -> LocalInferenceResult.Success(outcome.text)
+            is ProtectedCleanupOutcome.Rejected -> {
                 // Log the reason, not the text: the prompt-echo case exists precisely because
                 // the output can contain the user's private vocabulary terms.
                 android.util.Log.w(
                     "RealLocalInferenceEngine",
-                    "Rejected local cleanup output: ${verdict.reason} -- ${verdict.detail}",
+                    "Rejected local cleanup output: ${outcome.label} -- ${outcome.detail}",
                 )
-                LocalInferenceResult.Failure("Local cleanup output rejected (${verdict.reason})")
+                LocalInferenceResult.Failure("Local cleanup output rejected (${outcome.label})")
             }
         }
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/NumericSpanProtector.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/NumericSpanProtector.kt
@@ -1,0 +1,405 @@
+package com.trevornk.ramblr
+
+/**
+ * One numeric span lifted out of a transcript before local cleanup (#155).
+ *
+ * [original] is the exact substring of the raw transcript, byte-for-byte, including any internal
+ * punctuation or casing. [sentinel] is the opaque token that stood in its place while the model
+ * saw the text.
+ */
+data class ProtectedNumericSpan(val sentinel: String, val original: String)
+
+/**
+ * The result of [NumericSpanProtector.mask].
+ *
+ * [maskedText] is what should be sent to the model. When [spans] is empty, [maskedText] is
+ * reference-identical to the input and [NumericSpanProtector.restore] is a pure pass-through --
+ * text with no numbers must never be perturbed by this feature.
+ */
+data class NumericMasking(
+    val originalText: String,
+    val maskedText: String,
+    val spans: List<ProtectedNumericSpan>,
+) {
+    val isEmpty: Boolean get() = spans.isEmpty()
+}
+
+/**
+ * Outcome of putting the protected spans back after cleanup.
+ *
+ * [Failed] is not an error condition to be swallowed: it means the model returned text this code
+ * cannot reassemble without guessing, and the caller must treat local cleanup as a failed step so
+ * the waterfall falls through to the next step or to raw-text injection. Raw text is unpolished
+ * but numerically correct, which is the whole point of #155.
+ */
+sealed class NumericRestoration {
+    data class Restored(val text: String) : NumericRestoration()
+    data class Failed(val reason: String) : NumericRestoration()
+}
+
+/** Verdict on one protected local-cleanup round trip. See [protectedLocalCleanupOutcome]. */
+sealed class ProtectedCleanupOutcome {
+    data class Accepted(val text: String) : ProtectedCleanupOutcome()
+
+    /** [label] is the short failure category surfaced in the step-failure message;
+     *  [detail] is a longer, still non-sensitive diagnostic for logcat -- like
+     *  [LocalCleanupValidation.Rejected.detail] neither ever contains transcript or model text. */
+    data class Rejected(val label: String, val detail: String) : ProtectedCleanupOutcome() {
+        companion object {
+            /** [label] used when the model mangled the sentinels rather than the prose. */
+            const val NUMERIC_RESTORATION = "NUMERIC_RESTORATION"
+        }
+    }
+}
+
+/**
+ * The post-inference half of the protected local-cleanup path (#155): restore the numeric spans
+ * [NumericSpanProtector.mask] took out, then run the existing [LocalCleanupOutputValidator]
+ * against the ORIGINAL transcript and the RESTORED output.
+ *
+ * Ordering matters, and this function exists so that ordering lives in one pure, unit-testable
+ * place instead of inside `RealLocalInferenceEngine`, which the JVM suite cannot construct:
+ *
+ *  - restoring *before* validating is what keeps [LocalCleanupOutputValidator] meaningful.
+ *    Validating masked-vs-masked would neuter [LocalCleanupValidation.Reason.NUMERIC_DIVERGENCE]
+ *    entirely (masked text contains no numbers, so the check returns early) and would compare a
+ *    length ratio between two texts whose numeric content had been replaced by short sentinels.
+ *  - validating against [rawInput] rather than the masked input keeps the length baseline
+ *    exactly what the validator's thresholds were measured against.
+ *
+ * A restoration failure is reported as a rejection, not an exception: the caller must treat it as
+ * this one step failing so the waterfall falls through to raw text.
+ */
+fun protectedLocalCleanupOutcome(
+    rawInput: String,
+    systemPrompt: String,
+    masking: NumericMasking,
+    modelOutput: String,
+): ProtectedCleanupOutcome =
+    when (val restoration = NumericSpanProtector.restore(masking, modelOutput)) {
+        is NumericRestoration.Failed ->
+            ProtectedCleanupOutcome.Rejected(
+                ProtectedCleanupOutcome.Rejected.NUMERIC_RESTORATION,
+                restoration.reason,
+            )
+        is NumericRestoration.Restored ->
+            when (val verdict = LocalCleanupOutputValidator.validate(rawInput, systemPrompt, restoration.text)) {
+                is LocalCleanupValidation.Valid -> ProtectedCleanupOutcome.Accepted(restoration.text)
+                is LocalCleanupValidation.Rejected ->
+                    ProtectedCleanupOutcome.Rejected(verdict.reason.name, verdict.detail)
+            }
+    }
+
+/**
+ * Keeps spoken numbers away from the local cleanup model (#155).
+ *
+ * ## Why protect rather than normalize
+ *
+ * The measured failure on the 69-case corpus is not that the models fail to *find* numbers, it is
+ * that they perform spoken-numeral -> digit conversion badly: 24.6% corruption for LFM2.5-350M,
+ * 47.8% for mumble-cleanup, with order-of-magnitude errors (`one point two million dollars` ->
+ * `$1200M`) and dropped digits in phone numbers. Masking removes that operation from the model's
+ * reach entirely. It cannot invent a wrong value: the worst case is that the user gets
+ * `twenty three percent` spelled out -- visibly unconverted rather than silently wrong.
+ *
+ * A rule-based spoken-numeral -> digit converter would additionally have to *decide* the correct
+ * rendering (is it `23%`, `23 percent`, or `twenty-three percent`?), which changes user-visible
+ * output and carries its own correctness surface. This class deliberately does neither.
+ *
+ * ## Sentinel choice
+ *
+ * Sentinels are `ZQX` followed by a bijective base-26 letter suffix: `ZQXA`, `ZQXB`, ... `ZQXZ`,
+ * `ZQXAA`, ... Every property of that shape is load-bearing for a 0.5B model asked to "fix
+ * punctuation, capitalization, and obvious speech-to-text errors":
+ *
+ *  - **Letters only, no digits.** An index like `NUM1` reintroduces exactly the token class the
+ *    model mishandles; it will happily respace, comma-group or renumber it. The index is encoded
+ *    in letters so there is no digit anywhere in the masked text.
+ *  - **No punctuation and no brackets.** `{{1}}`, `<n1>` and `[1]` all read as markup, and a
+ *    model told to fix punctuation treats markup as punctuation to normalize, translate to the
+ *    surrounding markup dialect, or drop. `ZQXA` is a bare word to the tokenizer.
+ *  - **No whitespace.** A multi-token sentinel can be split across a line wrap or have a
+ *    "missing" space inserted into it.
+ *  - **`ZQX` does not occur in English** (nor in any of the 23 reference transcripts), which
+ *    minimizes collisions with dictated content. The bare word also avoids the numeric and markup
+ *    token classes these small models demonstrably mangle. It is not assumed to survive: the
+ *    restoration checks below reject missing or unknown sentinels and fall back to raw text.
+ *  - **Case-insensitive on the way back.** Models do lowercase or title-case mid-sentence words;
+ *    [restore] matches case-insensitively so a returned `Zqxa` still resolves.
+ *
+ * ## Degradation policy (exact)
+ *
+ * [restore] never throws and never emits a value the speaker did not say. Given the model's
+ * output:
+ *
+ *  1. **Every recognized sentinel occurrence is replaced by its span verbatim.** If the model
+ *     duplicated a sentinel, the number appears twice. That is a prose defect of the same kind
+ *     the model can already introduce with ordinary words, and it is strictly preferable to
+ *     inventing a value.
+ *  2. **A sentinel glued to trailing letters** (`ZQXAdollars`) resolves by longest valid prefix,
+ *     so only the sentinel part is replaced and the stray letters are left alone.
+ *  3. **A missing sentinel fails the restoration** -- [NumericRestoration.Failed]. The model
+ *     dropped a number outright; re-inserting it at a guessed position would produce a sentence
+ *     that reads as authoritative and is wrong ("Send to the account $450"). Falling through to
+ *     raw text is the honest outcome.
+ *  4. **An unknown sentinel fails the restoration.** `ZQXQQ` when only two spans exist means the
+ *     model hallucinated a token; there is nothing correct to substitute.
+ *  5. **No spans at all** -> the model output is returned byte-identical, with no scanning.
+ *
+ * Kept free of Android and llama.cpp imports so every branch above is a plain JVM unit test, in
+ * the same style as [LocalCleanupOutputValidator].
+ */
+object NumericSpanProtector {
+
+    /** The fixed, non-English prefix every sentinel starts with. See the class kdoc. */
+    const val SENTINEL_PREFIX = "ZQX"
+
+    /** Matches a sentinel-shaped token anywhere in text, case-insensitively. The suffix is greedy
+     *  on purpose; [resolveSentinel] then takes the longest *valid* prefix of it, which is what
+     *  makes `ZQXAdollars` degrade gracefully instead of failing. */
+    private val SENTINEL_PATTERN = Regex("${SENTINEL_PREFIX}[a-z]+", RegexOption.IGNORE_CASE)
+
+    /**
+     * Replaces every numeric span in [text] with a sentinel.
+     *
+     * Returns an empty masking (input unchanged) when [text] contains no numeric span. A raw
+     * transcript that already contains a sentinel-shaped word is still masked, but that word is
+     * skipped when assigning sentinels. If it survives in model output, [restore] recognizes it
+     * as unknown and safely fails the local step rather than substituting the wrong number.
+     */
+    fun mask(text: String): NumericMasking {
+        val spans = detectSpans(text)
+        if (spans.isEmpty()) return NumericMasking(text, text, emptyList())
+
+        val builder = StringBuilder(text.length)
+        val protected = mutableListOf<ProtectedNumericSpan>()
+        var cursor = 0
+        var sentinelIndex = 0
+        spans.forEach { range ->
+            var sentinel = sentinelFor(sentinelIndex++)
+            while (text.contains(sentinel, ignoreCase = true)) {
+                sentinel = sentinelFor(sentinelIndex++)
+            }
+            builder.append(text, cursor, range.first)
+            builder.append(sentinel)
+            protected += ProtectedNumericSpan(sentinel, text.substring(range.first, range.last))
+            cursor = range.last
+        }
+        builder.append(text, cursor, text.length)
+        return NumericMasking(text, builder.toString(), protected)
+    }
+
+    /**
+     * Puts the protected spans back into [modelOutput]. See the class kdoc for the exact policy;
+     * in short, verbatim substitution, and a drop or a hallucinated sentinel fails the whole
+     * cleanup rather than guessing.
+     */
+    fun restore(masking: NumericMasking, modelOutput: String): NumericRestoration {
+        if (masking.isEmpty) return NumericRestoration.Restored(modelOutput)
+
+        val bySentinel: Map<String, String> =
+            masking.spans.associate { it.sentinel.lowercase() to it.original }
+        val seen = mutableSetOf<String>()
+        val builder = StringBuilder(modelOutput.length)
+        var cursor = 0
+
+        for (match in SENTINEL_PATTERN.findAll(modelOutput)) {
+            val resolved = resolveSentinel(match.value, bySentinel)
+                ?: return NumericRestoration.Failed(
+                    "model returned an unrecognized sentinel-shaped token",
+                )
+            builder.append(modelOutput, cursor, match.range.first)
+            builder.append(resolved.original)
+            seen += resolved.key
+            // Only the matched prefix was a sentinel; anything the model glued onto its tail
+            // stays in the output untouched.
+            cursor = match.range.first + resolved.consumedLength
+        }
+        builder.append(modelOutput, cursor, modelOutput.length)
+
+        val missing = bySentinel.keys.count { it !in seen }
+        if (missing > 0) {
+            return NumericRestoration.Failed("$missing of ${bySentinel.size} protected number(s) missing from output")
+        }
+        return NumericRestoration.Restored(builder.toString())
+    }
+
+    /** A resolved sentinel occurrence: which span it maps to, and how many characters of the
+     *  greedy match actually belonged to the sentinel. */
+    private data class ResolvedSentinel(val key: String, val original: String, val consumedLength: Int)
+
+    private fun resolveSentinel(matched: String, bySentinel: Map<String, String>): ResolvedSentinel? {
+        val lowered = matched.lowercase()
+        for (length in lowered.length downTo SENTINEL_PREFIX.length + 1) {
+            val candidate = lowered.substring(0, length)
+            val original = bySentinel[candidate] ?: continue
+            return ResolvedSentinel(candidate, original, length)
+        }
+        return null
+    }
+
+    /** `0 -> ZQXA`, `25 -> ZQXZ`, `26 -> ZQXAA`. Bijective base-26 so no index maps to an empty
+     *  suffix and every sentinel is a distinct letter word. */
+    internal fun sentinelFor(index: Int): String {
+        require(index >= 0) { "sentinel index must be non-negative" }
+        val suffix = StringBuilder()
+        var n = index
+        while (true) {
+            suffix.append('A' + (n % 26))
+            n = n / 26 - 1
+            if (n < 0) break
+        }
+        return SENTINEL_PREFIX + suffix.reverse()
+    }
+
+    // --- detection -------------------------------------------------------------------------
+
+    /**
+     * Half-open `[first, last)` character ranges of every numeric span in [text], in order and
+     * non-overlapping.
+     *
+     * Exposed internally so tests can assert on parsed spans rather than on masked-string
+     * proxies.
+     */
+    internal fun detectSpans(text: String): List<IntRange2> {
+        val tokens = tokenize(text)
+        val spans = mutableListOf<IntRange2>()
+        var index = 0
+        while (index < tokens.size) {
+            val startsWithMonth = tokens[index].kind == TokenKind.DATE_MONTH &&
+                index + 1 < tokens.size && tokens[index + 1].kind.startsSpan
+            if (!tokens[index].kind.startsSpan && !startsWithMonth) {
+                index++
+                continue
+            }
+            var end = index
+            var cursor = index + 1
+            while (cursor < tokens.size) {
+                val kind = tokens[cursor].kind
+                when {
+                    kind.startsSpan -> {
+                        end = cursor
+                        cursor++
+                    }
+                    // A connector only stays inside a span if a number actually follows it, so a
+                    // trailing "and" or a sentence-final "point" is never swallowed.
+                    kind == TokenKind.CONNECTOR &&
+                        cursor + 1 < tokens.size && tokens[cursor + 1].kind.startsSpan -> cursor++
+                    kind == TokenKind.TRAILING -> {
+                        end = cursor
+                        cursor++
+                    }
+                    else -> break
+                }
+            }
+            spans += IntRange2(tokens[index].coreStart, tokens[end].coreEnd)
+            index = end + 1
+        }
+        return spans
+    }
+
+    /** A half-open character range. Named to avoid confusion with Kotlin's inclusive [IntRange]. */
+    internal data class IntRange2(val first: Int, val last: Int)
+
+    private enum class TokenKind(val startsSpan: Boolean) {
+        /** Contains a digit: a digit run, `$12,500`, `50%`, `3:30`, `12/03/2026`, `1st`, `2pm`. */
+        LITERAL(true),
+
+        /** Spelled-out cardinal or ordinal, possibly hyphenated (`twenty-three`). */
+        NUMBER_WORD(true),
+
+        /** Joins two numeric tokens: `and`, `point`, `oh`, `dot`. Never starts or ends a span. */
+        CONNECTOR(false),
+
+        /** Attaches to the end of a span: `percent`, `dollars`, `o'clock`, `pm`. */
+        TRAILING(false),
+
+        /** Starts a date only when immediately followed by a numeric token (`August 18th`). */
+        DATE_MONTH(false),
+
+        OTHER(false),
+    }
+
+    private data class Token(val coreStart: Int, val coreEnd: Int, val kind: TokenKind)
+
+    /**
+     * Splits [text] on whitespace and classifies each token by its "core" -- the token with
+     * surrounding punctuation stripped. Span offsets use the core, so a sentence-final period
+     * stays outside the mask and the model can still repunctuate around it.
+     */
+    private fun tokenize(text: String): List<Token> {
+        val tokens = mutableListOf<Token>()
+        var i = 0
+        while (i < text.length) {
+            if (text[i].isWhitespace()) {
+                i++
+                continue
+            }
+            var end = i
+            while (end < text.length && !text[end].isWhitespace()) end++
+            var coreStart = i
+            var coreEnd = end
+            while (coreStart < coreEnd && text[coreStart] in TRIMMABLE) coreStart++
+            while (coreEnd > coreStart && text[coreEnd - 1] in TRIMMABLE) coreEnd--
+            if (coreStart < coreEnd) {
+                tokens += Token(coreStart, coreEnd, classify(text.substring(coreStart, coreEnd)))
+            }
+            i = end
+        }
+        return tokens
+    }
+
+    private fun classify(core: String): TokenKind {
+        if (core.any { it.isDigit() }) return TokenKind.LITERAL
+        val lowered = core.lowercase()
+        if (lowered in CONNECTOR_WORDS) return TokenKind.CONNECTOR
+        if (lowered in TRAILING_WORDS) return TokenKind.TRAILING
+        if (lowered in DATE_MONTHS) return TokenKind.DATE_MONTH
+        val parts = lowered.split('-').filter { it.isNotEmpty() }
+        if (parts.isNotEmpty() && parts.all { it in NUMBER_WORDS || it in ORDINAL_WORDS }) {
+            return TokenKind.NUMBER_WORD
+        }
+        return TokenKind.OTHER
+    }
+
+    /** Punctuation stripped off a token's edges before classification. Currency symbols and `%`
+     *  are deliberately absent: they are part of the number, not decoration around it. */
+    private val TRIMMABLE: Set<Char> = charArrayOf(
+        '.', ',', '!', '?', ';', ':', '"', '\'', '(', ')', '[', ']', '{', '}', '\u2014', '\u2019',
+    ).toSet()
+
+    /** `point` and `dot` carry decimals (`one point two million`); `oh` is a spoken zero inside a
+     *  digit run (`five oh five`); `and` joins cardinal parts (`four hundred and fifty`). */
+    private val CONNECTOR_WORDS: Set<String> = setOf("and", "point", "dot", "oh")
+
+    /** Units that belong to the number and must be masked with it, so the model is never invited
+     *  to rewrite `ZQXA percent` as `ZQXA%` or `ZQXA dollars` as `$ZQXA`. */
+    private val TRAILING_WORDS: Set<String> = setOf(
+        "percent", "percentage", "%",
+        "dollar", "dollars", "cent", "cents", "euro", "euros", "pound", "pounds",
+        "buck", "bucks", "pence", "penny",
+        "o'clock", "oclock", "am", "pm", "a.m", "p.m",
+    )
+
+    private val DATE_MONTHS: Set<String> = setOf(
+        "january", "february", "march", "april", "may", "june", "july", "august", "september",
+        "october", "november", "december",
+        "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept", "oct", "nov", "dec",
+    )
+
+    private val NUMBER_WORDS: Set<String> = setOf(
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen",
+        "nineteen", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+        "hundred", "thousand", "million", "billion", "trillion",
+        "hundreds", "thousands", "millions", "billions",
+    )
+
+    private val ORDINAL_WORDS: Set<String> = setOf(
+        "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth",
+        "tenth", "eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth", "sixteenth",
+        "seventeenth", "eighteenth", "nineteenth", "twentieth", "thirtieth", "fortieth",
+        "fiftieth", "sixtieth", "seventieth", "eightieth", "ninetieth", "hundredth",
+        "thousandth", "millionth",
+    )
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/NumericSpanProtectorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/NumericSpanProtectorTest.kt
@@ -1,0 +1,397 @@
+package com.trevornk.ramblr
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression suite for [NumericSpanProtector] and [protectedLocalCleanupOutcome] (#155).
+ *
+ * The three `ISSUE_` fixtures are verbatim from the issue body's measured failure list -- the
+ * exact utterances both local models corrupt today. They are the reason this class exists, so
+ * they are asserted as fixtures rather than paraphrased.
+ *
+ * The `EVAL_` tests run the checked-in reference transcripts in
+ * `app/src/test/resources/eval_samples/` (real ASR output; 12 of 23 contain spelled-out numbers)
+ * through a full mask -> identity-model -> restore round trip and assert the text comes back
+ * byte-identical. Those are the strongest negative control available: nothing in the corpus,
+ * numeric or not, may be perturbed by this feature.
+ *
+ * Assertions are on parsed structures ([NumericMasking.spans], [NumericSpanProtector.detectSpans],
+ * [ProtectedCleanupOutcome]), never on substring checks against a masked string.
+ *
+ * Mutation-proving: disable masking, disable restoration, or relax the unmatched-sentinel policy
+ * and the specific tests named in each section's comment must fail. Evidence recorded in the #155
+ * PR description.
+ */
+class NumericSpanProtectorTest {
+
+    private val plainPrompt: String =
+        LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList())
+
+    /** The original substrings the protector lifted out, in order. */
+    private fun originals(text: String): List<String> =
+        NumericSpanProtector.mask(text).spans.map { it.original }
+
+    /** A model that returns the masked text unchanged -- the ideal round trip. */
+    private fun roundTrip(text: String): NumericRestoration {
+        val masking = NumericSpanProtector.mask(text)
+        return NumericSpanProtector.restore(masking, masking.maskedText)
+    }
+
+    private fun restoredText(restoration: NumericRestoration): String {
+        assertTrue(
+            "expected a successful restoration but got $restoration",
+            restoration is NumericRestoration.Restored,
+        )
+        return (restoration as NumericRestoration.Restored).text
+    }
+
+    // --- the three verbatim failures from the issue body --------------------------------------
+    // Mutation: make detectSpans return emptyList(), or drop any of the decimal / percent /
+    // digit-run branches, and these three fail.
+
+    @Test fun `ISSUE decimal million with currency is protected as one span`() {
+        // "one point two million dollars" -> "$1200M" today: a 1000x overstatement.
+        val text = "the round was one point two million dollars in total"
+        assertEquals(listOf("one point two million dollars"), originals(text))
+        assertEquals(text, restoredText(roundTrip(text)))
+    }
+
+    @Test fun `ISSUE spoken percentage is protected as one span`() {
+        // "we saw like a twenty three percent increase" -> "We saw a 203% increase" today.
+        val text = "we saw like a twenty three percent increase"
+        assertEquals(listOf("twenty three percent"), originals(text))
+        assertEquals(text, restoredText(roundTrip(text)))
+    }
+
+    @Test fun `ISSUE spoken phone number is protected as one span`() {
+        // "five five five one two three four five six seven" -> "551234567" today: a dropped digit.
+        val text = "call me at five five five one two three four five six seven"
+        assertEquals(listOf("five five five one two three four five six seven"), originals(text))
+        assertEquals(text, restoredText(roundTrip(text)))
+    }
+
+    // --- detection coverage -------------------------------------------------------------------
+    // Mutation: remove an entry from NUMBER_WORDS / ORDINAL_WORDS / TRAILING_WORDS, or make
+    // classify() ignore digits, and the matching case below fails.
+
+    @Test fun `digit runs currency and percentages are detected`() {
+        assertEquals(listOf("2026"), originals("ship it in 2026"))
+        assertEquals(listOf("\$12,500"), originals("transfer \$12,500 tomorrow"))
+        assertEquals(listOf("50%"), originals("margin is 50% now"))
+        assertEquals(listOf("3.14"), originals("pi is about 3.14 roughly"))
+    }
+
+    @Test fun `times dates and ordinals are detected`() {
+        assertEquals(listOf("3:30"), originals("meet at 3:30 downstairs"))
+        assertEquals(listOf("12/03/2026"), originals("due 12/03/2026 latest"))
+        assertEquals(listOf("August eighteenth"), originals("due August eighteenth latest"))
+        assertEquals(listOf("Aug 18, 2026"), originals("due Aug 18, 2026 latest"))
+        assertEquals(listOf("1st"), originals("the 1st attempt failed"))
+        assertEquals(listOf("twenty first"), originals("the twenty first attempt failed"))
+        assertEquals(listOf("four thirty"), originals("actually at four thirty instead"))
+    }
+
+    @Test fun `hyphenated and connector-joined cardinals stay one span`() {
+        assertEquals(listOf("twenty-three"), originals("about twenty-three people came"))
+        assertEquals(
+            listOf("four hundred and fifty dollars"),
+            originals("send four hundred and fifty dollars over"),
+        )
+        assertEquals(listOf("five oh five"), originals("area code five oh five here"))
+    }
+
+    @Test fun `a trailing connector is not swallowed into the span`() {
+        // "and" only continues a span when a number follows it; "point" likewise.
+        assertEquals(listOf("three"), originals("we need three and then some rest"))
+        assertEquals(listOf("two"), originals("that is my two point exactly here"))
+    }
+
+    @Test fun `surrounding punctuation stays outside the span so the model can repunctuate`() {
+        assertEquals(listOf("twenty three percent"), originals("it rose, twenty three percent."))
+    }
+
+    @Test fun `detected spans are ordered and non-overlapping`() {
+        val text = "first item rose twenty three percent then cost four hundred dollars later"
+        val spans = NumericSpanProtector.detectSpans(text)
+        assertEquals(3, spans.size)
+        spans.zipWithNext().forEach { (a, b) ->
+            assertTrue("spans must be ordered and non-overlapping: $a then $b", a.last <= b.first)
+        }
+        assertEquals(
+            listOf("first", "twenty three percent", "four hundred dollars"),
+            spans.map { text.substring(it.first, it.last) },
+        )
+    }
+
+    // --- sentinels ----------------------------------------------------------------------------
+    // Mutation: change sentinelFor to emit digits or punctuation and these fail.
+
+    @Test fun `sentinels are letters only and contain no digits or markup`() {
+        val text = "call five five five one two three four and send \$12,500 by 3:30"
+        val masking = NumericSpanProtector.mask(text)
+        assertEquals(3, masking.spans.size)
+        masking.spans.forEach { span ->
+            assertTrue(
+                "sentinel must be prefix + letters only: ${span.sentinel}",
+                span.sentinel.matches(Regex("ZQX[A-Z]+")),
+            )
+        }
+        assertFalse(
+            "masked text must contain no digits at all",
+            masking.maskedText.any { it.isDigit() },
+        )
+        assertEquals(
+            "sentinels must be distinct",
+            masking.spans.size,
+            masking.spans.map { it.sentinel }.toSet().size,
+        )
+    }
+
+    @Test fun `sentinel indices are bijective base 26`() {
+        assertEquals("ZQXA", NumericSpanProtector.sentinelFor(0))
+        assertEquals("ZQXZ", NumericSpanProtector.sentinelFor(25))
+        assertEquals("ZQXAA", NumericSpanProtector.sentinelFor(26))
+        assertEquals("ZQXAB", NumericSpanProtector.sentinelFor(27))
+        val generated = (0 until 60).map { NumericSpanProtector.sentinelFor(it) }
+        assertEquals("every index must yield a distinct sentinel", 60, generated.toSet().size)
+    }
+
+    @Test fun `a preexisting sentinel-shaped word cannot be substituted as a number`() {
+        val text = "the ZQXA part number needs twenty three units"
+        val masking = NumericSpanProtector.mask(text)
+        assertEquals(listOf("twenty three"), masking.spans.map { it.original })
+        assertEquals("ZQXB", masking.spans.single().sentinel)
+        assertTrue(
+            NumericSpanProtector.restore(masking, masking.maskedText) is NumericRestoration.Failed,
+        )
+    }
+
+    // --- restoration and the degradation policy -----------------------------------------------
+    // Mutation: make restore() return the model output unchanged, or return Restored on a
+    // missing/unknown sentinel, and these fail.
+
+    @Test fun `restoration is verbatim through a realistic cleanup of the surrounding prose`() {
+        val text = "so um we saw like a twenty three percent increase i think"
+        val masking = NumericSpanProtector.mask(text)
+        val sentinel = masking.spans.single().sentinel
+        val modelOutput = "We saw a $sentinel increase."
+        assertEquals("We saw a twenty three percent increase.", restoredText(NumericSpanProtector.restore(masking, modelOutput)))
+    }
+
+    @Test fun `a lowercased sentinel still resolves`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars today")
+        val restoration = NumericSpanProtector.restore(masking, "Send zqxa today.")
+        assertEquals("Send four hundred dollars today.", restoredText(restoration))
+    }
+
+    @Test fun `a duplicated sentinel restores the span twice rather than failing`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars today")
+        val sentinel = masking.spans.single().sentinel
+        val restoration = NumericSpanProtector.restore(masking, "Send $sentinel, yes $sentinel, today.")
+        assertEquals(
+            "Send four hundred dollars, yes four hundred dollars, today.",
+            restoredText(restoration),
+        )
+    }
+
+    @Test fun `a sentinel glued to trailing letters resolves by longest valid prefix`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars today")
+        val sentinel = masking.spans.single().sentinel
+        val restoration = NumericSpanProtector.restore(masking, "Send ${sentinel}ish today.")
+        assertEquals("Send four hundred dollarsish today.", restoredText(restoration))
+    }
+
+    @Test fun `a dropped sentinel fails restoration instead of guessing a position`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars to the account today")
+        val restoration = NumericSpanProtector.restore(masking, "Send to the account today.")
+        assertTrue(
+            "a dropped number must fail the cleanup, not be re-inserted at a guess",
+            restoration is NumericRestoration.Failed,
+        )
+        assertTrue((restoration as NumericRestoration.Failed).reason.isNotBlank())
+    }
+
+    @Test fun `an unknown sentinel fails restoration`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars today")
+        val restoration = NumericSpanProtector.restore(masking, "Send ZQXQQQ today.")
+        assertTrue(
+            "a hallucinated sentinel has no correct substitution",
+            restoration is NumericRestoration.Failed,
+        )
+    }
+
+    @Test fun `restoration of a partially dropped multi-span output fails`() {
+        val masking = NumericSpanProtector.mask("call five five five one two three four about the \$12,500")
+        assertEquals(2, masking.spans.size)
+        val restoration = NumericSpanProtector.restore(
+            masking,
+            "Call ${masking.spans[0].sentinel} about it.",
+        )
+        assertTrue(restoration is NumericRestoration.Failed)
+    }
+
+    @Test fun `restoration never throws on adversarial model output`() {
+        val masking = NumericSpanProtector.mask("send four hundred dollars today")
+        val hostile = listOf("", "   ", "ZQX", "zqx zqxzzzzz ZQXA", "ZQXA".repeat(50), "<ZQXA/>")
+        hostile.forEach { output ->
+            // The assertion is that this returns a verdict at all rather than throwing.
+            assertNotNull("restore must not throw on: \"$output\"", NumericSpanProtector.restore(masking, output))
+        }
+    }
+
+    // --- negative controls: no numbers means no change ----------------------------------------
+    // Mutation: make mask() always allocate a masking, or make restore() rewrite when spans are
+    // empty, and these fail.
+
+    @Test fun `text with no numbers is masked to the identical instance`() {
+        val text = "text sarah back about dinner because the pasta thing needs olive oil"
+        val masking = NumericSpanProtector.mask(text)
+        assertTrue(masking.isEmpty)
+        assertSame("no-number text must not even be rebuilt", text, masking.maskedText)
+    }
+
+    @Test fun `restore is a pass-through when nothing was masked`() {
+        val masking = NumericSpanProtector.mask("where is paris")
+        val cleaned = "Where is Paris?"
+        assertEquals(cleaned, restoredText(NumericSpanProtector.restore(masking, cleaned)))
+    }
+
+    // --- real reference transcripts -----------------------------------------------------------
+
+    private fun evalSamples(): List<Pair<String, String>> {
+        val dir = File("src/test/resources/eval_samples")
+            .takeIf { it.isDirectory }
+            ?: File("app/src/test/resources/eval_samples")
+        assertTrue("eval_samples fixtures not found at ${dir.absolutePath}", dir.isDirectory)
+        val files = dir.listFiles { f: File -> f.name.endsWith(".txt") }?.sortedBy { it.name }.orEmpty()
+        assertTrue("expected the checked-in reference transcripts", files.size >= 20)
+        return files.map { it.name to it.readText() }
+    }
+
+    @Test fun `EVAL every reference transcript survives a mask and restore round trip byte-identically`() {
+        evalSamples().forEach { (name, text) ->
+            assertEquals("round trip changed $name", text, restoredText(roundTrip(text)))
+        }
+    }
+
+    @Test fun `EVAL number-free reference transcripts are not masked at all`() {
+        // Chosen because they contain no numeral, ordinal or digit at all; if the detector starts
+        // firing on ordinary prose it shows up here first.
+        val numberFree = setOf(
+            "edge_very_short_01.txt",
+            "quick_note_04.txt",
+            "rambling_brainstorm_04.txt",
+        )
+        val checked = evalSamples().filter { (name, _) -> name in numberFree }
+        assertEquals("fixture names drifted", numberFree.size, checked.size)
+        checked.forEach { (name, text) ->
+            val masking = NumericSpanProtector.mask(text)
+            assertTrue("$name should have no numeric span but got ${masking.spans}", masking.isEmpty)
+            assertSame(text, masking.maskedText)
+        }
+    }
+
+    @Test fun `EVAL number-bearing reference transcripts do produce spans`() {
+        val expected = mapOf(
+            "quick_note_02.txt" to listOf("five"),
+            "quick_note_03.txt" to listOf("seven", "six"),
+            "self_correction_02.txt" to listOf("three o'clock", "four thirty", "second", "one"),
+            "self_correction_04.txt" to listOf("twenty dollars", "twenty five"),
+            "rambling_brainstorm_03.txt" to listOf("six hundred", "ten", "ten"),
+        )
+        val samples = evalSamples().toMap()
+        expected.forEach { (name, spans) ->
+            val text = samples[name] ?: error("missing fixture $name")
+            assertEquals("spans in $name", spans, NumericSpanProtector.mask(text).spans.map { it.original })
+        }
+    }
+
+    // --- interaction with LocalCleanupOutputValidator ------------------------------------------
+    // Mutation: validate the MASKED input/output instead of the restored pair inside
+    // protectedLocalCleanupOutcome and these fail.
+
+    @Test fun `restored output is validated against the original transcript and accepted`() {
+        val raw = "so um we saw like a twenty three percent increase i think this quarter"
+        val masking = NumericSpanProtector.mask(raw)
+        val modelOutput = "We saw a ${masking.spans.single().sentinel} increase this quarter."
+        val outcome = protectedLocalCleanupOutcome(raw, plainPrompt, masking, modelOutput)
+        assertEquals(
+            ProtectedCleanupOutcome.Accepted("We saw a twenty three percent increase this quarter."),
+            outcome,
+        )
+    }
+
+    @Test fun `masking does not break the LENGTH_COLLAPSE check on a real collapse`() {
+        // The pre-#155 failure: "My address is four one two Selby Road" -> "Selby Road". Because
+        // restoration happens BEFORE validation, the validator still sees the full original
+        // transcript and the full restored output, so LENGTH_COLLAPSE still fires. Validating
+        // masked-vs-masked would have hidden this.
+        val raw = "My address is four one two Selby Road near the old post office"
+        val masking = NumericSpanProtector.mask(raw)
+        val outcome = protectedLocalCleanupOutcome(raw, plainPrompt, masking, masking.spans.single().sentinel)
+        assertTrue("a real collapse must still be rejected", outcome is ProtectedCleanupOutcome.Rejected)
+        assertEquals(
+            LocalCleanupValidation.Reason.LENGTH_COLLAPSE.name,
+            (outcome as ProtectedCleanupOutcome.Rejected).label,
+        )
+    }
+
+    @Test fun `the length ratio the validator sees is computed on restored not masked text`() {
+        // Directly asserts the ratio, so a future refactor that validates masked text is caught
+        // by an arithmetic fact rather than by a message string.
+        val raw = "transfer twelve thousand five hundred dollars tomorrow to the savings account"
+        val masking = NumericSpanProtector.mask(raw)
+        val restored = restoredText(NumericSpanProtector.restore(masking, masking.maskedText))
+        val maskedRatio = ratio(raw, masking.maskedText)
+        val restoredRatio = ratio(raw, restored)
+        assertEquals("a full round trip is length-neutral", 1.0, restoredRatio, 1e-9)
+        assertTrue(
+            "masked text is materially shorter, which is why it must not be what is validated " +
+                "(masked ratio $maskedRatio)",
+            maskedRatio < restoredRatio,
+        )
+        assertEquals(
+            ProtectedCleanupOutcome.Accepted(restored),
+            protectedLocalCleanupOutcome(raw, plainPrompt, masking, masking.maskedText),
+        )
+    }
+
+    private fun ratio(input: String, output: String): Double =
+        LocalCleanupOutputValidator.normalizeForLength(output).length.toDouble() /
+            LocalCleanupOutputValidator.normalizeForLength(input).length
+
+    @Test fun `a failed restoration is reported as a rejection so the waterfall falls through`() {
+        val raw = "send four hundred and fifty dollars to the account ending in nine three seven two"
+        val masking = NumericSpanProtector.mask(raw)
+        val outcome = protectedLocalCleanupOutcome(raw, plainPrompt, masking, "Send to the account.")
+        assertTrue(outcome is ProtectedCleanupOutcome.Rejected)
+        assertEquals(
+            ProtectedCleanupOutcome.Rejected.NUMERIC_RESTORATION,
+            (outcome as ProtectedCleanupOutcome.Rejected).label,
+        )
+        assertTrue("a rejection must carry a diagnostic detail", outcome.detail.isNotBlank())
+    }
+
+    @Test fun `NEGATIVE CONTROL correct cleanup of number-free text is still accepted unchanged`() {
+        val raw = "so i keep going back and forth on whether the clipboard fallback should be silent"
+        val masking = NumericSpanProtector.mask(raw)
+        val cleaned = "I keep going back and forth on whether the clipboard fallback should be silent."
+        assertEquals(
+            ProtectedCleanupOutcome.Accepted(cleaned),
+            protectedLocalCleanupOutcome(raw, plainPrompt, masking, cleaned),
+        )
+    }
+
+    @Test fun `NEGATIVE CONTROL prompt echo is still caught on the protected path`() {
+        val raw = "call me at five five five one two three four"
+        val masking = NumericSpanProtector.mask(raw)
+        val outcome = protectedLocalCleanupOutcome(raw, plainPrompt, masking, plainPrompt)
+        assertTrue(outcome is ProtectedCleanupOutcome.Rejected)
+    }
+}


### PR DESCRIPTION
## Summary

- Protect numeric spans from local cleanup by replacing them with letter-only sentinels and restoring the original spoken text verbatim.
- Reject local cleanup when a protected sentinel is dropped or unknown rather than guessing a value or position.
- Restore before running the existing local-output validator, comparing the restored output with the original raw transcript.

## Protect vs. normalize

This change deliberately **protects** numbers rather than converting spoken numerals to digits. Normalization must choose a rendering (`23%`, `23 percent`, or the original words) and adds a second value-conversion correctness surface. Protection preserves exactly what the speaker said; its worst successful outcome is visibly unnormalized text, not an invented numeric value.

The sentinels use only letters (`ZQXA`, `ZQXB`, …). Digits would reintroduce the token class under protection, while brackets and punctuation invite a punctuation-repair model to rewrite markup. The implementation does **not** assume a sentinel will always survive the model: restoration is case-insensitive, supports a valid sentinel glued to trailing prose by resolving the longest valid prefix, and fails closed when a protected sentinel is missing or no valid sentinel prefix exists.

Duplicated known sentinels are restored verbatim at each occurrence; the existing validator can then reject excessive duplication. Missing and unknown sentinels reject the local step without throwing, allowing the waterfall to continue or inject raw text.

## Integration ordering

1. Detect and mask numeric spans in the original local-cleanup input.
2. Run local inference on the masked input.
3. Restore every protected span verbatim.
4. Validate the restored output against the original raw input.

That ordering preserves both `LENGTH_COLLAPSE` and `NUMERIC_DIVERGENCE`; validating masked text would bypass numeric comparison and distort the length baseline. Rejection logs contain only category/detail, never transcript or model text.

## Verification

### Unit tests (JUnit XML)

- Clean baseline: **134 suites / 1,237 tests / 0 failures / 0 errors / 0 skipped**.
- Final unfiltered `:app:testGithubDebugUnitTest --offline --rerun-tasks`: **135 suites / 1,268 tests / 0 failures / 0 errors / 0 skipped**.

### Mutation proofs

- Disabled detection (`detectSpans` tokenization replaced with an empty list): focused suite **1 suite / 31 tests / 23 failures / 0 errors / 0 skipped**.
- Disabled restoration (`restore` returned model output unchanged): focused suite **1 suite / 31 tests / 16 failures / 0 errors / 0 skipped**, including verbatim restoration, lowercase/duplicate/glued-suffix restoration, issue fixtures, eval round trip, and validator-order tests.
- Relaxed missing/unknown policy (unknown matches skipped and missing check disabled): focused suite **1 suite / 31 tests / 5 failures / 0 errors / 0 skipped**, including dropped sentinel, unknown sentinel, partial multi-span drop, preexisting-sentinel collision, and waterfall rejection tests.
- Each temporary mutation produced assertion failures (not compile failures), then the production file was restored to its saved SHA-256 before the next run.

### Build and hygiene

- `:app:assembleGithubDebug --offline`: **BUILD SUCCESSFUL**.
- Fresh APK: `app/build/outputs/apk/github/debug/Ramblr-1.0.24-github-debug.apk` (81,736,718 bytes), mtime newer than pre-commit `HEAD`.
- `git diff --check`: clean.
- No unrelated or harness files included.

Refs #155
