### PR TITLE
Gate onboarding step 5 behind the LFM2.5 license answer (#170)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -573,8 +573,7 @@ class MainActivity : BaseSettingsActivity() {
             }
             .setNegativeButton("Use on-device") { _, _ ->
                 dismissOnboarding()
-                enableOnboardingCleanupLocal(recommendedLocal)
-                showOnboardingStreamingStep()
+                enableOnboardingCleanupLocal(recommendedLocal) { showOnboardingStreamingStep() }
             }
             .setNeutralButton("Skip (leave off)") { _, _ -> dismissOnboarding(); showOnboardingStreamingStep() }
             .show()
@@ -609,24 +608,36 @@ class MainActivity : BaseSettingsActivity() {
             .show()
     }
 
-    private fun enableOnboardingCleanupLocal(model: Model) {
-        // Ordering matters (#153): a non-free model must not be *selected* until its license is
-        // accepted. This used to write the selection first and prompt afterwards, so cancelling
-        // the license dialog left cleanup enabled and pointed at a model that was never
-        // installed -- the exact slip F-Droid review caught in fdroiddata!42401.
-        //
-        // downloadModelWithLicenseConsent invokes onStarted only when a download was actually
-        // enqueued, and for an already-installed or freely-licensed model it does so
-        // synchronously, so the non-download paths still commit immediately.
-        if (ModelDownloader.isInstalled(this, model)) {
-            commitOnboardingCleanupLocal(model)
-            return
-        }
-        downloadModelWithLicenseConsent(model) {
-            commitOnboardingCleanupLocal(model)
-            toast("Downloading ${model.name}...")
-            refresh()
-        }
+    /**
+     * Onboarding step 4's "Use on-device" branch.
+     *
+     * Ordering matters (#153): a non-free model must not be *selected* until its license is
+     * accepted. This used to write the selection first and prompt afterwards, so cancelling
+     * the license dialog left cleanup enabled and pointed at a model that was never
+     * installed -- the exact slip F-Droid review caught in fdroiddata!42401.
+     *
+     * Sequencing matters too (#170): the caller used to invoke this and then advance the wizard
+     * on the very next line, but for a not-yet-installed model this only *starts* an
+     * asynchronous license dialog, so step 5 and FINISH SETUP stacked over an unanswered consent
+     * prompt. [advance] is therefore run by [OnboardingCleanupLocalFlow] instead -- after the
+     * license is answered, either way, and never before. See that object for the full rule.
+     */
+    private fun enableOnboardingCleanupLocal(model: Model, advance: () -> Unit) {
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = ModelDownloader.isInstalled(this, model),
+            commit = { commitOnboardingCleanupLocal(model) },
+            advance = advance,
+            requestConsent = { onAccepted, onDeclined ->
+                downloadModelWithLicenseConsent(
+                    model,
+                    onStarted = {
+                        onAccepted()
+                        toast("Downloading ${model.name}...")
+                    },
+                    onDeclined = onDeclined,
+                )
+            },
+        )
     }
 
     /** Persists the local-cleanup selection for [model]. Split out of

--- a/app/src/main/kotlin/com/trevornk/ramblr/ModelLicensePrompt.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ModelLicensePrompt.kt
@@ -29,18 +29,35 @@ import android.net.Uri
  *
  * @param onStarted invoked only when a download was actually enqueued, so callers can show
  *   "Downloading..." without claiming a download that the user declined.
+ * @param onDeclined invoked exactly when [onStarted] is not: the prompt was cancelled, dismissed,
+ *   or the enqueue did not happen. Callers that gate further UI on the answer (onboarding, #170)
+ *   need a signal for "the user is done with this dialog and said no", otherwise a wizard waiting
+ *   on consent would stall forever on a dismissed prompt. Exactly one of the two always runs.
+ *   Note that "View license" dismisses the dialog to hand off to a browser, so it reports declined
+ *   too -- the user can re-enter the choice afterwards rather than being held in a modal.
  */
-fun Activity.downloadModelWithLicenseConsent(model: Model, onStarted: () -> Unit = {}) {
+fun Activity.downloadModelWithLicenseConsent(
+    model: Model,
+    onStarted: () -> Unit = {},
+    onDeclined: () -> Unit = {},
+) {
     if (ModelLicenseConsent.canDownload(this, model)) {
-        if (ModelDownloadWorker.enqueue(this, model)) onStarted()
+        if (ModelDownloadWorker.enqueue(this, model)) onStarted() else onDeclined()
         return
     }
+    // Tracked across the whole dialog rather than per-button so that back, outside-tap, "Cancel"
+    // and a failed enqueue all funnel into the same single onDeclined -- and so acceptance never
+    // double-reports through the dismiss listener that follows it.
+    var started = false
     AlertDialog.Builder(this)
         .setTitle("${model.name} uses a non-free license")
         .setMessage(ModelLicenseConsent.consentMessage(model))
         .setPositiveButton("Accept and download") { _, _ ->
             ModelLicenseConsent.recordAccepted(this, model)
-            if (ModelDownloadWorker.enqueue(this, model)) onStarted()
+            if (ModelDownloadWorker.enqueue(this, model)) {
+                started = true
+                onStarted()
+            }
         }
         .setNegativeButton("Cancel", null)
         .setNeutralButton("View license") { _, _ ->
@@ -50,5 +67,6 @@ fun Activity.downloadModelWithLicenseConsent(model: Model, onStarted: () -> Unit
                 startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(model.license.url)))
             }
         }
+        .setOnDismissListener { if (!started) onDeclined() }
         .show()
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/OnboardingCleanupLocalFlow.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/OnboardingCleanupLocalFlow.kt
@@ -1,0 +1,73 @@
+package com.trevornk.ramblr
+
+/**
+ * Ordering rule for onboarding step 4's "Use on-device" branch (#170).
+ *
+ * Extracted from [MainActivity.enableOnboardingCleanupLocal] because that branch's bug was purely
+ * a *sequencing* one and sequencing is the one part of it that can be unit-tested: the dialogs
+ * themselves need an Activity, but "when may the wizard advance, and what may be committed first"
+ * is pure logic. Keeping it here means the rule is asserted directly rather than inferred from
+ * dialog plumbing.
+ *
+ * The bug (fdroiddata!42401, reported against 1.0.24): the "Use on-device" branch called
+ * `enableOnboardingCleanupLocal(...)` and `showOnboardingStreamingStep()` back to back. For a
+ * not-yet-installed model the first call only *starts* the LFM2.5 license dialog and returns
+ * immediately, so step 5 -- and from there "Try it out" and FINISH SETUP -- stacked on top of a
+ * license prompt the user had not answered yet. The #153 ordering guarantee held (nothing was
+ * selected or downloaded on cancel), but the consent gate was visually buried, which is exactly
+ * the confusing state #153 existed to remove.
+ *
+ * The rule, then:
+ *  - already installed: no consent needed, commit and advance synchronously (unchanged);
+ *  - consent pending: neither commit nor advance -- the wizard waits on the dialog;
+ *  - accepted: commit, then advance;
+ *  - declined/dismissed: advance *without* committing. Refusing a non-free license must cost the
+ *    user nothing but the feature, and stalling the wizard on a dismissed dialog would trade one
+ *    bug for a worse dead end.
+ */
+object OnboardingCleanupLocalFlow {
+
+    /**
+     * Runs the "Use on-device" branch.
+     *
+     * @param isInstalled whether the model is already on disk (no license prompt is shown for it).
+     * @param commit persists the local-cleanup selection. Invoked at most once, and only on a path
+     *   where the license is satisfied.
+     * @param advance shows the next wizard step. Invoked exactly once per [start] call, always
+     *   after [commit] when both run, so the wizard can never render step 5 over a live prompt.
+     * @param requestConsent shows the license prompt, calling back exactly one of its two lambdas
+     *   once the user answers. It must not invoke either synchronously for a model that needs
+     *   consent -- that is the asynchronous gap this whole object exists to respect.
+     */
+    fun start(
+        isInstalled: Boolean,
+        commit: () -> Unit,
+        advance: () -> Unit,
+        requestConsent: (onAccepted: () -> Unit, onDeclined: () -> Unit) -> Unit,
+    ) {
+        if (isInstalled) {
+            commit()
+            advance()
+            return
+        }
+        // A dialog that reports both "accepted" and "dismissed" (accept, then the dismiss listener
+        // firing) must still advance the wizard exactly once -- showing step 5 twice would leave a
+        // stale dialog behind the live one, which is the same class of defect as #170 itself.
+        var settled = false
+        requestConsent(
+            {
+                if (!settled) {
+                    settled = true
+                    commit()
+                    advance()
+                }
+            },
+            {
+                if (!settled) {
+                    settled = true
+                    advance()
+                }
+            },
+        )
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/OnboardingCleanupConsentGateTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/OnboardingCleanupConsentGateTest.kt
@@ -1,0 +1,166 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #170: onboarding must not advance past an unanswered LFM2.5 license prompt.
+ *
+ * Reported by an F-Droid reviewer on a physical device against 1.0.24 (fdroiddata!42401): step 5
+ * and the "Try it out" dialog stacked over the pending consent dialog, so FINISH SETUP was
+ * reachable before the license had been answered. The dialogs themselves need an Activity, but
+ * the sequencing rule -- which was the whole bug -- is pure, and is asserted here.
+ *
+ * [FakeConsentPrompt] models the real dialog's defining property: for a model that needs consent
+ * it answers *later*, not during [OnboardingCleanupLocalFlow.start]. A test that let it answer
+ * synchronously would pass against the original buggy code too and would prove nothing.
+ */
+class OnboardingCleanupConsentGateTest {
+
+    /** Records what the flow did, in order, so ordering regressions are visible and not inferred. */
+    private class Recorder {
+        val events = mutableListOf<String>()
+        val commit: () -> Unit = { events += "commit" }
+        val advance: () -> Unit = { events += "advance" }
+    }
+
+    /** A license dialog that, like the real one, only answers when the user answers it. */
+    private class FakeConsentPrompt {
+        var shown = false
+            private set
+        private var onAccepted: (() -> Unit)? = null
+        private var onDeclined: (() -> Unit)? = null
+
+        val requestConsent: (() -> Unit, () -> Unit) -> Unit = { accepted, declined ->
+            shown = true
+            onAccepted = accepted
+            onDeclined = declined
+        }
+
+        fun accept() = checkNotNull(onAccepted) { "consent was never requested" }.invoke()
+        fun decline() = checkNotNull(onDeclined) { "consent was never requested" }.invoke()
+    }
+
+    // --- Acceptance case 1: the prompt is shown and the wizard waits for it ---
+
+    @Test fun `choosing on-device shows the license prompt and does not advance until it is answered`() {
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = false, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+
+        assertTrue("the license prompt must be shown for a not-yet-installed model", prompt.shown)
+        assertEquals(
+            "the wizard must not advance to step 5 (nor commit) while consent is pending -- " +
+                "that is #170: FINISH SETUP became reachable over an unanswered license dialog",
+            emptyList<String>(),
+            r.events,
+        )
+    }
+
+    // --- Acceptance case 2: accept -> enabled, wizard continues ---
+
+    @Test fun `accepting the license commits local cleanup and then advances the wizard`() {
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = false, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+        prompt.accept()
+
+        assertEquals(listOf("commit", "advance"), r.events)
+    }
+
+    // --- Acceptance case 3: cancel -> nothing selected, but no dead end ---
+
+    @Test fun `declining the license advances the wizard without enabling local cleanup`() {
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = false, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+        prompt.decline()
+
+        // #153 must not regress: refusing a non-free license selects nothing and downloads
+        // nothing. But the wizard still has to move on -- stalling on a dismissed dialog would
+        // trade #170 for a dead-end wizard, which is worse.
+        assertEquals(listOf("advance"), r.events)
+    }
+
+    // --- Acceptance case 4: already installed -> no prompt, immediate advance ---
+
+    @Test fun `an already-installed model commits and advances immediately with no license prompt`() {
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = true, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+
+        assertEquals(
+            "an installed model needs no consent and must keep advancing synchronously",
+            listOf("commit", "advance"),
+            r.events,
+        )
+        assertTrue("no license prompt may be shown for an installed model", !prompt.shown)
+    }
+
+    // --- Invariants that hold across every path ---
+
+    @Test fun `the wizard advances exactly once even if the prompt reports accept and then dismiss`() {
+        // The real AlertDialog's dismiss listener fires after the positive button's, so a naive
+        // wiring would advance twice and stack a second step 5 behind the first.
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = false, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+        prompt.accept()
+        prompt.decline()
+
+        assertEquals(listOf("commit", "advance"), r.events)
+    }
+
+    @Test fun `a repeated decline still advances only once`() {
+        val r = Recorder()
+        val prompt = FakeConsentPrompt()
+
+        OnboardingCleanupLocalFlow.start(
+            isInstalled = false, commit = r.commit, advance = r.advance,
+            requestConsent = prompt.requestConsent,
+        )
+        prompt.decline()
+        prompt.decline()
+
+        assertEquals(listOf("advance"), r.events)
+    }
+
+    @Test fun `commit never runs after advance on any path`() {
+        // The wizard's next step reads the cleanup prefs it renders, so committing after
+        // advancing would show step 5 built from stale state.
+        for (answer in listOf<(FakeConsentPrompt) -> Unit>({ it.accept() }, { it.decline() })) {
+            val r = Recorder()
+            val prompt = FakeConsentPrompt()
+            OnboardingCleanupLocalFlow.start(
+                isInstalled = false, commit = r.commit, advance = r.advance,
+                requestConsent = prompt.requestConsent,
+            )
+            answer(prompt)
+            val advanceAt = r.events.indexOf("advance")
+            val commitAt = r.events.indexOf("commit")
+            assertTrue("advance must happen", advanceAt >= 0)
+            if (commitAt >= 0) assertTrue("commit must precede advance", commitAt < advanceAt)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #170.

## Problem

Onboarding step 4's "Use on-device" branch ran two statements back to back:

```kotlin
enableOnboardingCleanupLocal(recommendedLocal)
showOnboardingStreamingStep()
```

For a not-yet-installed model, the first call only *starts* the LFM2.5 license dialog — `downloadModelWithLicenseConsent` invokes its callback asynchronously, on accept. `showOnboardingStreamingStep()` ran immediately and unconditionally on the next line, so step 5 and then the "Try it out" dialog stacked on top of an unanswered consent prompt, and FINISH SETUP became reachable before the license had been answered.

Reported by an F-Droid reviewer on a physical Redmi Note 8T (Android 13) against 1.0.24 / versionCode 27, in fdroiddata!42401.

#153's ordering guarantee was never broken — `commitOnboardingCleanupLocal` only ran on accept, so cancelling still selected nothing and downloaded nothing, and that is unchanged here. But burying the consent gate under two more dialogs is exactly the confusing state #153 existed to remove, and LFM2.5-350M's gate is load-bearing for the NonFreeAssets position.

## Fix

The wizard now advances only once the license has been answered.

- **`OnboardingCleanupLocalFlow`** (new, pure): holds the sequencing rule. The dialogs need an `Activity`, but "when may the wizard advance, and what may be committed first" is pure logic and is the entire bug — extracting the decision makes it directly assertable instead of inferred from dialog plumbing. It also collapses a duplicate answer (accept, then the dismiss listener firing) so step 5 can never be shown twice over itself.
- **`downloadModelWithLicenseConsent`** gains an `onDeclined` callback, driven by `setOnDismissListener` so Cancel, system back, and outside-tap all report exactly once. Without a "the user said no" signal, a wizard waiting on consent would stall forever on a dismissed prompt. Exactly one of `onStarted`/`onDeclined` always runs.
- **Declining advances *without* enabling local cleanup.** Refusing a non-free license must cost the user nothing but the feature, and stalling the wizard would trade this bug for a worse dead end.

The already-installed branch commits and advances synchronously, unchanged. `CleanupActivity`'s picker is untouched — it uses the new parameter's default.

## Acceptance

| Case | Covered by |
|---|---|
| "Use on-device" shows the license dialog and does **not** show step 5 until answered | `choosing on-device shows the license prompt and does not advance until it is answered` |
| Accept → local cleanup enabled, wizard continues | `accepting the license commits local cleanup and then advances the wizard` |
| Cancel → nothing selected, nothing downloaded, wizard still continues | `declining the license advances the wizard without enabling local cleanup` |
| Already-installed model → no prompt, immediate advance, unchanged | `an already-installed model commits and advances immediately with no license prompt` |

Plus two invariants: the wizard advances exactly once even if the prompt reports accept-then-dismiss, and `commit` never runs after `advance` on any path.

## Verification

`:app:testGithubDebugUnitTest --offline --rerun-tasks`, counts parsed from the JUnit XML under `app/build/test-results/` (not console text):

- **138 suites / 1293 tests / 0 failures / 0 errors / 0 skipped** — baseline on main is 137 / 1286, so +1 suite / +7 tests.
- `:app:assembleGithubDebug --offline` succeeds.

**Mutation-proofed.** The new tests were confirmed to fail when the fix is reverted, in two directions:

1. Hoisting `advance()` back outside the consent callback (the original bug) → **4 failures**: the pending-prompt test, the accept-ordering test, the accept-then-dismiss test, and the commit-before-advance invariant.
2. Advancing only on accept, never on decline (the dead-end wizard) → **3 failures**: both decline tests and the commit-before-advance invariant.

Source was then restored and verified byte-identical by `shasum -a 256` (`bb90f8a1…` before and after), and the suite returns to 0 failures. The fake consent prompt answers *asynchronously*, like the real dialog — a fake that answered synchronously would pass against the buggy ordering too and prove nothing.

## Not verified here

On-device behavior. The dialog stacking was reported on physical hardware and the fix is asserted at the sequencing level only; the actual on-screen ordering on a real device has not been re-checked in this change and is worth confirming during review.

Do not merge without review.
