### PR TITLE
Provision Silero VAD at local-mode selection so the first dictation decodes segmented

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -457,6 +457,31 @@ class MainActivity : BaseSettingsActivity() {
             .show()
     }
 
+    /**
+     * Provisions the Silero VAD model as soon as on-device transcription is chosen (#169).
+     *
+     * Without this the model is only fetched by the first local dictation itself, and because
+     * that fetch is asynchronous the triggering take always decodes unsegmented — the single-shot
+     * native decode #132 exists to avoid, measured at 665 MB RSS on a 4 GB device. Enqueueing at
+     * selection time lets the ~644 KB download overlap the rest of setup so the first real
+     * dictation already has it.
+     *
+     * Best-effort by design: [ModelDownloadWorker.enqueue]'s network constraint means an offline
+     * user simply gets it later, and [VadModelProvisioning.shouldFetch] remains the backstop at
+     * transcription time. Nothing here can block or fail onboarding.
+     */
+    private fun prefetchVadModel() {
+        if (!VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = prefs().getBoolean("use_local", true),
+                modelInstalled = ModelDownloader.vadModelFile(this, SILERO_VAD_MODEL) != null,
+            )
+        ) {
+            return
+        }
+        android.util.Log.i(TAG, "Local mode selected — prefetching VAD model for segmented decode (#169)")
+        ModelDownloadWorker.enqueue(this, SILERO_VAD_MODEL)
+    }
+
     private fun showOnboardingModeStep() {
         markOnboardingStep(STEP_MODE)
         val recommended = MODEL_CATALOG.firstOrNull { it.recommended } ?: MODEL_CATALOG.first()
@@ -471,6 +496,7 @@ class MainActivity : BaseSettingsActivity() {
             .setPositiveButton("Use on-device (recommended)") { _, _ ->
                 dismissOnboarding()
                 prefs().edit().putBoolean("use_local", true).apply()
+                prefetchVadModel()
                 if (ModelDownloader.isInstalled(this, recommended)) {
                     selectOnboardingModel(recommended.archive)
                 } else {
@@ -786,6 +812,7 @@ class MainActivity : BaseSettingsActivity() {
     }
 
     companion object {
+        private const val TAG = "MainActivity"
         private const val KEY_LOCAL_CLEANUP_CONSENT = "local_cleanup_consent_seen"
         private const val KEY_ONBOARDING_COMPLETE = "onboarding_complete"
         /** Instance-state key: whether the wizard already started this session (#80). */

--- a/app/src/main/kotlin/com/trevornk/ramblr/TranscriptionActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/TranscriptionActivity.kt
@@ -110,6 +110,7 @@ class TranscriptionActivity : BaseSettingsActivity() {
 
     private fun refresh() {
         val useLocal = prefs().getBoolean("use_local", true)
+        prefetchVadModel(useLocal)
         cloudSwitch.isChecked = !useLocal
         modelContainer.visibility = if (useLocal) View.VISIBLE else View.GONE
 
@@ -123,6 +124,28 @@ class TranscriptionActivity : BaseSettingsActivity() {
                 ?.let { selectModel(it.archive) }
         }
         refreshAllCards()
+    }
+
+    /**
+     * Provisions the Silero VAD model whenever this screen shows on-device transcription as the
+     * active mode (#169), covering the user who switches to local here rather than in onboarding.
+     *
+     * Called from [refresh] so it also catches the pre-existing local user who upgraded from a
+     * build without this prefetch: their first visit to this screen provisions the model instead
+     * of leaving it to a dictation that would decode unsegmented. Cheap to call repeatedly — the
+     * predicate short-circuits once the model is on disk, and `ExistingWorkPolicy.KEEP` collapses
+     * a duplicate enqueue during the download window.
+     */
+    private fun prefetchVadModel(useLocal: Boolean) {
+        if (!VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = useLocal,
+                modelInstalled = ModelDownloader.vadModelFile(this, SILERO_VAD_MODEL) != null,
+            )
+        ) {
+            return
+        }
+        android.util.Log.i(TAG, "Local mode active — prefetching VAD model for segmented decode (#169)")
+        ModelDownloadWorker.enqueue(this, SILERO_VAD_MODEL)
     }
 
     /**
@@ -335,6 +358,7 @@ class TranscriptionActivity : BaseSettingsActivity() {
     private fun refreshAllCards() = MODEL_CATALOG.forEach { refreshCard(it) }
 
     companion object {
+        private const val TAG = "TranscriptionActivity"
         private const val LP_MATCH = LinearLayout.LayoutParams.MATCH_PARENT
         private const val KEY_LOCAL_CLEANUP_CONSENT = "local_cleanup_consent_seen"
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/VadModelProvisioning.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/VadModelProvisioning.kt
@@ -24,6 +24,22 @@ package com.trevornk.ramblr
  * every take while the device is offline or the download is failing. Making a missing model fatal
  * would trade a rare OOM for "local transcription is broken", which is strictly worse. This only
  * ensures the model eventually arrives for the users who actually need it.
+ *
+ * ## Why first use is not early enough (#169)
+ *
+ * [shouldFetch] alone still leaves one guaranteed-bad take. Because the fetch is asynchronous,
+ * *the very dictation that triggers it* always decodes unsegmented — on a fresh install that is
+ * every new user's first long take, measured by an F-Droid reviewer at 9.3 s and 665 MB RSS for
+ * 47 s of audio on a 4 GB device, versus 325 ms once the model is present. First use is not a
+ * rare edge; it is universal, and it lands hardest on exactly the low-RAM devices #132 was filed
+ * for.
+ *
+ * [shouldPrefetchForLocalMode] closes that window by moving provisioning earlier, to the moment
+ * the user *chooses* on-device transcription (onboarding, or the Transcription settings toggle).
+ * The download then overlaps setup — while the user is still granting permissions and picking an
+ * ASR model, which already involves a far larger download — instead of racing their first
+ * dictation. [shouldFetch] deliberately stays as the backstop for anyone who selected local mode
+ * while offline, or upgraded from a build that predates this.
  */
 object VadModelProvisioning {
 
@@ -37,4 +53,23 @@ object VadModelProvisioning {
      */
     fun shouldFetch(modelInstalled: Boolean, downloadInFlight: Boolean): Boolean =
         !modelInstalled && !downloadInFlight
+
+    /**
+     * True when selecting on-device transcription should provision the VAD model up front (#169),
+     * so the first dictation already has it and decodes segmented.
+     *
+     * Deliberately does *not* take a `downloadInFlight` argument, unlike [shouldFetch]. The call
+     * sites are UI callbacks on the main thread, where reading WorkManager state means a blocking
+     * `.get()` that [WhisperAccessibilityService.vadDownloadStateFor] explicitly documents as
+     * background-thread-only. `ExistingWorkPolicy.KEEP` already collapses duplicate enqueues, so
+     * an installed-only check is both sufficient and the cheap one — a filesystem stat rather
+     * than a cross-process query.
+     *
+     * [localTranscriptionSelected] gates the whole thing: a cloud-only user should never pay for
+     * a download they will never use.
+     */
+    fun shouldPrefetchForLocalMode(
+        localTranscriptionSelected: Boolean,
+        modelInstalled: Boolean,
+    ): Boolean = localTranscriptionSelected && !modelInstalled
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/VadModelProvisioningTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/VadModelProvisioningTest.kt
@@ -59,4 +59,84 @@ class VadModelProvisioningTest {
     @Test fun `silero vad stays a small download`() {
         assertEquals(1, SILERO_VAD_MODEL.sizeMb)
     }
+
+    // --- #169: prefetch at local-mode selection ---------------------------------------------
+    //
+    // shouldFetch alone still leaves exactly one bad take: the fetch it triggers is asynchronous,
+    // so the dictation that triggers it always decodes unsegmented (665 MB RSS for 47 s of audio
+    // on a 4 GB device). shouldPrefetchForLocalMode moves provisioning to the moment on-device
+    // transcription is *chosen*, so the download overlaps setup instead of racing first use.
+
+    @Test fun `prefetches when local mode is selected and no model is installed`() {
+        assertTrue(
+            VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = true,
+                modelInstalled = false,
+            )
+        )
+    }
+
+    /** A cloud-only user must never pay for a download they will never use. */
+    @Test fun `does not prefetch for a cloud transcription user`() {
+        assertFalse(
+            VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = false,
+                modelInstalled = false,
+            )
+        )
+    }
+
+    /** Keeps repeated visits to the Transcription screen from re-enqueueing forever. */
+    @Test fun `does not prefetch when the model is already installed`() {
+        assertFalse(
+            VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = true,
+                modelInstalled = true,
+            )
+        )
+    }
+
+    /** Cloud mode wins even with nothing on disk — mode is the gate, not installedness. */
+    @Test fun `does not prefetch for a cloud user even with the model installed`() {
+        assertFalse(
+            VadModelProvisioning.shouldPrefetchForLocalMode(
+                localTranscriptionSelected = false,
+                modelInstalled = true,
+            )
+        )
+    }
+
+    /**
+     * The regression this issue is actually about. A fresh install that picked on-device
+     * transcription must have provisioning already triggered *before* the first dictation runs,
+     * so that dictation sees an installed model and takes the segmented path. Asserting the two
+     * predicates in sequence is what distinguishes the fix from the pre-#169 behavior: without
+     * the prefetch the first take is the thing that enqueues, and it decodes unsegmented.
+     */
+    @Test fun `fresh install selecting local mode provisions before the first dictation`() {
+        // Step 1: user picks on-device transcription during onboarding. Nothing on disk yet.
+        val prefetches = VadModelProvisioning.shouldPrefetchForLocalMode(
+            localTranscriptionSelected = true,
+            modelInstalled = false,
+        )
+        assertTrue("selecting local mode must provision the VAD model up front", prefetches)
+
+        // Step 2: the download lands during setup, so the first dictation finds it installed and
+        // must NOT need the transcription-time backstop at all.
+        assertFalse(
+            "first dictation should not have to fetch — the model is already there",
+            VadModelProvisioning.shouldFetch(modelInstalled = true, downloadInFlight = false)
+        )
+    }
+
+    /**
+     * No regression to the genuinely-missing-model case (#169 acceptance criterion 2): a user who
+     * selected local mode while offline gets no model from the prefetch, and the transcription-time
+     * backstop must still fire so the model eventually arrives.
+     */
+    @Test fun `transcription-time backstop still fires when the prefetch could not deliver`() {
+        assertTrue(
+            VadModelProvisioning.shouldFetch(modelInstalled = false, downloadInFlight = false)
+        )
+    }
 }


### PR DESCRIPTION
## Problem

`VadModelProvisioning` (#139) enqueues the Silero VAD download on first local transcription via WorkManager with a network constraint. Because provisioning is **asynchronous**, the very take that triggers the fetch always decodes unsegmented — the single-shot native decode path #132 exists to avoid.

On a physical Redmi Note 8T (Android 13, 4 GB), an F-Droid reviewer measured:

| Take | VAD model | Audio | Time | Peak RSS |
|------|-----------|-------|------|----------|
| 1 | `VAD model unavailable` | 47 s | 9.3 s | **665 MB** |
| 2 | present | 12 s | 325 ms | — |

First use is not a rare edge — it is *every* new install's first long dictation, and it lands hardest on exactly the low-RAM devices most likely to be running an F-Droid build.

## Approach: option 2 (provision at selection), not option 1 (bundle the .onnx)

The issue preferred bundling `silero_vad.onnx` in the APK. **I did not do that, on license-provenance grounds** — see below. Option 2 was implemented instead.

Provisioning now happens the moment the user *chooses* on-device transcription, so the ~644 KB download overlaps the rest of setup (permissions, and the far larger ASR model download) instead of racing the first dictation.

### Why not bundle the .onnx

The F-Droid scanner itself is **not** the blocker. Verified empirically against `fdroidserver` **2.4.2** (the version pinned to match CI, not PyPI latest):

- `scan_source()`'s per-file dispatch has hard-error branches for `.a`, `.aar`, `.apk`, `.class`, `.dex`, `.gz`/`.tgz`, `.so`, `.zip`, `.jar`, `.wasm`, plus a `['', '.bin', '.out', '.exe']` binary branch. **`.onnx` matches none of them**; the string `onnx` does not appear in 2.4.2's `scanner.py` at all.
- The `executable binary, possibly code` rule is a *warning* and requires the executable bit; the asset is mode `644`.
- Running the real `scan_source()` over a tree containing the asset returned a problem count of **0**.
- The asset is not inside either `scandelete` path (`sherpa-onnx`, `llama.cpp/examples/gguf-hash/deps`), so it would not be silently stripped.

I also confirmed `gradle/wrapper/gradle-wrapper.jar` is **not** precedent for committing binaries — 2.4.2 routes it to `removeproblem()`, i.e. the file is *deleted* before the build, not permitted.

**The blocker is license provenance of the specific artifact.** The file Ramblr consumes is the sherpa-onnx release asset (`643,854` bytes, sha256 `9e2449e1…`). That byte-for-byte artifact matches **no** upstream `snakers4/silero-vad` tag:

| Source | Size | sha256 |
|---|---|---|
| silero-vad v3.1 | 797,513 | `f87d83bb…` |
| silero-vad v4.0 | 1,807,522 | `a35ebf52…` |
| silero-vad v5/master | 2,327,524 | `1a153a22…` |
| **sherpa-onnx asset (ours)** | **643,854** | **`9e2449e1…`** |

It is a sherpa-onnx-specific re-export, redistributed under a release that ships **no LICENSE asset** alongside it. Upstream's LICENSE has been MIT since its only commit (2020-11-23), and sherpa-onnx is Apache-2.0, so the *terms* are almost certainly fine — but "almost certainly" is not a license claim worth committing into the source tree of an app that is **mid-F-Droid-review**. Downloading the artifact at runtime (status quo) carries no such redistribution question.

If a maintainer can pin this artifact's provenance to a specific upstream export, bundling becomes the strictly better fix and this change is a clean stepping stone toward it.

## Changes

- **`VadModelProvisioning.kt`** — new pure predicate `shouldPrefetchForLocalMode(localTranscriptionSelected, modelInstalled)`. Deliberately takes no `downloadInFlight` argument: call sites are main-thread UI callbacks, and reading WorkManager state there means the blocking `.get()` that `vadDownloadStateFor` documents as background-only. `ExistingWorkPolicy.KEEP` already collapses duplicates.
- **`MainActivity.kt`** — onboarding's "Use on-device (recommended)" now calls `prefetchVadModel()`.
- **`TranscriptionActivity.kt`** — `refresh()` prefetches when local mode is active, covering both the settings-toggle path and the existing local user upgrading from a build without this.

`shouldFetch` and the unsegmented fallback are **unchanged**: still the backstop for anyone who selected local mode offline. The kdoc reasoning at `VadModelProvisioning.kt:20-26` (a missing model must stay non-fatal) is preserved.

## Acceptance

- ✅ Fresh install's first long local dictation decodes **segmented** — provisioning is triggered at mode selection, before any dictation.
- ✅ No regression to the genuinely-missing-model fallback — covered by a dedicated test.

## Testing

`137 suites / 1292 tests / 0 failures / 0 errors / 0 skipped` (counts parsed from JUnit XML, unfiltered `--rerun-tasks` run). Baseline on main is 1286; **+6 new tests**.

**Mutation-proven.** Replacing the predicate body with `false` (pre-#169 behavior) made exactly these fail:

- `prefetches when local mode is selected and no model is installed`
- `fresh install selecting local mode provisions before the first dictation`

Source restored byte-for-byte and re-verified: sha256 `d2013c5888a3e46ba027789ef17ac228cccb107aa231e9591483121687b2a602` before and after, `diff` identical, suite green again at 1292/0.

Fixes #169
