### PR TITLE
Reject local cleanup output that expands past 2x its input (#181)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidator.kt
@@ -22,6 +22,9 @@ sealed class LocalCleanupValidation {
 
         /** The output is a fraction of the input -- content was dropped, not cleaned. */
         LENGTH_COLLAPSE,
+
+        /** The output is a multiple of the input -- the model added text instead of cleaning. */
+        LENGTH_EXPANSION,
     }
 }
 
@@ -41,8 +44,10 @@ sealed class LocalCleanupValidation {
  *       vocabulary terms (emails, family names) into whatever app they dictated into
  *
  * All three are worse than no cleanup at all, and all three are detectable without the model:
- * they are properties of (input, systemPrompt, output). Kept deliberately free of Android and
- * llama.cpp dependencies so every branch is a plain JVM unit test.
+ * they are properties of (input, systemPrompt, output). A fourth check (#181) rejects output that
+ * is a multiple of its input, the general form of #179's degenerate repetition loop. Kept
+ * deliberately free of Android and llama.cpp dependencies so every branch is a plain JVM unit
+ * test.
  *
  * Thresholds are biased toward ACCEPTING. A false rejection costs one fallback step; an
  * over-eager validator makes local cleanup useless. Every threshold below is set with real
@@ -88,7 +93,45 @@ object LocalCleanupOutputValidator {
     const val LENGTH_COLLAPSE_MIN_INPUT_CHARS = 24
 
     /**
-     * Runs the three checks in severity order and returns the first rejection, or [Valid].
+     * Maximum multiple of the input's normalized length the output may reach (#181).
+     *
+     * Cleanup removes filler and fixes punctuation; it never meaningfully lengthens a transcript.
+     * Measured over the corpus in `/tmp/qa` using this file's own [normalizeForLength], counting
+     * only output the earlier checks ACCEPT (output already rejected for echoing the prompt says
+     * nothing about where this threshold belongs):
+     *
+     *   healthy accepted output, normalized input >= 24 chars, n=8:  0.57x - 1.33x
+     *   the #179 degenerate repetition loop (580 chars -> 2197):     3.71x
+     *
+     * 2.0x sits between them with headroom on both sides: no false positive on any measured
+     * healthy output at 1.5x or above, and the loop is caught with margin. Consistent with the
+     * rest of this object, the threshold is deliberately loose rather than the tightest value
+     * that still passes -- a false rejection costs one fallback step, but an over-eager check
+     * makes local cleanup useless.
+     *
+     * This is the general guard; #179's detector handles only the verbatim-repetition shape of
+     * the same problem, and would miss a model that expanded by confabulating novel text.
+     */
+    const val LENGTH_EXPANSION_MAX_RATIO = 2.0
+
+    /**
+     * Inputs shorter than this (normalized) skip the expansion check.
+     *
+     * Legitimate expansion ratios are naturally high on very short input: "BETA" -> "Beta." and
+     * spelling out one mumbled word can double a four-word transcript without anything being
+     * wrong. Measured on the same corpus, "How old is Tom?" (14 normalized chars) legitimately
+     * cleaned to 29 chars -- a 2.07x ratio that would trip this check without a floor, while
+     * every sample at or above 24 chars stayed at or below 1.33x.
+     *
+     * Deliberately the same value as [LENGTH_COLLAPSE_MIN_INPUT_CHARS]: both checks are unreliable
+     * on the same short inputs for the same reason, and one floor is easier to reason about than
+     * two. Kept as a separate constant so the two can be tuned independently if the data ever
+     * says they should be.
+     */
+    const val LENGTH_EXPANSION_MIN_INPUT_CHARS = 24
+
+    /**
+     * Runs the four checks in severity order and returns the first rejection, or [Valid].
      *
      * A blank [modelOutput] is NOT this function's business: the caller already treats empty
      * output as its own failure, and reporting it here as a length collapse would be a
@@ -104,6 +147,7 @@ object LocalCleanupOutputValidator {
         checkPromptEcho(rawInput, systemPrompt, modelOutput)?.let { return it }
         checkNumericDivergence(rawInput, modelOutput)?.let { return it }
         checkLengthCollapse(rawInput, modelOutput)?.let { return it }
+        checkLengthExpansion(rawInput, modelOutput)?.let { return it }
         return LocalCleanupValidation.Valid
     }
 
@@ -398,6 +442,44 @@ object LocalCleanupOutputValidator {
             index++
         }
         return kept.joinToString(" ")
+    }
+
+    // --- (d) length expansion --------------------------------------------------------------
+
+    /**
+     * Rejects output that is a multiple of its input (#181) -- the model added text rather than
+     * cleaning what was said.
+     *
+     * The failure this catches is the #179 degenerate loop's general form: 580 characters of
+     * input producing 2197 characters of the same clause eleven times passed every other check
+     * cleanly. #179's detector stops that specific generation, but it keys on verbatim
+     * repetition, so a model that expanded by confabulating -- answering the transcript instead
+     * of cleaning it, continuing the speaker's story, appending commentary -- would produce no
+     * repeated window and reach the user's text field unchallenged.
+     *
+     * Deliberately runs LAST. Every other check names a more specific cause, and an over-long
+     * echo should be reported as [Reason.PROMPT_ECHO] rather than as an expansion.
+     *
+     * The normalization asymmetry that protects [checkLengthCollapse] works in this check's
+     * favour too but in the opposite direction, and is worth stating: [normalizeForLength] shrinks
+     * the input baseline by stripping filler and collapsing spoken numerals, which raises the
+     * measured ratio slightly. The threshold is set from ratios measured the same way, so this is
+     * already priced in.
+     */
+    private fun checkLengthExpansion(
+        rawInput: String,
+        modelOutput: String,
+    ): LocalCleanupValidation.Rejected? {
+        val baseline = normalizeForLength(rawInput)
+        if (baseline.length < LENGTH_EXPANSION_MIN_INPUT_CHARS) return null
+        val output = normalizeForLength(modelOutput)
+        val ratio = output.length.toDouble() / baseline.length
+        if (ratio <= LENGTH_EXPANSION_MAX_RATIO) return null
+        return LocalCleanupValidation.Rejected(
+            LocalCleanupValidation.Reason.LENGTH_EXPANSION,
+            "output is ${String.format(java.util.Locale.ROOT, "%.1f", ratio)}x the input's " +
+                "content length (maximum ${LENGTH_EXPANSION_MAX_RATIO}x)",
+        )
     }
 
     // --- shared vocabulary -----------------------------------------------------------------

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalCleanupOutputValidatorTest.kt
@@ -403,4 +403,101 @@ class LocalCleanupOutputValidatorTest {
             prompt = realDevicePrompt,
         )
     }
+
+    // --- (d) length expansion (#181) ---------------------------------------------------------
+    //
+    // The general form of #179's degenerate loop. #179 stops generation on verbatim repetition;
+    // this check rejects any output that is a multiple of its input, including one that expanded
+    // by confabulating novel text and so has no repeated window to detect.
+    //
+    // Mutation-check: raise LENGTH_EXPANSION_MAX_RATIO above 3.71, or delete the
+    // checkLengthExpansion call from validate(), and the two rejection tests below must fail.
+
+    @Test fun `REAL 179 degenerate loop output is rejected as an expansion (#181)`() {
+        // Verbatim what mumble-cleanup-2stage returned for the 580-char transcript: 2197 chars,
+        // the same clause eleven times. Before this check it was ACCEPTED -- it echoes no prompt,
+        // loses no number, and is far longer than the collapse floor -- so it went straight into
+        // the user's text field. Measured at 3.71x normalized.
+        assertRejected(
+            LocalCleanupValidation.Reason.LENGTH_EXPANSION,
+            realDeviceTranscript,
+            "I think I'm gonna go on a walk and then probably see if there's any chip-bunks hanging " +
+            "out around the park. If so, I'll maybe Play catch with Lily and see if she wants to " +
+            "chase after any of those chip-bunks hanging out around the park. It looks really good. " +
+            "So I'm gonna probably just cruise around, maybe see if she's gonna chase after any of " +
+            "those chip-buds hanging out around the park. That's and it's probably just really good. " +
+            "So I'm gonna probably try that out, but I'll probably just cruise around, maybe see if " +
+            "she's gonna chase after any of those chip-buds hanging out around the park, and that's " +
+            "and really good. So I'm gonna probably just cruise around, maybe see if she's gonna " +
+            "chase after any of those chip-buds hanging out around the park, and it looks really " +
+            "good. So I'm supposed to try that out, but she's gonna chase after any of those " +
+            "chip-buds hanging out around the park, and it looks really good, so I'm supposed to try " +
+            "that out, but she's gonna chase after any of those chip-buds hanging out around the " +
+            "park, and that's and really good. So I should try that out, but she's gonna chase after " +
+            "any of those chip-buds hanging out around the park, and it looks really good, so I'm " +
+            "supposed to try that out, but she's gonna chase after any of those chip-buds hanging out " +
+            "around the park, and it looks really good, so I'm supposed to try that, I'll probably " +
+            "just cruise around, maybe see if she's gonna chase after any of those chip-buds hanging " +
+            "out around the park, and that's and really good. So, I'm supposed to try that, I'll " +
+            "probably just cruise around, maybe see if she's gonna chase after any of those chip-buds " +
+            "hanging out around the park, and it's probably just really good. So I'm supposed to try " +
+            "that, I'll probably just cruise around, maybe see if she's gonna chase after any of " +
+            "those chip-buds hanging out around the park, and it looks really good, so I'm supposed " +
+            "to try that, I'll probably just cruise around, maybe see if she's gonna chase after any " +
+            "of those chip-buds hanging out around the park, and it's probably just really good. So, " +
+            "I'm supposed to try that, I'll probably just see if she's gonna chase after any of those " +
+            "chip-buds hanging out around the park,",
+            prompt = realDevicePrompt,
+        )
+    }
+
+    @Test fun `output that confabulates novel text past the limit is rejected (#181)`() {
+        // The failure #179's repetition detector cannot see: no repeated window, the model simply
+        // kept writing. Distinct sentences, so a repetition check passes it; the ratio does not.
+        val input = "So I went to the store this morning and picked up some milk and eggs"
+        assertRejected(
+            LocalCleanupValidation.Reason.LENGTH_EXPANSION,
+            input,
+            "So I went to the store this morning and picked up some milk and eggs. " +
+                "The weather was pleasant and the drive took about fifteen minutes. " +
+                "Afterwards I considered stopping for coffee but decided against it. " +
+                "The cashier mentioned that a new bakery had opened across the street. " +
+                "I plan to visit it sometime next week when I have more free time available.",
+            prompt = plainPrompt,
+        )
+    }
+
+    @Test fun `legitimate cleanup that lengthens slightly is not rejected (#181)`() {
+        // The negative control. Correct cleanup routinely lengthens a transcript a little --
+        // punctuation, capitalization, expanding a mumbled word -- and the measured healthy
+        // ceiling was 1.33x. Without this test, dropping the ratio to 1.0 would pass the suite.
+        assertAccepted(
+            "so i went down to the store this morning and i picked up some milk and some eggs",
+            "So, I went down to the store this morning, and I picked up some milk and some eggs.",
+        )
+    }
+
+    @Test fun `a short input is exempt from the expansion check (#181)`() {
+        // Measured: "How old is Tom?" (14 normalized chars) legitimately cleaned to 29 -- a 2.07x
+        // ratio on output that is entirely correct. Short utterances have naturally high ratios,
+        // which is what LENGTH_EXPANSION_MIN_INPUT_CHARS exists for. Deleting the floor fails
+        // this test.
+        assertAccepted("How old is Tom?", "How old is Tom? How old is Tom, exactly?")
+    }
+
+    @Test fun `an over-long prompt echo is still reported as an echo, not an expansion (#181)`() {
+        // Ordering guarantee: the expansion check runs last precisely so the more specific
+        // diagnosis wins. The #164 echo is both an echo AND an expansion; reporting it as an
+        // expansion would lose the reason that actually explains it.
+        assertRejected(
+            LocalCleanupValidation.Reason.PROMPT_ECHO,
+            "This is a second test to see if it inserts",
+            "Watch for these project names and personal vocabulary terms, which speech-to-text " +
+                "often mishears: Nash-Keller, Wyatt, Terelle, Dyson, Dys, Adalyn, Ady, Emsley, " +
+                "Emy, Londyn, trevor@nashkellermedia.com, assistant@nashkellermedia.com, " +
+                "trevornk@gmail.com, trevor@nashkeller.com, Selby, Mobridge, Affine, Unishell, " +
+                "Pi, Codex, Claude, Hetzner",
+            prompt = realDevicePrompt,
+        )
+    }
 }


### PR DESCRIPTION
Refs #181.

`LENGTH_COLLAPSE` is one-sided — nothing rejected output *longer* than its input. The #179 degenerate repetition loop (580 chars in, 2197 chars of the same clause eleven times out) passed validation cleanly and went straight into the user's text field: it echoes no prompt, loses no number, and is far above the collapse floor.

#179's detector stops that specific generation, but it keys on **verbatim repetition**. A model that expanded by confabulating novel text — answering the transcript instead of cleaning it, continuing the speaker's story, appending commentary — produces no repeated window and would still get through. This is the general guard.

## Threshold, from measurement

Ratios computed with the validator's own `normalizeForLength`, counting **only output the earlier checks accept** — output already rejected for echoing the prompt says nothing about where this threshold belongs. (My first tuning pass got this wrong and scored rows against the wrong prompt, which made prompt echoes look like accepted 8x expansions.)

| | ratio |
|---|---|
| healthy accepted output, normalized input ≥24 chars, n=8 | **0.57x – 1.33x** |
| the #179 degenerate loop | **3.71x** |

`2.0x` sits between them. Zero false positives on measured healthy output at 1.5x or above.

`LENGTH_EXPANSION_MIN_INPUT_CHARS` mirrors the existing collapse floor at 24. Short inputs have naturally high legitimate ratios — measured, `"How old is Tom?"` (14 normalized chars) cleaned correctly to 29 chars, a 2.07x ratio that would trip this check without a floor.

The check runs **last**, so a more specific diagnosis always wins: an over-long prompt echo is reported as `PROMPT_ECHO`, not as an expansion. Pinned by a test.

## Verification

- Full suite: **138 suites / 1312 tests / 0 failures**, counted from JUnit XML.
- **Mutation-proved, three independent mutations** — the check, the threshold, and the floor are separate claims:

| Mutation | Result |
|---|---|
| delete the `checkLengthExpansion` call | 2 failures |
| raise ratio above the measured 3.71x | 2 failures |
| remove the short-input floor | 2 failures |

Source restored byte-identical (`a3dccd95…b395`), clean re-run green. Removing the floor also failed a *pre-existing* test I didn't write, which is decent evidence the floor is load-bearing beyond my own additions.

The loop fixture is the real 2197-character device output, not synthetic text.

No device testing performed — this is pure JVM logic with no Android or llama.cpp dependencies.

Deliberately no closing keyword: I'll close #181 by hand once this is merged and verified. (My last PR's `Fixes #182` auto-closed an issue I'd explicitly said should stay open.)
