### PR TITLE
Fix ASR catalog sizeMb authored in MiB instead of decimal MB

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ModelDownloader.kt
@@ -155,13 +155,13 @@ data class Model(
 // interleaved by its own real quality standing, not pinned to the bottom.
 val MODEL_CATALOG = listOf(
     Model("Parakeet 0.6B", "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
-        465, "★★★★ Best quality",
+        487, "★★★★ Best quality",
         sha256 = "5793d0fd397c5778d2cf2126994d58e9d56b1be7c04d13c7a15bb1b4eafb16bf",
         license = CC_BY_4_0),
-    // Smallest AND best-value entry in the catalog (100MB, ~7.5% avg WER on the Open ASR
+    // Smallest AND best-value entry in the catalog (104MB, ~7.5% avg WER on the Open ASR
     // Leaderboard) -- recommended default.
     Model("Parakeet 110M", "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8",
-        100, "★★★ Best value · Smallest", recommended = true,
+        104, "★★★ Best value · Smallest", recommended = true,
         sha256 = "17f945007b52ccd8b7200ffc7c5652e9e8e961dfdf479cefcabd06cf5703630b",
         license = CC_BY_4_0),
     // Replaces Whisper Base.en for #98 (Claude Fable 5 STT model consult): Canary-180m-flash is
@@ -174,7 +174,7 @@ val MODEL_CATALOG = listOf(
     // 153,692,328-byte asset from the real sherpa-onnx GitHub release and hashing it locally
     // (`shasum -a 256`), same discipline as every other entry in this file.
     Model("Canary 180M Flash", "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8",
-        147, "★★★★ Multilingual, punctuated",
+        153, "★★★★ Multilingual, punctuated",
         sha256 = "7a38ed8b13f014ad632b09ff8d22e0c6f1359dd046af9235d281dfae841b9ab9",
         license = CC_BY_4_0),
     // Moonshine Tiny REMOVED (#98, follow-up to Trevor's request to clean up mislabeled/confusing

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelDownloaderTest.kt
@@ -65,6 +65,36 @@ class ModelDownloaderTest {
         assertTrue(MODEL_CATALOG.all { it.sizeMb > 0 })
     }
 
+    @Test fun `ASR and streaming catalog sizeMb is decimal MB matching each model's real byte size`() {
+        // Same contract, and the same failure mode, as the local-cleanup test below: sizeMb is
+        // consumed by requiredSpaceBytes as DECIMAL MB. These three entries were authored from
+        // MiB figures (100/147/465 instead of 104/153/487), so every ASR install reserved ~4.9%
+        // less disk than it needed. The cleanup test above it existed and passed the whole time
+        // -- it just never covered MODEL_CATALOG or STREAMING_MODEL_CATALOG, which is exactly how
+        // the drift survived. Pin every downloadable catalog, not a subset.
+        val realBytes = mapOf(
+            "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8" to 487_170_055L,
+            "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8" to 104_337_827L,
+            "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8" to 153_692_328L,
+            "sherpa-onnx-streaming-zipformer-en-kroko-2025-08-06" to 57_267_600L,
+        )
+
+        for (model in MODEL_CATALOG + STREAMING_MODEL_CATALOG) {
+            val bytes = realBytes[model.archive]
+                ?: fail("no recorded byte size for ${model.archive}; add it when adding a catalog entry")
+            val expectedDecimalMb = ((bytes as Long) / 1_000_000L).toInt()
+            assertEquals(
+                "${model.archive} sizeMb should be decimal MB ($bytes bytes), not MiB",
+                expectedDecimalMb,
+                model.sizeMb,
+            )
+            assertTrue(
+                "${model.archive}: requiredSpaceBytes must exceed the real download size",
+                ModelDownloader.requiredSpaceBytes(model.sizeMb, model.isSingleFile) > bytes,
+            )
+        }
+    }
+
     @Test fun `local cleanup catalog sizeMb is decimal MB matching each model's real byte size`() {
         // requiredSpaceBytes multiplies sizeMb by 1_000_000, so these entries have to be decimal
         // MB. MUMBLE_CLEANUP_Q4_0_MODEL was authored from the MiB figure (336 instead of 352),


### PR DESCRIPTION
`requiredSpaceBytes` multiplies `sizeMb` by `1_000_000`, so catalog entries must carry **decimal MB**. All three `MODEL_CATALOG` entries were authored from MiB figures, under-reserving install headroom by ~4.9% each.

| Model | Was | Now | Real bytes |
|---|---|---|---|
| Parakeet 0.6B | 465 | 487 | 487,170,055 |
| Parakeet 110M | 100 | 104 | 104,337,827 |
| Canary 180M Flash | 147 | 153 | 153,692,328 |

Streaming Zipformer's `57` was already correct (57,267,600 bytes).

This is the same bug fixed for `MUMBLE_CLEANUP_Q4_0_MODEL` in #146 (336 → 352). The regression test added there has been passing the whole time — it only iterated `LOCAL_CLEANUP_MODEL_CATALOG`, never `MODEL_CATALOG` or `STREAMING_MODEL_CATALOG`. That gap is why the identical mistake survived in three more entries, so the test now pins every downloadable catalog.

## Verification

Mutation-proven, not just green:

- Reverting the three constants to their old MiB values → `ModelDownloaderTest > ASR and streaming catalog sizeMb is decimal MB... FAILED`, `66 tests completed, 1 failed`.
- Restoring them → full unfiltered suite `138 suites / 1,300 tests / 0 failures / 0 errors / 0 skipped`.

Sizes taken from `content-length` on the sherpa-onnx `asr-models` release assets, not estimated.

## Impact

User-visible only on a nearly-full device, where an install could pass the space check and then fail mid-download. No behavior change otherwise — `sizeMb` also feeds the size shown in the model picker, which was understating each download by the same ~4.9%.

Refs #177. Does not address the other findings in that issue (stale WER figures, the Canary-as-default question) — those need an on-device latency test first.