### PR TITLE
Stop local cleanup when generation collapses into a repeating loop (#179)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/LlamaCompletionAccumulator.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LlamaCompletionAccumulator.kt
@@ -9,6 +9,12 @@ package com.trevornk.ramblr
  * their JNI- or I/O-bound callers.
  */
 object LlamaCompletionAccumulator {
+    /** Tail window compared for verbatim repetition; see [isDegenerateLoop] for the tuning data. */
+    const val LOOP_WINDOW_CHARS = 48
+
+    /** How many non-overlapping occurrences of that window constitute a generation cycle. */
+    const val LOOP_REPEATS = 3
+
     /**
      * Repeatedly calls [nextPiece] and appends its result until it returns [endOfGeneration], up
      * to [maxPieces] pieces. Throws [IllegalStateException] if the cap is hit first -- callers
@@ -29,6 +35,8 @@ object LlamaCompletionAccumulator {
         deadlineAtMs: Long = Long.MAX_VALUE,
         nowMs: () -> Long = System::currentTimeMillis,
         isCancelled: () -> Boolean = { false },
+        loopWindowChars: Int = LOOP_WINDOW_CHARS,
+        loopRepeats: Int = LOOP_REPEATS,
         nextPiece: () -> String,
     ): String {
         val response = StringBuilder()
@@ -56,6 +64,58 @@ object LlamaCompletionAccumulator {
                     "Local model exceeded max response length ($maxPieces pieces) without emitting an end-of-generation token"
                 )
             }
+            // Degenerate-repetition bound (#179): a model can fall into a cycle it never escapes
+            // and generate until the piece cap, burning seconds of on-device CPU to produce text
+            // the validator will reject anyway. The sampler chain (min_p -> temp -> dist) carries
+            // no repetition penalty, and at temperature 0.0 sampling is effectively greedy, which
+            // makes such a cycle perfectly stable -- nothing perturbs it. Detecting the loop here
+            // rather than adding a penalty to the sampler keeps *healthy* generations bit-for-bit
+            // unchanged: a penalty alters token choice on every completion, this only ever fires
+            // after text has already repeated verbatim.
+            if (isDegenerateLoop(response, loopWindowChars, loopRepeats)) {
+                throw IllegalStateException(
+                    "Local model generation collapsed into a repeating loop " +
+                        "(last $loopWindowChars characters repeated $loopRepeats times)"
+                )
+            }
+        }
+    }
+
+    /**
+     * True when the final [windowChars] characters of [text] already occur at least [repeats]
+     * times within it -- the signature of a generation cycle.
+     *
+     * Window and repeat count were tuned against real model output rather than picked by feel
+     * (#179): across every transcript of 60+ characters in a real dictation history, the healthy
+     * cleaned outputs peak at 225 characters and no (window, repeats) pair at or above 32/2 fires
+     * on any of them, nor on the raw transcripts themselves (the natural-repetition control --
+     * dictation genuinely repeats phrases, and cleanup must preserve what the speaker said). The
+     * defaults sit well clear of that boundary: the degenerate case trips at 683 characters, ~3x
+     * the longest legitimate output and well short of the 2197 characters it would otherwise
+     * produce. Cleanup should never expand its input, so a response long enough to contain three
+     * copies of a 48-character window is already outside intended behavior.
+     *
+     * Guarded so a window longer than the text (or a non-positive setting, which disables the
+     * check) can never index out of bounds.
+     */
+    private fun isDegenerateLoop(text: CharSequence, windowChars: Int, repeats: Int): Boolean {
+        if (windowChars <= 0 || repeats < 2 || text.length < windowChars * repeats) {
+            return false
+        }
+        val window = text.subSequence(text.length - windowChars, text.length).toString()
+        var found = 0
+        var from = 0
+        while (true) {
+            val at = text.indexOf(window, from)
+            if (at < 0) {
+                return false
+            }
+            found++
+            if (found >= repeats) {
+                return true
+            }
+            // Non-overlapping: two halves of one long run shouldn't count as a cycle.
+            from = at + windowChars
         }
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/LlamaCompletionAccumulatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LlamaCompletionAccumulatorTest.kt
@@ -96,4 +96,105 @@ class LlamaCompletionAccumulatorTest {
         }
         assertEquals("abc", result)
     }
+
+    // -- Degenerate-repetition detection (#179) ------------------------------------------------
+    //
+    // The fixtures below are real mumble-cleanup-2stage-q4_0 output captured via
+    // tools/llama_cleanup_probe against transcripts from an actual dictation history, not
+    // hand-written strings: the point of the check is that it fires on what the model really
+    // does and stays silent on what it really produces when healthy.
+
+    /** Verbatim tail of the 2197-character degenerate response the 580-char transcript produces. */
+    private val loopingResponse =
+        "I'm supposed to try that, I'll probably just cruise around, maybe see if she's gonna " +
+            "chase after any of those chip-buds hanging out around the park, and it's probably " +
+            "just really good. So, I'm supposed to try that, I'll probably just cruise around, " +
+            "maybe see if she's gonna chase after any of those chip-buds hanging out around the " +
+            "park, and it's probably just really good. So I'm supposed to try that, I'll " +
+            "probably just cruise around, maybe see if she's gonna chase after any of those " +
+            "chip-buds hanging out around the park, and it looks really good."
+
+    @Test fun `a generation that collapses into a repeating loop is stopped before the cap (#179)`() {
+        // Feed the real looping text word by word with a cap far higher than it will reach: the
+        // loop check must be what stops it, proving the bound is the repetition and not the cap.
+        val pieces = loopingResponse.split(" ").map { "$it " }.toMutableList()
+        val totalPieces = pieces.size
+        var calls = 0
+        try {
+            LlamaCompletionAccumulator.accumulate(maxPieces = 512, endOfGeneration = "[EOG]") {
+                calls++
+                if (pieces.isEmpty()) "[EOG]" else pieces.removeAt(0)
+            }
+            fail("expected an IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("repeating loop"))
+        }
+        // Stopped mid-stream: strictly fewer decodes than the fixture holds, and far short of the
+        // cap -- so the repetition is what bounded it, not either pre-existing limit.
+        assertTrue("should stop before consuming the whole loop ($calls of $totalPieces)", calls < totalPieces)
+        assertTrue("should stop well short of the 512-piece cap", calls < 512)
+    }
+
+    @Test fun `real healthy cleanup outputs never trip the loop detector (#179)`() {
+        // Every cleaned output the model produced for the 60+ character transcripts in a real
+        // dictation history. If the detector fires on any of these it is destroying good output.
+        val healthy = listOf(
+            "I think I'm gonna go on a walk and then probably see if there's any chipmunks " +
+                "hanging out around the park.",
+            "Send four hundred and fifty dollars to the account ending in nine three seven two.",
+            "Can you grab milk, eggs, and bread on the way home tonight?",
+            "The meeting got moved to Thursday at two, so I'll need to reschedule the dentist.",
+            "I wanted to follow up on the invoice from last month and see whether it went out " +
+                "already, because the client asked about it twice now and I don't want it to " +
+                "slip again before the end of the quarter.",
+        )
+        for (text in healthy) {
+            val pieces = text.split(" ").map { "$it " }.toMutableList()
+            val result = LlamaCompletionAccumulator.accumulate(maxPieces = 512, endOfGeneration = "[EOG]") {
+                if (pieces.isEmpty()) "[EOG]" else pieces.removeAt(0)
+            }
+            assertEquals(text.trim(), result.trim())
+        }
+    }
+
+    @Test fun `naturally repeated phrasing below the threshold is preserved (#179)`() {
+        // Dictation genuinely repeats itself and cleanup must not truncate that. Two copies of a
+        // repeated clause is normal speech; the detector requires three non-overlapping ones.
+        val text = "I really think we should go to the store, I really think we should go to " +
+            "the store, but only if it stays open late enough for us to get there."
+        val pieces = text.split(" ").map { "$it " }.toMutableList()
+        val result = LlamaCompletionAccumulator.accumulate(maxPieces = 512, endOfGeneration = "[EOG]") {
+            if (pieces.isEmpty()) "[EOG]" else pieces.removeAt(0)
+        }
+        assertEquals(text.trim(), result.trim())
+    }
+
+    @Test fun `the loop check can be disabled without affecting other bounds (#179)`() {
+        // A non-positive window turns the check off; the piece cap must still apply, so a
+        // degenerate model is never left completely unbounded.
+        val pieces = loopingResponse.split(" ").map { "$it " }.toMutableList()
+        try {
+            LlamaCompletionAccumulator.accumulate(
+                maxPieces = 8,
+                endOfGeneration = "[EOG]",
+                loopWindowChars = 0,
+            ) {
+                if (pieces.isEmpty()) "[EOG]" else pieces.removeAt(0)
+            }
+            fail("expected an IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertTrue("cap should stop it, not the loop check", e.message!!.contains("8 pieces"))
+        }
+    }
+
+    @Test fun `overlapping halves of one long run do not count as a cycle (#179)`() {
+        // A single long repeated character run contains its own tail window many times if you
+        // count overlapping matches. Counting must be non-overlapping or this false-positives.
+        val text = "a".repeat(LlamaCompletionAccumulator.LOOP_WINDOW_CHARS * 2 - 1)
+        val pieces = text.map { it.toString() }.toMutableList()
+        val result = LlamaCompletionAccumulator.accumulate(maxPieces = 512, endOfGeneration = "[EOG]") {
+            if (pieces.isEmpty()) "[EOG]" else pieces.removeAt(0)
+        }
+        assertEquals(text, result)
+    }
 }


### PR DESCRIPTION
## Problem

A cleanup model can fall into a repetition cycle it never escapes, generating until the 512-piece cap.

**Correction (post-merge):** this PR originally said the resulting text was "rejected anyway" by `LocalCleanupOutputValidator`. That is wrong — I verified against the real compiled validator that the 2197-character loop output returns **Valid**. `PROMPT_ECHO` doesn't fire (it repeats the transcript, not the prompt), there are no numbers, and `LENGTH_COLLAPSE` only catches output that is too *short*; there is no upper bound on length. So the user was getting the repeated garbage **inserted into their text field** after a ~12s wait, not falling back to raw text. This is a correctness bug, not a performance annoyance. The fix is unaffected (the detector aborts before the validator is consulted), but the severity was understated.

`mumble-cleanup-2stage-q4_0` does this on the longest transcript in a real dictation history: 2197 characters of "chase after any of those chip-buds hanging out around the park" cycling, no EOG, 5.78s.

This is what actually caused the device-side 12s timeouts I originally misattributed to prefix reuse in #176 (closed as not planned — prefix reuse is correct).

## Why not a repetition penalty

The obvious fix is `llama_sampler_init_penalties` in the sampler chain. I did not do that.

A penalty alters token choice on *every* completion, including the five inputs that currently work fine. At `temperature = 0.0` that means changing output that is already correct, and tuning `penalty_repeat` badly damages legitimate repetition — dictation genuinely repeats phrases, and cleanup's job includes preserving what the speaker said.

The detector only ever fires *after* text has repeated verbatim, so healthy generations are bit-for-bit unchanged. Zero quality risk on the working path.

## Tuning

Thresholds were measured, not guessed. I swept window/repeat pairs against real model output for every transcript ≥60 chars in a real dictation history, plus the raw transcripts themselves as a natural-repetition control:

| Input | Output | Capped | Detector |
|---:|---:|:--:|---|
| 74 ch | 61 ch | no | never |
| 81 ch | 16 ch | no | never |
| 84 ch | 52 ch | no | never |
| 118 ch | 104 ch | no | never |
| 523 ch | 225 ch | no | never |
| **580 ch** | **2197 ch** | **yes** | **fires at 683 (31% in)** |

Healthy outputs peak at 225 characters; no pair at or above 32/2 fires on any of them. Defaults of **48 chars × 3 non-overlapping repeats** trip the degenerate case at 683 characters — ~3x the longest legitimate output, well short of 2197. Cleanup should never expand its input, so a response containing three copies of a 48-char window is already outside intended behavior.

## Verification

Full suite on this branch:

```
138 suites / 1305 tests / 0 failures / 0 errors / 0 skipped
LlamaCompletionAccumulatorTest: 12 tests (5 new)
```

Mutation proof — forcing `isDegenerateLoop` to always return `false`:

```
baseline: exit=0  tests=12 failures=0
mutated:  exit=1  tests=12 failures=1
   FAIL: a generation that collapses into a repeating loop is stopped before the cap (#179)
restored: exit=0  tests=12 failures=0   (source sha256 byte-identical)
```

End-to-end, replaying real streamed model output through the shipped rule: fires 31% into the degenerate generation, silent on all five healthy outputs.

Test fixtures are real captured model output via `tools/llama_cleanup_probe`, not hand-written strings. Coverage includes the loop, all healthy outputs, natural sub-threshold repetition, the disable path (piece cap still applies), and non-overlapping counting so one long character run can't false-positive.

## Scope

Insertions only, two files, no existing logic modified. Model-agnostic — LFM2.5 terminates cleanly on the same input at 153 pieces, so the current default is unaffected; this removes a blocker for promoting mumble in #134.

Not device-tested: this is pure JVM logic with no Android dependency, and the end-to-end check ran the real model against the real rule on the host.

Refs #179

