### PR TITLE
Normalize spoken numbers before local cleanup and verify preservation

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -744,16 +744,26 @@ object CleanupWaterfallExecutor {
             // as `deadlineAtMs - CLEANUP_WATERFALL_HARD_CAP_MS` -- exact here, since execute()
             // builds deadlineAtMs as startedAtMs + CLEANUP_WATERFALL_HARD_CAP_MS.
             val localDeadlineAtMs = localLlmStepDeadline(deadlineAtMs, System.currentTimeMillis(), isLastStep)
+            val normalization = SpokenNumberNormalizer.normalize(text)
             callback(
-                when (val result = localInference.complete(localPrompt, text, modelPath, localDeadlineAtMs, { cancelHolder.isCancelled })) {
+                when (
+                    val result = localInference.complete(
+                        localPrompt,
+                        normalization.text,
+                        modelPath,
+                        localDeadlineAtMs,
+                        { cancelHolder.isCancelled },
+                    )
+                ) {
                     is LocalInferenceResult.Success -> {
-                        // Trim to match what both cloud parsers already do to their model text
-                        // (PostProcessor.parseResponse / AnthropicCleanupProvider.parseResponse):
-                        // small local models routinely emit a leading space or newline as the
-                        // first sampled piece, which was injected verbatim (#84).
+                        // Trim to match what both cloud parsers already do to their model text.
                         val trimmed = result.text.trim()
-                        if (trimmed.isNotEmpty()) CleanupStepOutcome.Success(trimmed)
-                        else CleanupStepOutcome.StepFailed("Local model produced an empty response")
+                        when {
+                            trimmed.isEmpty() -> CleanupStepOutcome.StepFailed("Local model produced an empty response")
+                            NumericPreservationVerifier.verify(normalization, trimmed) is NumericPreservation.Rejected ->
+                                CleanupStepOutcome.StepFailed("Local cleanup output rejected (NUMERIC_DIVERGENCE)")
+                            else -> CleanupStepOutcome.Success(trimmed)
+                        }
                     }
                     is LocalInferenceResult.Failure -> CleanupStepOutcome.StepFailed(result.message)
                     is LocalInferenceResult.TimedOut -> CleanupStepOutcome.StepFailed(result.message)

--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
@@ -204,7 +204,9 @@ object LocalCleanupOutputValidator {
         val inputRuns = numericRuns(rawInput)
         if (inputRuns.isEmpty()) return null
 
-        val outputValues = numericRuns(modelOutput).flatten().toSet()
+        val outputValues = (
+            numericRuns(modelOutput).flatten() + NumericValueExtractor.extract(modelOutput)
+        ).toSet()
         val missing = inputRuns.firstOrNull { candidates -> candidates.none { it in outputValues } }
             ?: return null
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/NumericPreservationVerifier.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/NumericPreservationVerifier.kt
@@ -1,0 +1,74 @@
+package com.trevornk.ramblr
+
+/** Result of exact, ordered semantic numeric preservation after local-model cleanup. */
+sealed class NumericPreservation {
+    object Valid : NumericPreservation()
+    data class Rejected(val detail: String) : NumericPreservation()
+}
+
+/**
+ * Verifies that local cleanup returned exactly the normalized numeric sequence it received (#155).
+ * Formatting is not identity: a ten-digit phone value may gain parentheses, spaces, or hyphens.
+ * Values may not change, disappear, duplicate, or reorder. Diagnostics contain counts only, never
+ * transcript or model output.
+ */
+object NumericPreservationVerifier {
+    fun verify(
+        normalization: SpokenNumberNormalization,
+        modelOutput: String,
+    ): NumericPreservation {
+        val actual = NumericValueExtractor.extract(modelOutput)
+        return if (actual == normalization.semanticValues) {
+            NumericPreservation.Valid
+        } else {
+            NumericPreservation.Rejected(
+                "numeric sequence diverged (expected ${normalization.semanticValues.size} value(s), " +
+                    "found ${actual.size})",
+            )
+        }
+    }
+}
+
+/** Shared numeric semantics for normalized input and post-model output. */
+internal object NumericValueExtractor {
+    fun extract(text: String): List<String> =
+        VALUE.findAll(text).map { match ->
+            // A phone-shaped match is digits only: its separators are formatting, and `.` must not
+            // survive the way a decimal point does or `212.555.3476` would never equal the
+            // normalized `2125553476`.
+            if (isPhone(match.value)) {
+                match.value.filter { it.isDigit() }
+            } else {
+                match.value.filter { it.isDigit() || it == '.' }.trimEnd('.')
+            }
+        }.toList()
+
+    /**
+     * A single dot is far more likely a decimal point than a phone separator, so `3.1415926`
+     * keeps its decimal meaning while `212.555.3476` is treated as formatting.
+     */
+    private fun isPhone(value: String): Boolean {
+        if (!PHONE.matches(value)) return false
+        return value.count { it == '.' } != 1
+    }
+
+    /**
+     * Phone separators models actually emit: space, hyphen, or dot, with optional area parens and
+     * an optional country code. Covers the 7-digit local form as well as 10-digit NANP, because a
+     * punctuation-only reformat must never read as a value change.
+     */
+    private const val SEP = "[ .-]?"
+    private const val PHONE_BODY =
+        "(?:\\+?\\d{1,3}$SEP)?(?:\\(\\d{3}\\)$SEP|\\d{3}$SEP)?\\d{3}$SEP\\d{4}"
+
+    private val PHONE = Regex(PHONE_BODY)
+
+    // Phone is the first alternative so `(212) 555-3476` is one semantic value. Other punctuation
+    // is deliberately parsed as separate values: `100 minus 25 is 75` must remain a 3-value
+    // sequence, while currency grouping and decimals stay one value.
+    private val VALUE = Regex(
+        "(?<![\\d+(])$PHONE_BODY(?!\\d)|" +
+            "(?<![\\p{L}\\d])[$€£¥]?\\d+(?:,\\d{3})*(?:\\.\\d+)?(?:st|nd|rd|th)?(?![\\p{L}\\d])",
+        RegexOption.IGNORE_CASE,
+    )
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/SpokenNumberNormalizer.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/SpokenNumberNormalizer.kt
@@ -1,0 +1,305 @@
+package com.trevornk.ramblr
+
+import java.math.BigDecimal
+
+/** Deterministic text and the ordered numeric values introduced into it for local cleanup. */
+data class SpokenNumberNormalization(
+    val text: String,
+    val semanticValues: List<String>,
+)
+
+/**
+ * Conservative spoken-number to digit normalization for the local cleanup path (#155).
+ *
+ * This is intentionally pure Kotlin with no model or Android dependency. Ambiguous quantifiers
+ * (half, quarter, dozen) are not vocabulary, and a bare "one" is left alone because it is commonly
+ * an article or pronoun. Renderings are plain ungrouped digits; units remain words. A decimal with
+ * a multiplier is expanded (`one point two million` -> `1200000`) to avoid ambiguous model tokens.
+ */
+object SpokenNumberNormalizer {
+    fun normalize(text: String): SpokenNumberNormalization {
+        val tokens = tokenize(text)
+        val replacements = mutableListOf<Replacement>()
+        var index = 0
+        while (index < tokens.size) {
+            val monthOrdinal = parseMonthOrdinal(tokens, index, text)
+            if (monthOrdinal != null) {
+                replacements += monthOrdinal
+                index = monthOrdinal.nextToken
+                continue
+            }
+            if (tokens[index].word !in NUMBER_OR_ORDINAL_WORDS) {
+                index++
+                continue
+            }
+            // A run with no confident rendering is skipped whole. Re-scanning inside it would
+            // convert a fragment of an expression we just declined to read ("twenty twenty
+            // dollar bills"), which is exactly the silent corruption this pass exists to avoid.
+            val runEnd = runEndToken(tokens, index, text)
+            val parsed = parseNumberRun(tokens, index, text)
+            if (parsed != null) replacements += parsed
+            index = parsed?.nextToken ?: (runEnd + 1)
+        }
+        if (replacements.isEmpty()) {
+            return SpokenNumberNormalization(text, NumericValueExtractor.extract(text))
+        }
+
+        val output = StringBuilder(text.length)
+        var position = 0
+        replacements.forEach { replacement ->
+            output.append(text, position, replacement.start)
+            output.append(replacement.value)
+            position = replacement.end
+        }
+        output.append(text, position, text.length)
+        val normalizedText = output.toString()
+        return SpokenNumberNormalization(
+            normalizedText,
+            NumericValueExtractor.extract(normalizedText),
+        )
+    }
+
+    private fun parseMonthOrdinal(tokens: List<Token>, index: Int, text: String): Replacement? {
+        if (tokens[index].word !in MONTHS || index + 1 >= tokens.size) return null
+        val run = collectOrdinalRun(tokens, index + 1, text) ?: return null
+        val rendered = renderOrdinal(run.words) ?: return null
+        return Replacement(tokens[index + 1].start, tokens[run.endToken].end, rendered, run.endToken + 1)
+    }
+
+    /** Collect through the first ordinal and stop, so a following spoken year is a separate run. */
+    private fun collectOrdinalRun(tokens: List<Token>, start: Int, text: String): Run? {
+        val words = mutableListOf<String>()
+        var cursor = start
+        while (cursor < tokens.size) {
+            if (cursor > start && text.substring(tokens[cursor - 1].end, tokens[cursor].start).any { !it.isWhitespace() }) return null
+            val word = tokens[cursor].word
+            if (word == "and" && words.isNotEmpty()) {
+                words += word
+            } else if (word in NUMBER_OR_ORDINAL_WORDS) {
+                words += word
+                if (word in ORDINALS) return Run(words, cursor)
+            } else {
+                return null
+            }
+            cursor++
+        }
+        return null
+    }
+
+    private fun runEndToken(tokens: List<Token>, index: Int, text: String): Int =
+        collectRun(tokens, index, text)?.endToken ?: index
+
+    private fun parseNumberRun(tokens: List<Token>, index: Int, text: String): Replacement? {
+        val run = collectRun(tokens, index, text) ?: return null
+        val previous = tokens.getOrNull(index - 1)?.word
+        val next = tokens.getOrNull(run.endToken + 1)?.word
+        val rendered = renderTime(run.words, previous, next)
+            ?: renderDecimal(run.words)
+            ?: renderOrdinal(run.words)
+            ?: renderSpokenYear(run.words, previous)
+            ?: renderCardinal(run.words, next)
+            ?: return null
+        return Replacement(tokens[index].start, tokens[run.endToken].end, rendered, run.endToken + 1)
+    }
+
+    private fun collectRun(tokens: List<Token>, start: Int, text: String): Run? {
+        val words = mutableListOf<String>()
+        var cursor = start
+        var end = start - 1
+        while (cursor < tokens.size) {
+            // A run may only span whitespace. Punctuation ends it, so "one, two" and "one. Two"
+            // stay two numbers instead of merging into 12.
+            if (cursor > start && text.substring(tokens[cursor - 1].end, tokens[cursor].start).any { !it.isWhitespace() }) break
+            val word = tokens[cursor].word
+            val numeric = word in NUMBER_OR_ORDINAL_WORDS || word == "point" || word == "dot"
+            // "and" continues only a scale compound ("four hundred and fifty"); "one and two"
+            // is two separate quantities.
+            val connector = word == "and" && words.any { it in BIG_SCALES || it == "hundred" } &&
+                cursor + 1 < tokens.size && tokens[cursor + 1].word in NUMBER_OR_ORDINAL_WORDS
+            if (!numeric && !connector) break
+            words += word
+            end = cursor
+            cursor++
+        }
+        return if (end >= start) Run(words, end) else null
+    }
+
+    /**
+     * Clock times in the shapes ASR actually produces: `four thirty`, `four thirty five`,
+     * `twelve oh five`. Only fires with explicit time context ("at"/"around"/"by") or an
+     * am/pm/o'clock suffix, so a bare "four thirty five" stays a cardinal.
+     */
+    private fun renderTime(words: List<String>, previous: String?, next: String?): String? {
+        if (words.size !in 2..3 || (previous !in TIME_CONTEXT && next !in TIME_SUFFIXES)) return null
+        val hour = VALUES[words[0]] ?: return null
+        if (hour !in 1..12) return null
+        val minute = when (words.size) {
+            2 -> VALUES[words[1]] ?: return null
+            // "oh five" -> 5; "thirty five" -> 35. Anything else is not a clock reading.
+            else -> {
+                val first = VALUES[words[1]] ?: return null
+                val second = VALUES[words[2]] ?: return null
+                when {
+                    words[1] in ZERO_WORDS && second in 1..9 -> second
+                    first in TENS_WORDS_VALUES && second in 1..9 -> first + second
+                    else -> return null
+                }
+            }
+        }
+        if (minute !in 0..59) return null
+        return "$hour:${minute.toString().padStart(2, '0')}"
+    }
+
+    private fun renderDecimal(words: List<String>): String? {
+        val point = words.indexOfFirst { it == "point" || it == "dot" }
+        if (point <= 0 || point == words.lastIndex) return null
+        val multiplierWord = words.last().takeIf { it in BIG_SCALES }
+        val fractionEnd = if (multiplierWord == null) words.size else words.lastIndex
+        val fraction = words.subList(point + 1, fractionEnd)
+        if (fraction.isEmpty() || fraction.any { it !in DIGITS }) return null
+        val whole = cardinalValue(words.subList(0, point).filterNot { it == "and" }) ?: return null
+        var value = BigDecimal("$whole.${fraction.joinToString("") { DIGITS.getValue(it).toString() }}")
+        if (multiplierWord != null) value = value.multiply(BigDecimal(BIG_SCALES.getValue(multiplierWord)))
+        return value.stripTrailingZeros().toPlainString()
+    }
+
+    private fun renderOrdinal(words: List<String>): String? {
+        val last = words.lastOrNull() ?: return null
+        val ordinalValue = ORDINALS[last] ?: return null
+        val cardinalWords = words.dropLast(1).filterNot { it == "and" }
+        val prefix = if (cardinalWords.isEmpty()) null else cardinalValue(cardinalWords) ?: return null
+        // Scale ordinals multiply ("two hundredth" = 200th); the rest add ("twenty first" = 21st).
+        val value = when {
+            prefix == null -> ordinalValue
+            last in SCALE_ORDINALS -> prefix * ordinalValue
+            else -> prefix + ordinalValue
+        }
+        val suffix = when (value % 100) {
+            11L, 12L, 13L -> "th"
+            else -> when (value % 10) { 1L -> "st"; 2L -> "nd"; 3L -> "rd"; else -> "th" }
+        }
+        return "$value$suffix"
+    }
+
+    /**
+     * Common ASR year form: `twenty twenty six` -> 2026, `nineteen eighty four` -> 1984.
+     * Requires date context ("in 2026", "August eighteenth 2026") because `twenty twenty dollar
+     * bills` is two quantities, not a year. A two-word cardinal such as `twenty one` stays 21.
+     */
+    private fun renderSpokenYear(words: List<String>, previous: String?): String? {
+        if (previous == null) return null
+        if (previous !in YEAR_CONTEXT && previous !in ORDINALS && previous !in MONTHS) return null
+        val century = when (words.firstOrNull()) {
+            "nineteen" -> 1900L
+            "twenty" -> 2000L
+            else -> return null
+        }
+        val remainderWords = words.drop(1).filterNot { it == "and" }
+        if (remainderWords.isEmpty()) return null
+        val looksLikeYear = remainderWords.size >= 2 || (VALUES[remainderWords.first()] ?: 0L) >= 10L
+        if (!looksLikeYear) return null
+        val remainder = if (remainderWords.all { it in DIGITS }) {
+            remainderWords.joinToString("") { DIGITS.getValue(it).toString() }.toLongOrNull()
+        } else {
+            cardinalValue(remainderWords)
+        } ?: return null
+        if (remainder !in 0L..99L) return null
+        return (century + remainder).toString()
+    }
+
+    private fun renderCardinal(words: List<String>, next: String? = null): String? {
+        val cardinalWords = words.filterNot { it == "and" }
+        if (cardinalWords.isEmpty()) return null
+        if (cardinalWords == listOf("one") && next !in UNAMBIGUOUS_ONE_UNITS) return null
+        if (cardinalWords.all { it in DIGITS } && cardinalWords.size >= 2) {
+            return cardinalWords.joinToString("") { DIGITS.getValue(it).toString() }
+        }
+        return cardinalValue(cardinalWords)?.toString()
+    }
+
+    /**
+     * Standard cardinal accumulation ("twelve thousand five hundred" -> 12500).
+     *
+     * Consecutive value words must strictly decrease ("twenty three" = 23), so a non-cardinal
+     * sequence such as "twenty twenty" is rejected rather than silently summed to 40.
+     */
+    private fun cardinalValue(words: List<String>): Long? {
+        if (words.isEmpty() || words.any { it !in VALUES }) return null
+        var total = 0L
+        var chunk = 0L
+        var lastAdded: Long? = null
+        words.forEach { word ->
+            when {
+                word == "hundred" -> {
+                    chunk = (if (chunk == 0L) 1L else chunk) * 100L
+                    lastAdded = null
+                }
+                word in BIG_SCALES -> {
+                    total += (if (chunk == 0L) 1L else chunk) * BIG_SCALES.getValue(word)
+                    chunk = 0L
+                    lastAdded = null
+                }
+                else -> {
+                    val value = VALUES.getValue(word)
+                    val previous = lastAdded
+                    if (previous != null && value >= previous) return null
+                    chunk += value
+                    lastAdded = value
+                }
+            }
+        }
+        return total + chunk
+    }
+
+    private fun tokenize(text: String): List<Token> = TOKEN.findAll(text).mapNotNull { match ->
+        val value = match.value
+        val leading = value.indexOfFirst { it.isLetterOrDigit() }.takeIf { it >= 0 } ?: return@mapNotNull null
+        val trailing = value.indexOfLast { it.isLetterOrDigit() }
+        Token(match.range.first + leading, match.range.first + trailing + 1, value.substring(leading, trailing + 1).lowercase())
+    }.toList()
+
+    private data class Token(val start: Int, val end: Int, val word: String)
+    private data class Run(val words: List<String>, val endToken: Int)
+    private data class Replacement(val start: Int, val end: Int, val value: String, val nextToken: Int)
+
+    private val TOKEN = Regex("\\S+")
+    private val DIGITS = mapOf(
+        "zero" to 0, "oh" to 0, "one" to 1, "two" to 2, "three" to 3, "four" to 4,
+        "five" to 5, "six" to 6, "seven" to 7, "eight" to 8, "nine" to 9,
+    )
+    private val BIG_SCALES = mapOf("thousand" to 1_000L, "million" to 1_000_000L, "billion" to 1_000_000_000L)
+    private val VALUES: Map<String, Long> = buildMap {
+        DIGITS.forEach { (word, value) -> put(word, value.toLong()) }
+        put("ten", 10); put("eleven", 11); put("twelve", 12); put("thirteen", 13)
+        put("fourteen", 14); put("fifteen", 15); put("sixteen", 16); put("seventeen", 17)
+        put("eighteen", 18); put("nineteen", 19); put("twenty", 20); put("thirty", 30)
+        put("forty", 40); put("fifty", 50); put("sixty", 60); put("seventy", 70)
+        put("eighty", 80); put("ninety", 90); put("hundred", 100)
+        BIG_SCALES.forEach { (word, value) -> put(word, value) }
+    }
+    private val ORDINALS = mapOf(
+        "first" to 1L, "second" to 2L, "third" to 3L, "fourth" to 4L, "fifth" to 5L,
+        "sixth" to 6L, "seventh" to 7L, "eighth" to 8L, "ninth" to 9L, "tenth" to 10L,
+        "eleventh" to 11L, "twelfth" to 12L, "thirteenth" to 13L, "fourteenth" to 14L,
+        "fifteenth" to 15L, "sixteenth" to 16L, "seventeenth" to 17L, "eighteenth" to 18L,
+        "nineteenth" to 19L, "twentieth" to 20L, "thirtieth" to 30L, "fortieth" to 40L,
+        "fiftieth" to 50L, "sixtieth" to 60L, "seventieth" to 70L, "eightieth" to 80L,
+        "ninetieth" to 90L, "hundredth" to 100L, "thousandth" to 1_000L,
+    )
+    private val NUMBER_OR_ORDINAL_WORDS = VALUES.keys + ORDINALS.keys
+    private val SCALE_ORDINALS = setOf("hundredth", "thousandth")
+    private val ZERO_WORDS = setOf("oh", "zero")
+    private val TENS_WORDS_VALUES = setOf(20L, 30L, 40L, 50L)
+    private val MONTHS = setOf(
+        "january", "february", "march", "april", "may", "june", "july", "august", "september",
+        "october", "november", "december", "jan", "feb", "mar", "apr", "jun", "jul", "aug",
+        "sep", "sept", "oct", "nov", "dec",
+    )
+    private val TIME_CONTEXT = setOf("at", "around", "by")
+    private val YEAR_CONTEXT = setOf("in", "since", "of", "year", "from", "until", "till", "by")
+    private val TIME_SUFFIXES = setOf("am", "pm", "oclock")
+    private val UNAMBIGUOUS_ONE_UNITS = setOf(
+        "dollar", "dollars", "euro", "euros", "pound", "pounds", "yen",
+        "percent", "percentage", "percentages",
+    )
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
@@ -116,6 +116,7 @@ class CleanupWaterfallCursorTest {
  *  testable with no real I/O: each call to [send] pops and returns the next queued outcome. */
 private class FakeCleanupHttpTransport(private val outcomes: MutableList<CleanupHttpOutcome>) : CleanupHttpTransport {
     val requestedUrls = mutableListOf<String>()
+    val requestedBodies = mutableListOf<String>()
 
     override fun send(
         url: String,
@@ -126,6 +127,7 @@ private class FakeCleanupHttpTransport(private val outcomes: MutableList<Cleanup
         callback: (CleanupHttpOutcome) -> Unit,
     ) {
         requestedUrls.add(url)
+        requestedBodies.add(jsonBody)
         check(outcomes.isNotEmpty()) { "FakeCleanupHttpTransport ran out of queued outcomes for url=$url" }
         callback(outcomes.removeAt(0))
     }
@@ -487,10 +489,11 @@ class LocalLlmWaterfallStepTest {
         localModelPath: () -> String?,
         credentialLookup: (CleanupCredentialSlot) -> String = { "" },
         localPrompt: String = PostProcessor.SIMPLE_PROMPT,
+        text: String = "raw transcript",
     ): PostProcessor.Result {
         var captured: PostProcessor.Result? = null
         CleanupWaterfallExecutor.execute(
-            text = "raw transcript",
+            text = text,
             prompt = "clean it up",
             waterfall = waterfall,
             cursor = CleanupWaterfallCursor(),
@@ -760,6 +763,45 @@ class LocalLlmWaterfallStepTest {
 
         assertEquals("cleaned via fallback", result.text)
         assertEquals(1, transport.requestedUrls.size)
+    }
+
+    @Test fun `local step normalizes before inference and accepts punctuation-only phone formatting`() {
+        val transport = FakeCleanupHttpTransport(mutableListOf())
+        val engine = FakeLocalInferenceEngine(mutableListOf(LocalInferenceResult.Success("Call (212) 555-3476.")))
+        val waterfall = CleanupWaterfall(listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, LocalCleanupProvider.MODEL.archive)))
+
+        val result = execute(
+            waterfall, transport, engine,
+            localModelPath = { "/path/to/model.gguf" },
+            text = "call two one two five five five three four seven six",
+        )
+
+        assertEquals("call 2125553476", engine.calls.single().second)
+        assertEquals("Call (212) 555-3476.", result.text)
+    }
+
+    @Test fun `numeric verification failure rejects local output and cloud still receives raw text`() {
+        val transport = FakeCleanupHttpTransport(mutableListOf(okOutcome("cleaned safely by cloud")))
+        val engine = FakeLocalInferenceEngine(mutableListOf(LocalInferenceResult.Success("The round was $1,200 dollars.")))
+        val waterfall = CleanupWaterfall(
+            listOf(
+                CleanupStep(CleanupStepGroup.LOCAL_LLM, LocalCleanupProvider.MODEL.archive),
+                CleanupStep(CleanupStepGroup.OPENAI_DIRECT, "gpt-4o-mini"),
+            ),
+        )
+        val raw = "the round was one point two million dollars"
+
+        val result = execute(
+            waterfall, transport, engine,
+            localModelPath = { "/path/to/model.gguf" },
+            credentialLookup = { "openai-key" },
+            text = raw,
+        )
+
+        assertEquals("the round was 1200000 dollars", engine.calls.single().second)
+        assertEquals("cleaned safely by cloud", result.text)
+        assertTrue(transport.requestedBodies.single().contains(raw))
+        assertTrue(!transport.requestedBodies.single().contains("1200000"))
     }
 }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
@@ -193,11 +193,12 @@ class LocalCleanupOutputValidatorTest {
         )
     }
 
-    @Test fun `comma grouping and currency symbols compare equal to the plain digits`() {
+    @Test fun `comma grouping currency and phone punctuation compare by semantic digits`() {
         assertAccepted(
             "the invoice total came to 12500 dollars this quarter",
             "The invoice total came to $12,500 this quarter.",
         )
+        assertAccepted("call 2125553476", "Call (212) 555-3476.")
     }
 
     @Test fun `digits already present in the input must survive verbatim`() {

--- a/app/src/test/kotlin/com/trevornk/ramblr/NumericPreservationVerifierTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/NumericPreservationVerifierTest.kt
@@ -1,0 +1,62 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumericPreservationVerifierTest {
+    private fun assertValid(input: String, output: String) {
+        val normalized = SpokenNumberNormalizer.normalize(input)
+        assertTrue(
+            "expected numeric preservation for ${normalized.semanticValues}",
+            NumericPreservationVerifier.verify(normalized, output) is NumericPreservation.Valid,
+        )
+    }
+
+    private fun assertRejected(input: String, output: String) {
+        val normalized = SpokenNumberNormalizer.normalize(input)
+        val verdict = NumericPreservationVerifier.verify(normalized, output)
+        assertTrue("expected rejection for ${normalized.semanticValues}", verdict is NumericPreservation.Rejected)
+        assertTrue((verdict as NumericPreservation.Rejected).detail.isNotBlank())
+    }
+
+    @Test fun `phone punctuation changes pass when the digit sequence is identical`() {
+        assertValid("call 2125553476", "Call 212-555-3476.")
+        assertValid("call 2125553476", "Call 212.555.3476.")
+        assertValid("call two one two five five five three four seven six", "Call (212) 555-3476.")
+        assertValid("call 5553476", "Call 555-3476.")
+        assertValid("call 12125553476", "Call +1 (212) 555-3476.")
+    }
+
+    @Test fun `changed dropped duplicated and reordered values are rejected`() {
+        assertRejected("send 450 dollars to account 9372", "Send 150 dollars to account 9372.")
+        assertRejected("send 450 dollars to account 9372", "Send 450 dollars.")
+        assertRejected("send 450 dollars", "Send 450, actually 450 dollars.")
+        assertRejected("codes are 12 then 34", "Codes are 34 then 12.")
+    }
+
+    @Test fun `arithmetic evaluation and collapsed arithmetic are rejected`() {
+        assertRejected("divide it by 3 and you get 33", "Divide it by 3 and you get 11.")
+        assertRejected("100 minus 25 is 75", "75")
+    }
+
+    @Test fun `expanded decimal multiplier must survive as its exact value`() {
+        val normalized = SpokenNumberNormalizer.normalize("one point two million dollars")
+        assertEquals("1200000 dollars", normalized.text)
+        assertEquals(listOf("1200000"), normalized.semanticValues)
+        assertTrue(NumericPreservationVerifier.verify(normalized, "$1,200,000") is NumericPreservation.Valid)
+        assertTrue(NumericPreservationVerifier.verify(normalized, "$1,200") is NumericPreservation.Rejected)
+    }
+
+    @Test fun `long decimals keep decimal meaning despite phone-shaped digit counts`() {
+        val normalized = SpokenNumberNormalizer.normalize("pi is 3.1415926")
+        assertEquals(listOf("3.1415926"), normalized.semanticValues)
+        assertTrue(NumericPreservationVerifier.verify(normalized, "Pi is 3.1415926.") is NumericPreservation.Valid)
+        assertTrue(NumericPreservationVerifier.verify(normalized, "Pi is 3.1415927.") is NumericPreservation.Rejected)
+    }
+
+    @Test fun `number free text has no numeric preservation burden`() {
+        val normalized = SpokenNumberNormalizer.normalize("hello there")
+        assertTrue(NumericPreservationVerifier.verify(normalized, "Hello there.") is NumericPreservation.Valid)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/SpokenNumberNormalizerTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/SpokenNumberNormalizerTest.kt
@@ -1,0 +1,110 @@
+package com.trevornk.ramblr
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpokenNumberNormalizerTest {
+    @Test fun `cardinal compounds become digits without changing surrounding prose`() {
+        assertEquals(
+            "send 450 dollars to the joint account",
+            SpokenNumberNormalizer.normalize("send four hundred and fifty dollars to the joint account").text,
+        )
+        assertEquals(
+            "the total is 12500 tomorrow",
+            SpokenNumberNormalizer.normalize("the total is twelve thousand five hundred tomorrow").text,
+        )
+    }
+
+    @Test fun `repeated spoken digits retain every digit in one run`() {
+        assertEquals(
+            "call me at 5551234567",
+            SpokenNumberNormalizer.normalize("call me at five five five one two three four five six seven").text,
+        )
+        assertEquals("room 042", SpokenNumberNormalizer.normalize("room oh four two").text)
+    }
+
+    @Test fun `decimals and multipliers render their exact expanded value`() {
+        assertEquals(
+            "the round was 1200000 dollars in total",
+            SpokenNumberNormalizer.normalize("the round was one point two million dollars in total").text,
+        )
+        assertEquals("pi is 3.14", SpokenNumberNormalizer.normalize("pi is three point one four").text)
+    }
+
+    @Test fun `currency and percentages keep their units with normalized values`() {
+        assertEquals("send 450 dollars", SpokenNumberNormalizer.normalize("send four hundred fifty dollars").text)
+        assertEquals("charge 1 dollar", SpokenNumberNormalizer.normalize("charge one dollar").text)
+        assertEquals("a 1 percent decrease", SpokenNumberNormalizer.normalize("a one percent decrease").text)
+        assertEquals("a 23 percent increase", SpokenNumberNormalizer.normalize("a twenty three percent increase").text)
+    }
+
+    @Test fun `times dates ordinals and literal digits cover the measured categories`() {
+        assertEquals("meet at 4:30 pm", SpokenNumberNormalizer.normalize("meet at four thirty pm").text)
+        assertEquals("due August 18th", SpokenNumberNormalizer.normalize("due August eighteenth").text)
+        assertEquals(
+            "due August 18th 2026",
+            SpokenNumberNormalizer.normalize("due August eighteenth twenty twenty six").text,
+        )
+        assertEquals("the 21st attempt", SpokenNumberNormalizer.normalize("the twenty first attempt").text)
+        val literal = "meet at 3:30 on 08/18/2026 with $12,500"
+        assertSame(literal, SpokenNumberNormalizer.normalize(literal).text)
+    }
+
+    @Test fun `eval samples normalize their measured numeric phrases`() {
+        val dir = File("src/test/resources/eval_samples").takeIf { it.isDirectory }
+            ?: File("app/src/test/resources/eval_samples")
+        fun sample(name: String) = File(dir, name).readText()
+        assertEquals(
+            "pick up the dry cleaning on the way home it should be ready by 5\n",
+            SpokenNumberNormalizer.normalize(sample("quick_note_02.txt")).text,
+        )
+        assertEquals(
+            "the meeting is at 3 o'clock no sorry i'm looking at the wrong calendar it's actually at 4:30 in the conference room on the 2nd floor not the one downstairs that we usually use\n",
+            SpokenNumberNormalizer.normalize(sample("self_correction_02.txt")).text,
+        )
+        val pricing = SpokenNumberNormalizer.normalize(sample("self_correction_04.txt")).text
+        assertTrue(pricing.contains("charge 20 dollars"))
+        assertTrue(pricing.contains("say 25"))
+        val model = SpokenNumberNormalizer.normalize(sample("rambling_brainstorm_03.txt")).text
+        assertTrue(model.contains("the 600 meg parakeet model"))
+        assertTrue(model.contains("take 10 seconds or 10 minutes"))
+    }
+
+    @Test fun `ambiguous article and quantifiers are left alone`() {
+        val text = "one of the things is half a dozen eggs and a quarter cup"
+        val result = SpokenNumberNormalizer.normalize(text)
+        assertSame(text, result.text)
+        assertEquals(emptyList<String>(), result.semanticValues)
+    }
+
+    @Test fun `separate numbers are never merged across punctuation or conjunctions`() {
+        assertEquals("one, 2, 3 options", SpokenNumberNormalizer.normalize("one, two, three options").text)
+        assertEquals("one. 2 ideas", SpokenNumberNormalizer.normalize("one. two ideas").text)
+        assertEquals("one and 2", SpokenNumberNormalizer.normalize("one and two").text)
+        assertEquals("3 and 4", SpokenNumberNormalizer.normalize("three and four").text)
+        // The connector still belongs to a genuine scale compound.
+        assertEquals("450 dollars", SpokenNumberNormalizer.normalize("four hundred and fifty dollars").text)
+    }
+
+    @Test fun `three word spoken times keep their real clock value`() {
+        assertEquals("meet at 4:35 pm", SpokenNumberNormalizer.normalize("meet at four thirty five pm").text)
+        assertEquals("meet at 12:05", SpokenNumberNormalizer.normalize("meet at twelve oh five").text)
+        assertEquals("meet at 9:15 am", SpokenNumberNormalizer.normalize("meet at nine fifteen am").text)
+    }
+
+    @Test fun `spoken years need date context and stay untouched when ambiguous`() {
+        assertEquals("shipped in 2026", SpokenNumberNormalizer.normalize("shipped in twenty twenty six").text)
+        assertEquals("back in 1984", SpokenNumberNormalizer.normalize("back in nineteen eighty four").text)
+        val ambiguous = "twenty twenty dollar bills"
+        assertSame(ambiguous, SpokenNumberNormalizer.normalize(ambiguous).text)
+    }
+
+    @Test fun `scale ordinals multiply instead of adding`() {
+        assertEquals("the 100th customer", SpokenNumberNormalizer.normalize("the one hundredth customer").text)
+        assertEquals("the 200th customer", SpokenNumberNormalizer.normalize("the two hundredth customer").text)
+        assertEquals("the 1000th customer", SpokenNumberNormalizer.normalize("the one thousandth customer").text)
+    }
+}


### PR DESCRIPTION
## Problem

Local cleanup models silently corrupt spoken numbers. Sentinel masking was measured against both shipped models and rejected: no placeholder format survived reliably (best bareword format: 81.2% on LFM2.5, 15.9% on mumble-cleanup). Real digits survived 95.5% / 98.5%.

Refs #155.

## Approach

Normalize conservative spoken-number spans to digits before **local** inference, then reject local output whose ordered semantic numeric values changed, disappeared, duplicated, or reordered. Cloud cleanup is untouched; rejection falls through the existing waterfall; diagnostics carry counts only, never transcript or model text.

Covered: cardinal compounds, repeated spoken digits, decimals with expanded multipliers (`one point two million` -> `1200000`), currency/percent, clock times including three-word forms (`four thirty five`, `twelve oh five`), month ordinals, spoken years in date context, ordinals, and existing literal digits.

Deliberately conservative: `half`/`quarter`/`dozen` and bare prose `one` are left alone (`one dollar`/`one percent` do normalize); a run with no confident reading is skipped whole rather than partially rewritten; `twenty twenty dollar bills` stays untouched while `in twenty twenty six` becomes `2026`.

## Verification

- Baseline before this branch: 134 suites / 1,237 tests / 0 failures / 0 errors / 0 skipped
- Final unfiltered rerun, counted from JUnit XML: **136 suites / 1,256 tests / 0 failures / 0 errors / 0 skipped**
- `:app:assembleGithubDebug --offline`: BUILD SUCCESSFUL, APK newer than every changed source
- `git diff --check`: clean

Each behavior below was proven by an intentional mutation that produced an assertion failure (never a compile error), with the source restored byte-identically afterward (SHA-256 verified):

| Mutation | Failing test |
| --- | --- |
| punctuation no longer ends a numeric run | separate numbers are never merged... |
| bare `and` rejoins separate quantities | separate numbers are never merged... |
| three-word times revert to two-word only | three word spoken times keep their real clock value |
| scale ordinals add instead of multiply | scale ordinals multiply instead of adding |
| phone regex loses 7-digit / country-code forms | phone punctuation changes pass... |
| single-dot decimals treated as phone formatting | long decimals keep decimal meaning... |
| verification always accepts | 3 safety tests |
| numeric order ignored | reorder rejection test |

## Safety behavior

Changed, dropped, duplicated, or reordered numbers reject. Arithmetic evaluation or collapse rejects. Punctuation-only phone reformatting (`(212) 555-3476`, `212.555.3476`, `555-3476`, `+1 212 555 3476`) passes. Number-free text carries no burden.

## Not included

No sentinel/masking code from closed PR #166; no cloud provider changes; no model default or prompt changes; no attempt at unlimited English-number grammar.
