### PR TITLE
Warm only cloud hosts a credentialed call could actually reach

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/NetworkWarmup.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/NetworkWarmup.kt
@@ -21,6 +21,21 @@ import okhttp3.Request
  * [hostsToWarm] is the pure, unit-testable part: given the resolved transcription candidates and
  * effective cleanup chain for this dictation, return the distinct hostnames a real call could
  * hit. [warmUpAsync] does the actual (impure, Android-only) connection attempts.
+ *
+ * ## Credential gating (#168)
+ *
+ * A host is only warmed when a real call could actually reach it, which means the provider must
+ * have a credential configured. Both real call paths already refuse to contact a keyless
+ * provider -- [TranscriptionChain.precheck] returns SKIP for OPENAI/GEMINI without a credential,
+ * and [CleanupWaterfallExecutor] fails the step with "No credential configured" before building
+ * a request -- so warming a keyless host opened a connection that, by construction, nothing was
+ * ever going to reuse.
+ *
+ * That was not merely a wasted handshake. F-Droid review of 1.0.24 (fdroiddata!42401) observed
+ * every dictation opening a TLS connection to api.openai.com with cleanup off, Local mode, and
+ * no API key set -- sending the user's IP and an api.openai.com SNI to a proprietary service the
+ * user had explicitly opted out of. The optimization only ever paid off for users who configured
+ * a key; gating on that costs those users nothing and makes the opted-out case silent.
  */
 object NetworkWarmup {
     /**
@@ -29,13 +44,22 @@ object NetworkWarmup {
      * with a [ProviderChainEntry.baseUrlOverride] warms that host instead of the default one, so
      * this stays correct for anyone pointed at a proxy/self-hosted endpoint. LOCAL entries never
      * produce a host -- there's no network call to warm for on-device inference.
+     *
+     * [hasCredential] is the caller's seam onto [ProviderCredentialStore]; an entry whose kind
+     * has no credential contributes no host (#168). This applies to `baseUrlOverride` entries
+     * too: a self-hosted proxy still carries the provider's Authorization header, so the real
+     * call is skipped for exactly the same reason and its host must not be warmed either.
      */
     fun hostsToWarm(
         transcriptionCandidates: List<ProviderChainEntry>,
         cleanupChain: ProviderChain,
+        hasCredential: (ProviderKind) -> Boolean,
     ): Set<String> {
         val entries = transcriptionCandidates + cleanupChain.entries
-        return entries.mapNotNull { entry -> hostFor(entry) }.toSet()
+        return entries
+            .filter { entry -> entry.kind == ProviderKind.LOCAL || hasCredential(entry.kind) }
+            .mapNotNull { entry -> hostFor(entry) }
+            .toSet()
     }
 
     private fun hostFor(entry: ProviderChainEntry): String? {

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2212,12 +2212,19 @@ class WhisperAccessibilityService : AccessibilityService() {
      * timing [warmUpLocalCleanupModelIfNeeded]/[warmUpTranscribersIfTrimmed] already use. Reads
      * the same [ProviderChainStore]/[CloudFeatureToggle] state the real transcription and cleanup
      * call sites resolve against, so this only opens connections a real call could actually use.
+     *
+     * The [ProviderCredentialStore] gate (#168) is what makes that last sentence true: without
+     * it this warmed a host for a provider that has no key, which both real call paths refuse to
+     * contact, so a Local-mode user with cleanup off and no key still opened a TLS connection to
+     * api.openai.com on every dictation.
      */
     private fun warmUpCloudConnectionsIfNeeded() {
         val chain = ProviderChainStore.load(this)
         val transcriptionCandidates = ProviderChainRuntime.transcriptionCandidates(chain)
         val cleanupChain = ProviderChainRuntime.effectiveChainForCleanup(chain, CloudFeatureToggle.cleanupEnabled(this))
-        val hosts = NetworkWarmup.hostsToWarm(transcriptionCandidates, cleanupChain)
+        val hosts = NetworkWarmup.hostsToWarm(transcriptionCandidates, cleanupChain) { kind ->
+            ProviderCredentialStore.isConfigured(this, kind)
+        }
         NetworkWarmup.warmUpAsync(hosts)
     }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/NetworkWarmupTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/NetworkWarmupTest.kt
@@ -8,17 +8,22 @@ import org.junit.Test
  * Covers [NetworkWarmup.hostsToWarm], the pure part of the pre-warm fix (#100 perceived-latency
  * follow-up): given the resolved transcription candidates and effective cleanup chain for a
  * dictation, it must return exactly the distinct cloud hostnames a real call could hit -- no
- * more (that would waste a handshake on a host nothing will call), no less (that would leave the
+ * more (that would waste a handshake on a host nothing will call, and #168 showed "waste" can
+ * mean "contact a proprietary service the user opted out of"), no less (that would leave the
  * real call to pay full DNS+TLS cold).
  */
 class NetworkWarmupTest {
     private fun entry(kind: ProviderKind, model: String = "m", baseUrlOverride: String? = null) =
         ProviderChainEntry(kind, model, baseUrlOverride)
 
+    /** Default for the pre-#168 cases: every provider has a key, so gating changes nothing. */
+    private val allKeysPresent: (ProviderKind) -> Boolean = { true }
+
     @Test fun `maps each cloud provider kind to its default host`() {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = listOf(entry(ProviderKind.OPENAI)),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.ANTHROPIC), entry(ProviderKind.GEMINI))),
+            hasCredential = allKeysPresent,
         )
         assertEquals(
             setOf("api.openai.com", "api.anthropic.com", "generativelanguage.googleapis.com"),
@@ -30,6 +35,7 @@ class NetworkWarmupTest {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = listOf(entry(ProviderKind.LOCAL)),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.LOCAL))),
+            hasCredential = allKeysPresent,
         )
         assertEquals(emptySet<String>(), hosts)
     }
@@ -38,6 +44,7 @@ class NetworkWarmupTest {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = listOf(entry(ProviderKind.OPENAI)),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.OPENAI), entry(ProviderKind.OPENAI, "other-model"))),
+            hasCredential = allKeysPresent,
         )
         assertEquals(setOf("api.openai.com"), hosts)
     }
@@ -46,6 +53,7 @@ class NetworkWarmupTest {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = emptyList(),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.OPENAI, baseUrlOverride = "https://my-proxy.example.com/v1"))),
+            hasCredential = allKeysPresent,
         )
         assertEquals(setOf("my-proxy.example.com"), hosts)
     }
@@ -54,6 +62,7 @@ class NetworkWarmupTest {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = emptyList(),
             cleanupChain = ProviderChain(emptyList()),
+            hasCredential = allKeysPresent,
         )
         assertEquals(emptySet<String>(), hosts)
     }
@@ -74,6 +83,7 @@ class NetworkWarmupTest {
         val hosts = NetworkWarmup.hostsToWarm(
             transcriptionCandidates = emptyList(),
             cleanupChain = ProviderChain(listOf(entry(ProviderKind.OMNIROUTE))),
+            hasCredential = allKeysPresent,
         )
         val expected = if (OmniRoute.isConfigured) {
             setOfNotNull(OmniRoute.BASE_URL.toHttpUrlOrNull()?.host)
@@ -81,5 +91,66 @@ class NetworkWarmupTest {
             emptySet()
         }
         assertEquals(expected, hosts)
+    }
+
+    // ---- #168: credential gating ----
+
+    /**
+     * The exact scenario F-Droid review reproduced on a Redmi Note 8T against 1.0.24
+     * (fdroiddata!42401): Local mode, cleanup off, no API key -- and yet every dictation opened a
+     * TLS connection to api.openai.com. The chain still carries its OPENAI entry (capability
+     * filtering keeps it; only a credential check removes it), so this is the shape that leaked.
+     */
+    @Test fun `no host is warmed for a provider with no credential configured`() {
+        val hosts = NetworkWarmup.hostsToWarm(
+            transcriptionCandidates = listOf(entry(ProviderKind.OPENAI), entry(ProviderKind.LOCAL)),
+            cleanupChain = ProviderChain(listOf(entry(ProviderKind.LOCAL))),
+            hasCredential = { false },
+        )
+        assertEquals(emptySet<String>(), hosts)
+    }
+
+    /** #100 must not regress: a user who HAS configured a key still gets the pre-warm. */
+    @Test fun `a provider with a credential is still warmed`() {
+        val hosts = NetworkWarmup.hostsToWarm(
+            transcriptionCandidates = listOf(entry(ProviderKind.OPENAI)),
+            cleanupChain = ProviderChain(emptyList()),
+            hasCredential = { it == ProviderKind.OPENAI },
+        )
+        assertEquals(setOf("api.openai.com"), hosts)
+    }
+
+    /** Gating is per-kind, not all-or-nothing: the keyed provider warms, the keyless one doesn't. */
+    @Test fun `only the credentialed provider is warmed in a mixed chain`() {
+        val hosts = NetworkWarmup.hostsToWarm(
+            transcriptionCandidates = listOf(entry(ProviderKind.OPENAI)),
+            cleanupChain = ProviderChain(listOf(entry(ProviderKind.GEMINI), entry(ProviderKind.ANTHROPIC))),
+            hasCredential = { it == ProviderKind.GEMINI },
+        )
+        assertEquals(setOf("generativelanguage.googleapis.com"), hosts)
+    }
+
+    /**
+     * A self-hosted proxy still carries the provider's Authorization header, so the real call is
+     * skipped without a key for exactly the same reason -- the override host must not be warmed
+     * either. Without this, pointing at a proxy would reopen the leak through a different host.
+     */
+    @Test fun `baseUrlOverride does not bypass the credential gate`() {
+        val hosts = NetworkWarmup.hostsToWarm(
+            transcriptionCandidates = emptyList(),
+            cleanupChain = ProviderChain(listOf(entry(ProviderKind.OPENAI, baseUrlOverride = "https://my-proxy.example.com/v1"))),
+            hasCredential = { false },
+        )
+        assertEquals(emptySet<String>(), hosts)
+    }
+
+    /** LOCAL has no credential slot at all, so it must never be filtered out by the gate. */
+    @Test fun `LOCAL is unaffected by the credential gate`() {
+        val hosts = NetworkWarmup.hostsToWarm(
+            transcriptionCandidates = listOf(entry(ProviderKind.LOCAL), entry(ProviderKind.OPENAI)),
+            cleanupChain = ProviderChain(listOf(entry(ProviderKind.LOCAL))),
+            hasCredential = { false },
+        )
+        assertEquals(emptySet<String>(), hosts)
     }
 }


### PR DESCRIPTION
## Problem

F-Droid review of 1.0.24 (fdroiddata!42401) reproduced this on a physical Redmi Note 8T, Android 13: with **cleanup off, Local mode, and no API key set**, every dictation still opened a TLS connection to `api.openai.com`, logging `warm-up connect to api.openai.com succeeded in 230ms` while transcription ran entirely on-device.

Fixes #168.

## Root cause

`NetworkWarmup.hostsToWarm` mapped every non-LOCAL chain entry straight to a hostname without asking whether a credential exists. Both real call paths do ask:

- `TranscriptionChain.precheck` returns `SKIP` for `OPENAI`/`GEMINI` when no credential is configured, so `transcribeApi` never calls that provider.
- `CleanupWaterfallExecutor.performStep` fails the step with "No credential configured" before building a request.

`effectiveChainForCleanup(chain, cleanupEnabled=false)` correctly strips cloud entries from the *cleanup* chain, but the transcription candidate list is capability-filtered only — the OPENAI entry survives with no key, and that is what leaked.

So the warm-up was opening a connection that, by construction, nothing was ever going to reuse. Not just a wasted handshake: it sent the user's IP and an `api.openai.com` SNI to a proprietary service on every dictation, for a user who had explicitly opted out of all cloud features.

## Fix

`hostsToWarm` takes a `hasCredential: (ProviderKind) -> Boolean` seam (the caller passes `ProviderCredentialStore.isConfigured`) and warms a host only when a real call could actually reach it. `LOCAL` has no credential slot and is unaffected.

The #100 optimization is untouched for users who *have* configured a key — the only case where it was ever doing useful work.

`baseUrlOverride` is deliberately gated too: a self-hosted proxy still carries the provider's Authorization header, so the real call is skipped for the same reason. Without that, pointing at a proxy would reopen the leak through a different hostname.

## Verification

- Full suite: **137 suites / 1286 tests / 0 failures / 0 errors / 0 skipped**, counted from JUnit XML with `--rerun-tasks` after deleting prior results. `NetworkWarmupTest` goes 6 → 11.
- `assembleGithubDebug --offline`: successful, APK newer than every changed source.
- `git diff --check`: clean.

Mutation-proved — a test that passes against the unfixed code proves nothing:

| Mutation | Result |
| --- | --- |
| drop the credential filter (exact pre-fix behavior) | 4 failures: keyless-provider, baseUrlOverride-bypass, mixed-chain, LOCAL |
| invert the gate (warm only keyless providers) | 8 failures |
| baseline (fixed) | 0 failures |

Source restored byte-identically after each mutation (SHA-256 `b338bb01…` before and after).

## Note on release mechanics

fdroiddata!42401 is pinned to the `v1.0.24` tag (`78aa442`), so merging this to `main` does **not** reach the reviewer. A new tagged release is required before the MR can be updated.
