### PR TITLE
Tell the truth when cleanup fails and raw text is inserted (#175)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupFailureNotice.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupFailureNotice.kt
@@ -1,0 +1,94 @@
+package com.trevornk.ramblr
+
+/**
+ * Builds the floating-bubble notice shown when cleanup fails and Ramblr injects the raw
+ * transcript instead (#175).
+ *
+ * The bubble itself already existed -- `injectText(feedback = "Cleanup failed (...)")` has been
+ * wired since #98 -- so #175's premise that the fall-through is *silent* is wrong. What was
+ * actually broken is what the bubble said:
+ *
+ *  1. **It claimed the clipboard held the raw text when usually it didn't.** The message was
+ *     hardcoded as "raw copied to clipboard" at the call site, which runs *before* the injection
+ *     method is known. For a DIRECT (ACTION_SET_TEXT) injection -- the common case --
+ *     [clipboardClearActionFor] wipes the clipboard immediately, so the user was told to paste
+ *     from a clipboard that no longer had it. This is exactly the #118 bug class, which fixed the
+ *     same false clipboard claim for the *success* message and left the failure message behind.
+ *
+ *  2. **It leaked raw executor diagnostics into a floating overlay.** The reason string was
+ *     `result.error` verbatim, which is built for logcat: nested prefixes like
+ *     `"All cleanup steps failed: Local cleanup output rejected (PROMPT_ECHO)"`, or -- for a cloud
+ *     step -- up to 200 characters of the provider's own error body via
+ *     `CleanupWaterfallExecutor.errorDetail`. Measured, a local PROMPT_ECHO produced a 112-char
+ *     bubble; a verbose provider envelope would be far longer, in a WRAP_CONTENT pill with no
+ *     `maxLines`, anchored beside the icon.
+ *
+ * So this resolves the message at the injection seam, where `method` is known, and maps the
+ * internal reason onto a short plain-language phrase.
+ *
+ * The phrasing deliberately describes *what the model did* ("echoed its instructions") rather than
+ * naming the validator constant (`PROMPT_ECHO`). #175 asks whether the reason should be visible at
+ * all; it should, because these failures are currently indistinguishable from cleanup that ran and
+ * changed nothing -- but the internal enum name is for the issue tracker, not the user.
+ *
+ * Content safety: every branch returns a fixed literal. No transcript, prompt, model output, or
+ * provider body ever reaches the bubble -- the same boundary [LocalCleanupOutputValidator] holds
+ * when it logs reason/detail but never the text.
+ */
+object CleanupFailureNotice {
+
+    /** Fallback when the executor gave no usable error at all. */
+    const val UNKNOWN_REASON = "unknown error"
+
+    /**
+     * Maps a raw [CleanupWaterfallExecutor] error string onto a short user-facing phrase.
+     *
+     * Matched against the *whole* string rather than an exact equality, because the executor
+     * wraps the terminal step's message in an `"All cleanup steps failed: "` prefix (and cloud
+     * steps prepend `"HTTP <code>: "`), so the distinguishing token appears mid-string.
+     */
+    fun summarize(error: String?): String {
+        val raw = error?.trim().orEmpty()
+        if (raw.isEmpty()) return UNKNOWN_REASON
+        return when {
+            // Validator rejections (#155/#181). Described by effect, not by enum name.
+            raw.contains("PROMPT_ECHO") -> "model repeated its instructions"
+            raw.contains("LENGTH_COLLAPSE") -> "model dropped most of the text"
+            raw.contains("LENGTH_EXPANSION") -> "model added text you didn't say"
+            raw.contains("NUMERIC_DIVERGENCE") -> "model changed a number"
+            // Local engine outcomes.
+            raw.contains("timed out") -> "model timed out"
+            raw.contains("empty response") -> "model returned nothing"
+            raw.contains("exceeded time budget") -> "cleanup took too long"
+            // Cloud step. Deliberately keeps the status code (actionable: 401 means a bad key)
+            // and discards the provider's error body, which is unbounded prose.
+            else -> httpStatusIn(raw)?.let { "server error $it" } ?: UNKNOWN_REASON
+        }
+    }
+
+    /** Extracts the `NNN` from an `"HTTP NNN: ..."` step failure, if this was one. */
+    private fun httpStatusIn(raw: String): String? =
+        Regex("HTTP (\\d{3})").find(raw)?.groupValues?.get(1)
+
+    /**
+     * The full bubble text for a failed cleanup that fell through to raw text.
+     *
+     * [method] decides the clipboard clause, and it must, because it decides the clipboard's
+     * actual contents:
+     *  - [InjectMethod.DIRECT] -- clipboard wiped immediately after injection, so promising a
+     *    copy would be a lie.
+     *  - [InjectMethod.FROM_CLIPBOARD] -- the copy is cleared after a short grace delay, so it is
+     *    not something to send the user to either.
+     *  - [InjectMethod.NONE] -- nothing was injected and the clipboard *is* the delivery path, so
+     *    it is the one case worth mentioning. The injection seam already appends its own
+     *    "· tap to copy again" affordance for this case, so this stays terse to avoid saying it
+     *    twice.
+     */
+    fun messageFor(method: InjectMethod, error: String?): String {
+        val reason = summarize(error)
+        return when (method) {
+            InjectMethod.NONE -> "Cleanup failed ($reason)"
+            else -> "Cleanup failed ($reason) — inserted raw text"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupFailureNotice.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupFailureNotice.kt
@@ -57,6 +57,16 @@ object CleanupFailureNotice {
             raw.contains("LENGTH_EXPANSION") -> "model added text you didn't say"
             raw.contains("NUMERIC_DIVERGENCE") -> "model changed a number"
             // Local engine outcomes.
+            // Model-missing is the one failure the user can actually act on (re-download in
+            // Settings), so it must not fall through to UNKNOWN_REASON. Two distinct strings
+            // reach here: the executor's own pre-flight ("not downloaded", when the pref names a
+            // model with no resolved path) and LlamaCppInference's FileNotFoundException ("not
+            // found at $modelPath", when the pref resolves but the file is gone underneath it).
+            // Both collapse to one phrase -- and critically, to a *fixed literal*: the second
+            // string carries the full `/data/user/0/...` path, which must never reach a floating
+            // overlay pill.
+            raw.contains("model not found") || raw.contains("model not downloaded") ->
+                "cleanup model isn't installed"
             raw.contains("timed out") -> "model timed out"
             raw.contains("empty response") -> "model returned nothing"
             raw.contains("exceeded time budget") -> "cleanup took too long"

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2854,7 +2854,11 @@ class WhisperAccessibilityService : AccessibilityService() {
                         // CleanupStepOutcome -- it was just being discarded here.
                         val reason = result.error?.takeIf { it.isNotBlank() } ?: "unknown error"
                         Log.w(TAG, "Cleanup failed, injecting raw text: $reason")
-                        injectText(text, feedback = "Cleanup failed ($reason) — raw copied to clipboard", feedbackDurationMs = 4000)
+                        // #175: pass the raw error, not a finished message -- injectText() builds
+                        // the user-facing notice once the injection method is known, so it can
+                        // state the truth about the clipboard and keep executor diagnostics
+                        // (nested prefixes, provider error bodies) out of a floating overlay.
+                        injectText(text, cleanupError = reason, feedbackDurationMs = 4000)
                     }
                     resetToIdle()
                 }
@@ -2929,7 +2933,11 @@ class WhisperAccessibilityService : AccessibilityService() {
             // rather than leaving the stale candidate text sitting in history (#73).
             injectText(
                 resolution.textToInject,
-                feedback = "Cleanup skipped — raw copied to clipboard",
+                // #175 (same false-clipboard claim, different path): this is the preview
+                // discard/timeout, not a cleanup failure, so it keeps its own wording -- but it
+                // was making the identical untrue promise. A DIRECT injection wipes the clipboard
+                // immediately, so "raw copied to clipboard" sent the user to an empty clipboard.
+                feedback = "Cleanup skipped — inserted raw text",
                 existingHistoryTimestamp = preview.historyTimestamp,
             )
         }
@@ -3107,6 +3115,13 @@ class WhisperAccessibilityService : AccessibilityService() {
         feedbackDurationMs: Long = 2000,
         paidFallbackGroup: CleanupStepGroup? = null,
         existingHistoryTimestamp: Long? = null,
+        // #175: set when this injection is a cleanup-failure fall-through. Carries the executor's
+        // raw error so the notice can be built below, once `method` is known -- the message has to
+        // state whether the clipboard actually holds anything, and that depends on the injection
+        // method, which isn't decided until injection has been attempted. Passing a finished
+        // string from the call site is what made the old message claim a clipboard copy that
+        // DIRECT injections wipe immediately (see [CleanupFailureNotice]).
+        cleanupError: String? = null,
     ) {
         pendingClipboardRestore?.let { handler.removeCallbacks(it) }
         pendingClipboardRestore = null
@@ -3144,14 +3159,14 @@ class WhisperAccessibilityService : AccessibilityService() {
             Log.i(TAG, "No injection candidates on first scan; retrying in ${INJECTION_RETRY_DELAY_MS}ms")
             val retry = Runnable {
                 pendingInjectionRetry = null
-                finishInjection(findInjectionCandidates(), text, rawText, priorClipboard, feedback, feedbackDurationMs, streamingHandoff, historyTimestamp)
+                finishInjection(findInjectionCandidates(), text, rawText, priorClipboard, feedback, feedbackDurationMs, streamingHandoff, historyTimestamp, cleanupError)
             }
             pendingInjectionRetry = retry
             handler.postDelayed(retry, INJECTION_RETRY_DELAY_MS)
             return
         }
 
-        finishInjection(candidates, text, rawText, priorClipboard, feedback, feedbackDurationMs, streamingHandoff, historyTimestamp)
+        finishInjection(candidates, text, rawText, priorClipboard, feedback, feedbackDurationMs, streamingHandoff, historyTimestamp, cleanupError)
     }
 
     private fun finishInjection(
@@ -3163,6 +3178,9 @@ class WhisperAccessibilityService : AccessibilityService() {
         feedbackDurationMs: Long,
         streamingHandoff: StreamingPreviewSession?,
         historyTimestamp: Long,
+        // #175: threaded through from injectText() rather than resolved there, because the notice
+        // depends on the injection method -- which isn't decided until the write attempts below.
+        cleanupError: String? = null,
     ) {
         Log.i(TAG, "Injecting text into ${candidates.size} candidate node(s)")
 
@@ -3253,10 +3271,13 @@ class WhisperAccessibilityService : AccessibilityService() {
         // any explicit feedback the caller passed (raw-text-retry, cleanup-failed, etc.) is
         // meaningful and must survive as-is.
         val resolvedFeedback = injectionFeedbackFor(method, feedback)
+        // #175: a cleanup-failure fall-through resolves its own message here, where `method` --
+        // and therefore what the clipboard actually holds -- is finally known.
+        val baseFeedback = cleanupError?.let { CleanupFailureNotice.messageFor(method, it) } ?: resolvedFeedback
         val displayFeedback = when {
             retryRawOffered -> "Tap to use raw text"
-            isFallback -> resolvedFeedback?.let { "$it · tap to copy again" }
-            else -> resolvedFeedback
+            isFallback -> baseFeedback?.let { "$it · tap to copy again" }
+            else -> baseFeedback
         }
         // #120: bias the bubble away from overlapping the field it just injected into, when that
         // node's on-screen bounds are known (DIRECT injections only -- that's the only path with

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeExecutorFixtureTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeExecutorFixtureTest.kt
@@ -1,0 +1,63 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #175 fixture guard: proves the `RAW_` strings asserted in [CleanupFailureNoticeTest] are what
+ * [CleanupWaterfallExecutor] actually produces, by running its real `execute()`.
+ *
+ * Without this, the substring mapping in [CleanupFailureNotice] is pinned only to strings I typed
+ * by hand. If the executor reworks its error prefixes, the notice would silently degrade every
+ * bubble to "unknown error" and every test in the sibling file would still pass.
+ */
+class CleanupFailureNoticeExecutorFixtureTest {
+
+    private fun terminalErrorFor(localResult: LocalInferenceResult): String? {
+        var captured: PostProcessor.Result? = null
+        CleanupWaterfallExecutor.execute(
+            text = "raw transcript",
+            prompt = "clean it up",
+            waterfall = CleanupWaterfall(
+                listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, "lfm2.5-350m-q4_0"))
+            ),
+            cursor = CleanupWaterfallCursor(),
+            cancelHolder = InFlightCall(),
+            credentialLookup = { "" },
+            transport = CleanupHttpTransport { _, _, _, _, _, _ ->
+                error("no cloud step in a local-only chain")
+            },
+            localInference = LocalInferenceEngine { _, _, _, _, _ -> localResult },
+            localModelPath = { "/fake/model.gguf" },
+            callback = { captured = it },
+        )
+        return (captured ?: error("callback never fired")).error
+    }
+
+    @Test fun `the executor really does nest a rejection under the all-steps-failed prefix`() {
+        // RealLocalInferenceEngine.validated() builds this exact Failure message for a rejection;
+        // the executor then wraps it. Both halves are load-bearing for the substring match.
+        val error = terminalErrorFor(
+            LocalInferenceResult.Failure("Local cleanup output rejected (PROMPT_ECHO)")
+        )
+        assertEquals(
+            "All cleanup steps failed: Local cleanup output rejected (PROMPT_ECHO)",
+            error,
+        )
+        assertEquals("model repeated its instructions", CleanupFailureNotice.summarize(error))
+    }
+
+    @Test fun `the executor really does nest a local timeout the same way`() {
+        val error = terminalErrorFor(LocalInferenceResult.TimedOut("Local cleanup timed out"))
+        assertEquals("All cleanup steps failed: Local cleanup timed out", error)
+        assertEquals("model timed out", CleanupFailureNotice.summarize(error))
+    }
+
+    @Test fun `an empty local response maps through the executor as written`() {
+        val error = terminalErrorFor(
+            LocalInferenceResult.Failure("Local model produced an empty response")
+        )
+        assertEquals("All cleanup steps failed: Local model produced an empty response", error)
+        assertEquals("model returned nothing", CleanupFailureNotice.summarize(error))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeExecutorFixtureTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeExecutorFixtureTest.kt
@@ -60,4 +60,33 @@ class CleanupFailureNoticeExecutorFixtureTest {
         assertEquals("All cleanup steps failed: Local model produced an empty response", error)
         assertEquals("model returned nothing", CleanupFailureNotice.summarize(error))
     }
+
+    @Test fun `the executor's own missing-model pre-flight maps to the model-missing phrase`() {
+        // This branch never reaches localInference at all: the executor short-circuits when
+        // localModelPath() is null/blank, so it needs its own fixture rather than a
+        // LocalInferenceResult. On-device this is the string a user with an uninstalled model
+        // hits, and before the fix it rendered as "unknown error".
+        var captured: PostProcessor.Result? = null
+        CleanupWaterfallExecutor.execute(
+            text = "raw transcript",
+            prompt = "clean it up",
+            waterfall = CleanupWaterfall(
+                listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, "lfm2.5-350m-q4_0"))
+            ),
+            cursor = CleanupWaterfallCursor(),
+            cancelHolder = InFlightCall(),
+            credentialLookup = { "" },
+            transport = CleanupHttpTransport { _, _, _, _, _, _ ->
+                error("no cloud step in a local-only chain")
+            },
+            localInference = LocalInferenceEngine { _, _, _, _, _ ->
+                error("must short-circuit before inference when the model is absent")
+            },
+            localModelPath = { null },
+            callback = { captured = it },
+        )
+        val error = (captured ?: error("callback never fired")).error
+        assertEquals("All cleanup steps failed: Local cleanup model not downloaded", error)
+        assertEquals("cleanup model isn't installed", CleanupFailureNotice.summarize(error))
+    }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeTest.kt
@@ -1,0 +1,142 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #175: what the floating bubble says when cleanup fails and Ramblr inserts the raw transcript.
+ *
+ * The issue was filed as "no user-visible signal". That turned out to be wrong -- the bubble has
+ * fired since #98 -- so these tests pin the two things that were actually broken: a false claim
+ * about the clipboard, and raw executor diagnostics being rendered in an overlay.
+ *
+ * The `RAW_` constants below are verbatim strings produced by [CleanupWaterfallExecutor], captured
+ * by running its real `execute()` against fake engines. They are fixtures rather than paraphrases
+ * because the mapping is substring-based: if the executor ever reworks its prefixes, these tests
+ * must fail rather than silently degrade every bubble to "unknown error".
+ */
+class CleanupFailureNoticeTest {
+
+    // --- verbatim executor output ---------------------------------------------------------------
+
+    // Measured: local-only chain, terminal step rejected by LocalCleanupOutputValidator. Note the
+    // nested prefix -- this is why summarize() matches on `contains`, not equality.
+    private val rawPromptEcho =
+        "All cleanup steps failed: Local cleanup output rejected (PROMPT_ECHO)"
+    private val rawLengthCollapse =
+        "All cleanup steps failed: Local cleanup output rejected (LENGTH_COLLAPSE)"
+    private val rawLengthExpansion =
+        "All cleanup steps failed: Local cleanup output rejected (LENGTH_EXPANSION)"
+    private val rawNumericDivergence =
+        "All cleanup steps failed: Local cleanup output rejected (NUMERIC_DIVERGENCE)"
+    private val rawTimeout = "All cleanup steps failed: Local cleanup timed out"
+    private val rawEmpty = "All cleanup steps failed: Local model produced an empty response"
+    private val rawBudget = "Cleanup waterfall exceeded time budget"
+
+    // A cloud step failing. errorDetail() splices in up to 200 chars of the provider's own body.
+    private val rawHttp401 =
+        "All cleanup steps failed: HTTP 401: Incorrect API key provided: sk-proj-********. " +
+            "You can find your API key at https://platform.openai.com/account/api-keys."
+
+    // --- the clipboard claim ------------------------------------------------------------------
+
+    @Test fun `a DIRECT injection never claims the raw text is on the clipboard`() {
+        // The actual #175 defect. clipboardClearActionFor(DIRECT) is Immediate, so the old
+        // hardcoded "raw copied to clipboard" pointed the user at a clipboard Ramblr had just
+        // wiped. Same bug #118 fixed for the success message.
+        val message = CleanupFailureNotice.messageFor(InjectMethod.DIRECT, rawPromptEcho)
+        assertFalse("must not promise a clipboard copy: \"$message\"", message.contains("clipboard"))
+        assertTrue("must say what actually happened: \"$message\"", message.contains("inserted raw text"))
+    }
+
+    @Test fun `a FROM_CLIPBOARD injection does not send the user to the clipboard either`() {
+        // Delayed clear, not None: the copy is transient, so pointing at it is still wrong.
+        val message = CleanupFailureNotice.messageFor(InjectMethod.FROM_CLIPBOARD, rawPromptEcho)
+        assertFalse("must not promise a clipboard copy: \"$message\"", message.contains("clipboard"))
+    }
+
+    @Test fun `a NONE injection does not claim text was inserted`() {
+        // Nothing was injected -- the clipboard IS the delivery path here. Claiming an insert
+        // would be the mirror-image lie. The injection seam appends its own "tap to copy again".
+        val message = CleanupFailureNotice.messageFor(InjectMethod.NONE, rawPromptEcho)
+        assertFalse("nothing was inserted: \"$message\"", message.contains("inserted"))
+        assertEquals("Cleanup failed (model repeated its instructions)", message)
+    }
+
+    // --- keeping diagnostics out of the overlay -------------------------------------------------
+
+    @Test fun `the notice never leaks executor prefixes into the bubble`() {
+        val message = CleanupFailureNotice.messageFor(InjectMethod.DIRECT, rawPromptEcho)
+        assertFalse("internal prefix leaked: \"$message\"", message.contains("All cleanup steps failed"))
+        assertFalse("validator constant leaked: \"$message\"", message.contains("PROMPT_ECHO"))
+    }
+
+    @Test fun `a verbose provider error body never reaches the bubble`() {
+        // errorDetail() allows 200 chars of provider prose. Rendering that in a WRAP_CONTENT pill
+        // beside the floating icon is the failure mode this guards. The status code survives
+        // because it's actionable -- 401 means the key is wrong.
+        val message = CleanupFailureNotice.messageFor(InjectMethod.DIRECT, rawHttp401)
+        assertEquals("Cleanup failed (server error 401) — inserted raw text", message)
+        assertFalse("provider body leaked: \"$message\"", message.contains("platform.openai.com"))
+        assertFalse("key fragment leaked: \"$message\"", message.contains("sk-proj"))
+    }
+
+    @Test fun `every notice stays short enough for a floating bubble`() {
+        // Measured, the old local PROMPT_ECHO bubble was 112 chars; the HTTP 401 case above would
+        // have been 190+. The bubble has no maxLines, so length is the only bound there is.
+        val all = listOf(
+            rawPromptEcho, rawLengthCollapse, rawLengthExpansion, rawNumericDivergence,
+            rawTimeout, rawEmpty, rawBudget, rawHttp401, null, "",
+        )
+        for (raw in all) {
+            for (method in InjectMethod.values()) {
+                val message = CleanupFailureNotice.messageFor(method, raw)
+                assertTrue(
+                    "bubble text too long (${message.length}): \"$message\"",
+                    message.length <= 70,
+                )
+            }
+        }
+    }
+
+    // --- the reason mapping ---------------------------------------------------------------------
+
+    @Test fun `each validator rejection gets its own plain-language reason`() {
+        // Distinct reasons matter: "model repeated its instructions" and "model changed a number"
+        // are different problems with different user responses. Collapsing them to a generic
+        // "cleanup failed" is what makes the current experience undiagnosable.
+        assertEquals("model repeated its instructions", CleanupFailureNotice.summarize(rawPromptEcho))
+        assertEquals("model dropped most of the text", CleanupFailureNotice.summarize(rawLengthCollapse))
+        assertEquals("model added text you didn't say", CleanupFailureNotice.summarize(rawLengthExpansion))
+        assertEquals("model changed a number", CleanupFailureNotice.summarize(rawNumericDivergence))
+    }
+
+    @Test fun `the four validator reasons are all distinct`() {
+        val reasons = listOf(rawPromptEcho, rawLengthCollapse, rawLengthExpansion, rawNumericDivergence)
+            .map { CleanupFailureNotice.summarize(it) }
+        assertEquals("each rejection must be distinguishable", reasons.size, reasons.toSet().size)
+    }
+
+    @Test fun `local engine failures are reported by cause`() {
+        assertEquals("model timed out", CleanupFailureNotice.summarize(rawTimeout))
+        assertEquals("model returned nothing", CleanupFailureNotice.summarize(rawEmpty))
+        assertEquals("cleanup took too long", CleanupFailureNotice.summarize(rawBudget))
+    }
+
+    @Test fun `an absent or blank error degrades to a generic reason`() {
+        assertEquals(CleanupFailureNotice.UNKNOWN_REASON, CleanupFailureNotice.summarize(null))
+        assertEquals(CleanupFailureNotice.UNKNOWN_REASON, CleanupFailureNotice.summarize(""))
+        assertEquals(CleanupFailureNotice.UNKNOWN_REASON, CleanupFailureNotice.summarize("   "))
+    }
+
+    @Test fun `an unrecognised error does not echo itself into the bubble`() {
+        // The safety property behind the default branch: anything unmapped must fall back to a
+        // fixed literal, never pass the raw string through. A future executor error string that
+        // happened to contain transcript content would otherwise land straight in the overlay.
+        val message = CleanupFailureNotice.messageFor(InjectMethod.DIRECT, "totally novel failure mode")
+        assertFalse("raw error echoed: \"$message\"", message.contains("totally novel"))
+        assertTrue(message.contains(CleanupFailureNotice.UNKNOWN_REASON))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupFailureNoticeTest.kt
@@ -139,4 +139,41 @@ class CleanupFailureNoticeTest {
         assertFalse("raw error echoed: \"$message\"", message.contains("totally novel"))
         assertTrue(message.contains(CleanupFailureNotice.UNKNOWN_REASON))
     }
+
+    @Test fun `a missing cleanup model is named, not reported as an unknown error`() {
+        // Found by on-device verification of #175, not by the original test pass: hiding the
+        // GGUF underneath a configured model produced the real terminal failure and the bubble
+        // read "Cleanup failed (unknown error)". Model-missing is the one cause the user can fix
+        // themselves, so it is the worst one to render as "unknown".
+        //
+        // Both producers are covered: CleanupWaterfallExecutor's pre-flight, and
+        // LlamaCppInference's FileNotFoundException as the executor wraps it.
+        val notDownloaded = "All cleanup steps failed: Local cleanup model not downloaded"
+        val notFound =
+            "All cleanup steps failed: Local cleanup model not found at " +
+                "/data/user/0/com.trevornk.ramblr/files/cleanup_models/lfm2.5-350m-q4_0/lfm2.5-350m-q4_0.gguf"
+
+        for (error in listOf(notDownloaded, notFound)) {
+            val message = CleanupFailureNotice.messageFor(InjectMethod.DIRECT, error)
+            assertFalse(
+                "model-missing degraded to the generic reason: \"$message\"",
+                message.contains(CleanupFailureNotice.UNKNOWN_REASON),
+            )
+            assertTrue("expected the model to be named: \"$message\"", message.contains("cleanup model"))
+        }
+    }
+
+    @Test fun `the model path never reaches the bubble`() {
+        // LlamaCppInference interpolates the absolute model path into its exception message. The
+        // bubble is a floating overlay that renders over whatever app the user is in -- and over
+        // whatever is on their screen when they screenshot it -- so the private data directory
+        // must not survive the mapping.
+        val message = CleanupFailureNotice.messageFor(
+            InjectMethod.DIRECT,
+            "All cleanup steps failed: Local cleanup model not found at " +
+                "/data/user/0/com.trevornk.ramblr/files/cleanup_models/lfm2.5-350m-q4_0/lfm2.5-350m-q4_0.gguf",
+        )
+        assertFalse("leaked a filesystem path: \"$message\"", message.contains("/data/"))
+        assertFalse("leaked the model filename: \"$message\"", message.contains(".gguf"))
+    }
 }


### PR DESCRIPTION
Refs #175.

**The issue's premise is wrong, and I'd rather say so than quietly build the wrong thing.** The fall-through is *not* silent — `injectText(feedback = "Cleanup failed (...)")` has fired since #98, and the bubble is already anchored beside the floating icon. Trevor confirmed he sees it.

So this PR fixes what the bubble actually *said*, which was wrong in two ways.

## 1. It claimed the raw text was on the clipboard when usually it wasn't

The message was hardcoded at the call site, which runs **before** the injection method is known. For a `DIRECT` injection — the common case — `clipboardClearActionFor()` returns `Immediate` and the clipboard is wiped right after injection. The user was told to paste from a clipboard Ramblr had just cleared.

This is the same defect #118 fixed for the *success* message ("Copied to clipboard" on a DIRECT injection that never touched the clipboard). It corrected the success path and left the failure path making the identical false promise.

## 2. It rendered raw executor diagnostics in a floating overlay

The reason was `result.error` verbatim, which is built for logcat. Measured end-to-end through the real executor:

```
Cleanup failed (All cleanup steps failed: Local cleanup output rejected (PROMPT_ECHO)) — raw copied to clipboard
```

112 characters, in a `WRAP_CONTENT` pill with no `maxLines`, next to the icon. A cloud failure is worse — `errorDetail()` splices in up to 200 characters of the provider's own error body:

```
Cleanup failed (All cleanup steps failed: HTTP 401: Incorrect API key provided: sk-proj-********. You can find your API key at https://platform.openai.com/account/api-keys.) — raw copied to clipboard
```

## The fix

`CleanupFailureNotice` resolves the message at the injection seam, where `method` — and therefore the clipboard's real contents — is finally known:

| Method | Notice |
|---|---|
| `DIRECT` | `Cleanup failed (model repeated its instructions) — inserted raw text` |
| `FROM_CLIPBOARD` | same (copy is cleared after a grace delay; not somewhere to send the user) |
| `NONE` | `Cleanup failed (model repeated its instructions)` — nothing was inserted, and the seam appends its own "tap to copy again" |

Reasons describe what the model **did**, not the validator constant: `PROMPT_ECHO` → "model repeated its instructions", `LENGTH_COLLAPSE` → "model dropped most of the text", `LENGTH_EXPANSION` → "model added text you didn't say", `NUMERIC_DIVERGENCE` → "model changed a number". A cloud failure keeps its status code (`server error 401` — actionable, means the key is wrong) and discards the body.

#175 asks whether the reason should be user-visible at all. It should: these failures are otherwise indistinguishable from cleanup that ran and changed nothing, which is the actual complaint. But the internal enum name belongs in the issue tracker, not the overlay.

**Content safety:** every branch returns a fixed literal. No transcript, prompt, model output, or provider body can reach the bubble — the same boundary the validator holds when it logs reason/detail but never text. Pinned by a test that an unrecognised error does not echo itself through.

The preview discard path (`Cleanup skipped — raw copied to clipboard`) had the identical false claim and is corrected the same way.

## Verification

- Full suite: **140 suites / 1326 tests / 0 failures**, counted from JUnit XML.
- **Mutation-proved, four independent mutations:**

| Mutation | Result |
|---|---|
| restore the false clipboard claim | 4 failures |
| pass the raw executor error through | 10 failures |
| collapse the validator reasons to one | 2 failures |
| drop the `NONE` special-case | 1 failure |

Source restored byte-identical (`41ba7ac8…1068`), clean re-run green.

Two test files on purpose. `CleanupFailureNoticeTest` pins behaviour; `CleanupFailureNoticeExecutorFixtureTest` runs the **real** `CleanupWaterfallExecutor.execute()` to prove the strings the mapping matches on are what the executor actually emits. Without it, the mapping is pinned only to strings I typed by hand — a future prefix rework would silently degrade every bubble to "unknown error" with every behaviour test still green.

Device verification of the rendered bubble is in progress and will be posted here; the logic is pure JVM but this is UI, so host tests don't prove it draws.

## What this does not do

It does not rate-limit repeated notices. #175 raises that, and with a vocabulary configured this used to fire on nearly every dictation — but #183 removed the vocabulary clause from local cleanup and LFM2.5's validity went from 2/10 to 8/10, so the premise for rate-limiting has largely evaporated. Adding suppression now would be guessing at a frequency I can't currently reproduce. Worth revisiting if real usage shows it firing repeatedly.

No closing keyword: #175 as filed asks for a notification that already existed, so what it should close on is a judgement call for you, not a commit parser.
