### PR TITLE
Stop sending personal vocabulary to local cleanup models (#182)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
@@ -34,25 +34,43 @@ object LocalCleanupProvider {
      * [systemPromptFor], which is unit-testable without a Context (no Robolectric here, so
      * pure-logic extraction is how the rest of this module stays covered).
      */
-    fun selectedSystemPrompt(ctx: Context, terms: List<String>): String =
-        systemPromptFor(selectedModel(ctx), terms)
+    fun selectedSystemPrompt(ctx: Context): String = systemPromptFor(selectedModel(ctx))
 
     /**
      * The model's own [Model.localSystemPrompt] when it declares one (a fine-tuned model like
      * `mumble-cleanup-2stage` that requires its exact training prompt), otherwise the
-     * general-purpose [PostProcessor.SIMPLE_PROMPT] -- always interpolated.
+     * general-purpose [PostProcessor.SIMPLE_PROMPT].
      *
-     * The interpolation fixes a real on-device failure: only the *cloud* prompt was run through
-     * [PostProcessor.interpolateVocabulary] (in WhisperAccessibilityService), so LFM2.5 got a
-     * literal [PostProcessor.VOCABULARY_PLACEHOLDER] as its system prompt and echoed
-     * `{{vocabulary}}` back as the whole cleaned transcript. Doing it in the one function that
-     * picks the prompt means no caller can reintroduce it by forgetting. Fine-tuned prompts carry
-     * no placeholder, so this is a no-op for them (see [MUMBLE_CLEANUP_SYSTEM_PROMPT]).
+     * **The personal-vocabulary clause is deliberately NOT interpolated here (#182).** It is
+     * still sent to cloud cleanup, where it works; on-device it made cleanup dramatically worse.
+     * Measured on 10 real transcripts with the shipping validator, LFM2.5's valid-output rate
+     * fell monotonically with the number of configured terms:
+     *
+     *   0 terms -> 8/10      5 terms -> 4/10      22 terms -> 2/10
+     *
+     * The failure is that a 350M model cannot reliably tell a 300-character list of proper nouns
+     * in its instructions from content it is supposed to emit, so it returns the term list itself
+     * as the "cleaned" transcript -- names and email addresses where the user's words should be.
+     * Rewording did not fix it: a terser clause scored 4/10, moving it after the output
+     * instruction 6/10, and moving it into the user message 3/10, all below the 8/10 baseline of
+     * simply not sending it.
+     *
+     * Note this is not a regression for the other catalog entry: `mumble-cleanup-2stage` declares
+     * its own [Model.localSystemPrompt], which carries no [PostProcessor.VOCABULARY_PLACEHOLDER],
+     * so interpolation was always a no-op for it. Local cleanup has therefore never actually
+     * delivered this feature -- it either did nothing or did harm. Making vocabulary work
+     * on-device needs a deterministic post-processing pass over the model's output rather than a
+     * prompt instruction; that is tracked separately in #182.
+     *
+     * The placeholder must still be *removed* rather than left in the string. Shipping a literal
+     * `{{vocabulary}}` to the model was the original on-device bug: LFM2.5 echoed it back as the
+     * entire cleaned transcript. Interpolating an empty term list renders the surrounding
+     * sentence cleanly (see [PostProcessor.vocabularyClause]).
      */
-    fun systemPromptFor(model: Model, terms: List<String>): String =
+    fun systemPromptFor(model: Model): String =
         PostProcessor.interpolateVocabulary(
             model.localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT,
-            terms,
+            emptyList(),
         )
 
     // A `run(text, prompt, modelPath, engine)` helper used to live here, kdoc-claiming the

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
@@ -148,7 +148,7 @@ class ProcessTextActivity : Activity() {
             vocabulary,
         )
         val localModel = LocalCleanupProvider.selectedModel(this)
-        val localPrompt = LocalCleanupProvider.selectedSystemPrompt(this, vocabulary)
+        val localPrompt = LocalCleanupProvider.selectedSystemPrompt(this)
         val localModelPath = ModelDownloader.localCleanupModelFile(this, localModel)?.absolutePath
 
         progressDialog = android.app.AlertDialog.Builder(this)

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2831,7 +2831,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                 cancelHolder = inFlightCall,
                 credentialLookup = { kind -> ProviderCredentialStore.get(this, kind) },
                 localModelPath = { ModelDownloader.localCleanupModelFile(this, LocalCleanupProvider.selectedModel(this))?.absolutePath },
-                localPrompt = LocalCleanupProvider.selectedSystemPrompt(this, vocabulary),
+                localPrompt = LocalCleanupProvider.selectedSystemPrompt(this),
                 benchmarkContext = this,
                 benchmarkCorrelationId = correlationIdFor(token),
             ) { result ->

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
@@ -22,15 +22,22 @@ import org.junit.Test
 class LocalCleanupOutputValidatorTest {
 
     // The prompt actually sent in the failing condition: SIMPLE_PROMPT with a 22-term clause.
-    private val vocabularyPrompt = LocalCleanupProvider.systemPromptFor(
-        LOCAL_CLEANUP_MODEL,
+    //
+    // Built here via interpolateVocabulary rather than LocalCleanupProvider.systemPromptFor,
+    // because #182 stopped the *local* path from interpolating terms at all. The validator is
+    // deliberately prompt-agnostic -- it echo-checks whatever prompt it is handed -- and a
+    // vocabulary-laden prompt is still exactly what cloud cleanup sends, so this coverage stays
+    // meaningful. Keeping it also means the validator remains correct if vocabulary ever returns
+    // to the local path through the post-processing route #182 describes.
+    private val vocabularyPrompt = PostProcessor.interpolateVocabulary(
+        PostProcessor.SIMPLE_PROMPT,
         listOf(
             "Nash-Keller", "Wyatt", "Terelle", "Ramblr", "FastHTML", "Selby", "Mobridge",
             "Hermes", "Trinity", "sherpa-onnx", "llama.cpp",
         ),
     )
 
-    private val plainPrompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList())
+    private val plainPrompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL)
 
     private fun assertRejected(
         expected: LocalCleanupValidation.Reason,
@@ -136,7 +143,7 @@ class LocalCleanupOutputValidatorTest {
 
     @Test fun `the fine-tuned model's own prompt is echo-checked too`() {
         val model = LOCAL_CLEANUP_MODEL_CATALOG.first { it.localSystemPrompt != null }
-        val prompt = LocalCleanupProvider.systemPromptFor(model, listOf("Ramblr"))
+        val prompt = LocalCleanupProvider.systemPromptFor(model)
         assertRejected(
             LocalCleanupValidation.Reason.PROMPT_ECHO,
             "so anyway I was thinking we should ship it on Friday",
@@ -335,8 +342,11 @@ class LocalCleanupOutputValidatorTest {
         "Unishell", "Pi", "Codex", "Claude", "Hetzner",
     )
 
+    // Built directly rather than through systemPromptFor: #182 removed vocabulary from the local
+    // path, but this test reproduces the on-device #164 echo, whose whole subject is a prompt
+    // carrying these 22 terms. The validator must still reject that echo wherever it is sent.
     private val realDevicePrompt =
-        LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, realDeviceVocabulary)
+        PostProcessor.interpolateVocabulary(PostProcessor.SIMPLE_PROMPT, realDeviceVocabulary)
 
     /** Verbatim `rawText` from `dictation_history.jsonl` on the same device. */
     private val realDeviceTranscript =
@@ -372,7 +382,7 @@ class LocalCleanupOutputValidatorTest {
             LocalCleanupValidation.Reason.LENGTH_COLLAPSE,
             realDeviceTranscript,
             "I think I'm going to the park tonight",
-            prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList()),
+            prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL),
         )
     }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupProviderTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupProviderTest.kt
@@ -18,68 +18,105 @@ class LocalCleanupProviderTest {
         assertTrue(LocalCleanupProvider.MODEL.isLocalCleanup)
     }
 
-    // --- local-prompt vocabulary interpolation (systemPromptFor) -------------------------------
+    // --- local prompt construction (systemPromptFor) -------------------------------------------
     //
-    // Real on-device failure: with the LOCAL_LLM step selected, dictation injected the literal
-    // text "{{vocabulary}}" instead of the transcript. Only the cloud prompt was run through
-    // interpolateVocabulary in WhisperAccessibilityService, so LFM2.5 -- which declares no
-    // fine-tuned prompt and falls back to SIMPLE_PROMPT -- got the raw placeholder as its system
-    // prompt and echoed it back.
+    // Two separate on-device failures shaped this function, and the tests below pin both.
     //
-    // These deliberately call systemPromptFor rather than PostProcessor.interpolateVocabulary,
-    // which was never the broken part: an earlier draft asserted on the latter and passed against
-    // the unfixed code. Mutation-check any change by reverting systemPromptFor's body to
-    // `model.localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT` -- three of these must fail.
+    // (1) The literal-placeholder bug: with the LOCAL_LLM step selected, dictation injected the
+    //     text "{{vocabulary}}" instead of the transcript, because only the cloud prompt was run
+    //     through interpolateVocabulary. LFM2.5 falls back to SIMPLE_PROMPT, so it received the
+    //     raw placeholder and echoed it back. The placeholder must still be *removed*.
+    //
+    // (2) #182: interpolating the real term list is what the placeholder was removed *for*, and
+    //     it turned out to be actively harmful on-device. LFM2.5's valid-output rate against the
+    //     shipping validator fell from 8/10 (no terms) to 4/10 (5 terms) to 2/10 (22 terms) --
+    //     it returns the term list itself as the cleaned transcript. Local cleanup now renders
+    //     the clause empty; vocabulary remains a cloud-only feature.
+    //
+    // Mutation-check any change by making systemPromptFor interpolate a non-empty term list --
+    // the #182 tests must fail. Reverting its body to a bare
+    // `model.localSystemPrompt ?: PostProcessor.SIMPLE_PROMPT` must fail the placeholder tests.
 
-    @Test fun `the local fallback prompt still carries the placeholder to interpolate`() {
-        // If this constant ever loses its placeholder, interpolation silently becomes a no-op and
-        // local cleanup quietly stops honouring personal vocabulary -- fail loudly instead.
+    @Test fun `the local fallback prompt still carries the placeholder to strip`() {
+        // If this constant ever loses its placeholder the interpolation call becomes dead code,
+        // and a future edit reintroducing terms would have nothing to substitute into. Pin it.
         assertTrue(
             "SIMPLE_PROMPT must contain the vocabulary placeholder for local cleanup to substitute",
             PostProcessor.SIMPLE_PROMPT.contains(PostProcessor.VOCABULARY_PLACEHOLDER),
         )
     }
 
-    @Test fun `a model without its own prompt gets vocabulary interpolated, not a literal placeholder`() {
+    @Test fun `a model without its own prompt gets no literal placeholder`() {
         // LFM2.5 declares no localSystemPrompt, so it falls back to SIMPLE_PROMPT -- the exact
         // path that shipped "{{vocabulary}}" to the screen.
-        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, listOf("Ramblr", "FastHTML"))
+        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL)
         assertFalse(
             "a literal {{vocabulary}} reaching the local model is the on-device bug",
             prompt.contains(PostProcessor.VOCABULARY_PLACEHOLDER),
         )
-        assertTrue(prompt.contains("Ramblr"))
-        assertTrue(prompt.contains("FastHTML"))
+        assertFalse("no template syntax may survive into the system prompt", prompt.contains("{{"))
     }
 
-    @Test fun `a model without its own prompt and no vocabulary terms still drops the placeholder`() {
-        // The empty-vocabulary case is the default for a fresh install, so it is the most likely
-        // path to ship broken: the clause collapses to "" but the placeholder must still be gone.
-        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL, emptyList())
-        assertFalse(prompt.contains(PostProcessor.VOCABULARY_PLACEHOLDER))
-        assertFalse("no template syntax may survive into the system prompt", prompt.contains("{{"))
+    @Test fun `the local prompt carries no personal vocabulary terms (#182)`() {
+        // The regression this fix exists to prevent. Terms configured by the user must not reach
+        // the local model's system prompt in any form: a 350M model returns them as its answer.
+        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL)
+        assertFalse(
+            "vocabulary terms in the local system prompt are what LFM2.5 echoes back (#182)",
+            prompt.contains("Watch for these project names"),
+        )
+        assertEquals(
+            "the local prompt must be exactly SIMPLE_PROMPT with an empty vocabulary clause",
+            PostProcessor.interpolateVocabulary(PostProcessor.SIMPLE_PROMPT, emptyList()),
+            prompt,
+        )
+    }
+
+    @Test fun `the local prompt is identical no matter what vocabulary the user has configured (#182)`() {
+        // systemPromptFor no longer takes terms at all, so this asserts the property that removal
+        // was meant to guarantee: nothing user-configured can vary the local prompt. If someone
+        // reintroduces a terms parameter, this test is the reason to think twice.
+        val prompt = LocalCleanupProvider.systemPromptFor(LOCAL_CLEANUP_MODEL)
+        val realDeviceVocabulary = listOf(
+            "Nash-Keller", "Wyatt", "Terelle", "Emsley", "trevor@nashkellermedia.com",
+        )
+        realDeviceVocabulary.forEach { term ->
+            assertFalse(
+                "$term leaked into the local system prompt",
+                prompt.contains(term),
+            )
+        }
     }
 
     @Test fun `a fine-tuned model's exact training prompt is passed through byte for byte`() {
         // mumble-cleanup-2stage must receive its exact training prompt; it declares no
-        // placeholder, so interpolation has to be a no-op even with vocabulary configured.
+        // placeholder, so the interpolation has to be a no-op for it.
         val model = LOCAL_CLEANUP_MODEL_CATALOG.first { it.localSystemPrompt != null }
         assertEquals(
             model.localSystemPrompt,
-            LocalCleanupProvider.systemPromptFor(model, listOf("Ramblr")),
+            LocalCleanupProvider.systemPromptFor(model),
         )
     }
 
     @Test fun `no catalog model can send an uninterpolated placeholder to the local engine`() {
         // Guards every current and future catalog entry, not just the two we know about.
         LOCAL_CLEANUP_MODEL_CATALOG.forEach { model ->
-            listOf(emptyList(), listOf("Ramblr")).forEach { terms ->
-                assertFalse(
-                    "${model.archive} would send a literal placeholder to the local model",
-                    LocalCleanupProvider.systemPromptFor(model, terms)
-                        .contains(PostProcessor.VOCABULARY_PLACEHOLDER),
-                )
-            }
+            assertFalse(
+                "${model.archive} would send a literal placeholder to the local model",
+                LocalCleanupProvider.systemPromptFor(model)
+                    .contains(PostProcessor.VOCABULARY_PLACEHOLDER),
+            )
+        }
+    }
+
+    @Test fun `no catalog model leaks vocabulary terms into its local prompt (#182)`() {
+        // The catalog-wide form of the #182 guard: a future entry that ships a prompt with a
+        // placeholder must still not receive the user's terms.
+        LOCAL_CLEANUP_MODEL_CATALOG.forEach { model ->
+            assertFalse(
+                "${model.archive} would send vocabulary terms to a local model (#182)",
+                LocalCleanupProvider.systemPromptFor(model).contains("Watch for these project names"),
+            )
         }
     }
 }


### PR DESCRIPTION
Fixes #182.

The personal-vocabulary clause interpolated into the local cleanup system prompt is the single largest cause of local cleanup failure. LFM2.5 — the default cleanup model, which declares no `localSystemPrompt` and falls back to `SIMPLE_PROMPT` — returns **the term list itself** as the cleaned transcript.

## Measurement

10 real dictation transcripts (≥24 chars) from device history, each in a fresh process via `tools/llama_cleanup_probe` (compiles production `LLMInference.cpp` verbatim, same sampler settings and chat template as `LlamaCppInference`), verdicts from the **real compiled `LocalCleanupOutputValidator`** driven by reflection rather than a reimplementation.

| Configured terms | Valid |
|---|---:|
| 0 | **8/10** |
| 5 | 4/10 |
| 22 (my device) | **2/10** — `PROMPT_ECHO` ×8 |

A 118-char transcript at 22 terms returned the vocabulary list — names and four email addresses. At 0 terms the same transcript cleaned correctly.

Rewording doesn't fix it: terse clause 4/10, clause moved after the output instruction 6/10, clause moved into the user message 3/10 — all below the 8/10 baseline of not sending it. (The user-message arm was scored with the clause included in the instruction surface handed to the validator, so relocating it can't hide an echo and score a false win.)

## Change

`systemPromptFor` renders the clause empty for local models. Cloud cleanup is untouched — both call sites keep their own `interpolateVocabulary` call for the cloud prompt.

The `terms` parameter is **removed** rather than ignored, so it can't be silently reintroduced by a future caller. The placeholder is still stripped rather than left in the string; shipping a literal `{{vocabulary}}` was the original on-device bug.

## Verification

- Full suite: **138 suites / 1307 tests / 0 failures**, counted from JUnit XML.
- **Mutation-proved**: reintroducing a non-empty term list fails exactly the three new #182 tests and nothing else; source restored byte-identical (sha256 `8f90676b…71ad`), clean re-run green.
- **End-to-end**: re-running the same corpus against the patched prompt with the real model takes LFM2.5 from **2/10 to 8/10**.

## Note

This was never actually delivering the feature on-device. `mumble-cleanup-2stage` declares its own prompt with no placeholder, so interpolation was always a no-op for it — local cleanup either did nothing with the setting or was harmed by it. Making vocabulary work on-device needs a deterministic post-processing pass over the model's output; #182 stays open for that.

Also worth noting for #134: at 0 terms LFM2.5 scores 8/10 against mumble's 7/10, which reverses the model-swap recommendation I'd made there. That comparison was confounded by exactly this bug.

No device testing performed. Host measurement only.
