### PR TITLE
Select the CPU backend at runtime instead of hardcoding ARMv8.6 (#187)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,9 +162,23 @@ android {
     // The onnxruntime AAR bundles arm64-v8a/libonnxruntime4j_jni.so -- the JNI glue for
     // onnxruntime's *own* Java API, which the app never touches (sherpa-onnx calls the C++
     // API directly). Drop it so only the two .so files actually used ship in the APK.
+    //
+    // The armv9 ggml CPU variants (#187) are dropped for a different reason: they build fine and
+    // would be selected, but they're slower. llama_cleanup/CMakeLists.txt turns on
+    // GGML_CPU_ALL_VARIANTS for runtime CPU dispatch, which emits seven arm64 variants. ggml
+    // picks by a feature-count score, not by speed, so any SVE2-capable device prefers
+    // armv9.0_1 over armv8.6_1 -- and on a Pixel 10a that measured 1.45x SLOWER on prompt eval
+    // (447.88 vs 688.35 t/s, llama-bench pp128, Q4_0, 6 threads), because Tensor's SVE is
+    // 128-bit, the same width as the NEON kernels it displaces. Excluding them here means
+    // SVE devices fall back to armv8.6_1, i.e. exactly what shipped before this change, and
+    // saves ~4.6MB. Keep in sync with kCpuVariantLibs in LLMInference.cpp (the CMake file
+    // hard-fails if upstream renames these targets).
     packaging {
         jniLibs {
             excludes += "**/libonnxruntime4j_jni.so"
+            excludes += "**/libggml-cpu-android_armv9.0_1.so"
+            excludes += "**/libggml-cpu-android_armv9.2_1.so"
+            excludes += "**/libggml-cpu-android_armv9.2_2.so"
         }
     }
 

--- a/app/src/main/cpp/llama_cleanup/CMakeLists.txt
+++ b/app/src/main/cpp/llama_cleanup/CMakeLists.txt
@@ -88,27 +88,73 @@ set(GIT_EXE "GIT_EXE-NOTFOUND" CACHE FILEPATH "" FORCE)
 # unless a child CMakeLists.txt overrides them -- verified none of them do. That covers every
 # SHARED target the compatibility dialog flagged (llama, llama-common, ggml, ggml-base,
 # ggml-cpu), plus llama-cleanup-jni itself since it's added after this point too.
+#
+# MODULE_LINKER_FLAGS matters as of #187: with GGML_BACKEND_DL on, ggml's own
+# ggml_add_backend_library() creates each ggml-cpu variant with `add_library(... MODULE ...)`
+# rather than SHARED (see ggml/src/CMakeLists.txt), and CMake applies CMAKE_MODULE_LINKER_FLAGS
+# -- not CMAKE_SHARED_LINKER_FLAGS -- to MODULE targets. Without this line the seven
+# libggml-cpu-android_*.so files link at the linker's 4KB default while every other library in
+# the APK is 16KB aligned; confirmed on-device, where Android's own compatibility dialog listed
+# exactly those seven and nothing else.
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384")
 
-# CPU feature targeting (#37 follow-up, real on-device timeout hit): ggml's GGML_NATIVE
-# defaults OFF for any cross-compiled build (this NDK build included -- see
-# CMAKE_CROSSCOMPILING in llama.cpp/ggml/CMakeLists.txt), and with GGML_CPU_ARM_ARCH unset
-# ggml-cpu/CMakeLists.txt's ARCH_FLAGS stays completely empty -- i.e. the ARM CPU quantized
+# CPU feature targeting (#37 follow-up, then #187): ggml's GGML_NATIVE defaults OFF for any
+# cross-compiled build (this NDK build included -- see CMAKE_CROSSCOMPILING in
+# llama.cpp/ggml/CMakeLists.txt), and with neither GGML_CPU_ARM_ARCH nor GGML_CPU_ALL_VARIANTS
+# set, ggml-cpu/CMakeLists.txt's ARCH_FLAGS stays completely empty -- i.e. the ARM CPU quantized
 # matmul kernels compile against the compiler's baseline armv8-a target only, with NO dotprod,
 # i8mm, or fp16-vector-arithmetic acceleration, regardless of what the real device supports.
 # llama.cpp's ARM CPU backend has dedicated fast paths for Q4_0 quantized matmul keyed on
 # exactly these instructions (see ggml-cpu/CMakeLists.txt's check_arm_feature block), so leaving
 # them off is a real, avoidable multiple-x decode slowdown, not just an untuned default.
-# armv8.6-a+dotprod+i8mm+fp16 is confirmed present on Trevor's real device (Pixel 10 Pro Fold
-# `/proc/cpuinfo` Features line: asimddp, i8mm, asimdhp/fphp) -- ndk.abiFilters already
-# restricts this app to arm64-v8a only and it isn't yet distributed beyond this one device
-# (see #99, Play Store distribution still unevaluated), so hardcoding to this device's real
-# baseline is safe today. Revisit with GGML_CPU_ALL_VARIANTS (runtime dispatch) instead of a
-# hardcoded -march if/when this ships to arbitrary ARM64 hardware.
-set(GGML_CPU_ARM_ARCH "armv8.6-a+dotprod+i8mm+fp16" CACHE STRING "" FORCE)
+#
+# This was originally a hardcoded `-march=armv8.6-a+dotprod+i8mm+fp16`, matching Trevor's own
+# Pixel. That is a compile-time choice with no runtime fallback, so on any pre-ARMv8.2 ARM64
+# device the very first Q4_0 matmul executes an unsupported instruction and the process dies
+# with SIGILL -- not a catchable Kotlin exception (#187; the F-Droid reviewer's Redmi Note 8T,
+# Snapdragon 665 / Cortex-A73, is exactly this case). Now that the app ships beyond one device,
+# switch to ggml's own runtime dispatch, which is what the old comment here said to revisit.
+#
+# GGML_CPU_ALL_VARIANTS builds one ggml-cpu library per ARM feature level and picks the best
+# supported one at runtime. It requires GGML_BACKEND_DL (ggml's own hard requirement, see
+# ggml/src/CMakeLists.txt), which turns ggml-cpu into a dlopen'ed module rather than a link-time
+# dependency -- hence the explicit loader in LLMInference.cpp, which replaces the default
+# search-path behavior that cannot work inside an APK.
+#
+# Why this is SIGILL-safe: each variant exports a ggml_backend_score() built from
+# ggml-cpu/arch/arm/cpu-feats.cpp, which reads real CPU features via getauxval(AT_HWCAP/AT_HWCAP2)
+# and returns 0 when the device lacks any feature the variant was compiled for. Upstream compiles
+# that file WITHOUT the variant's -march flags and with -fno-lto specifically so the check itself
+# can never execute an unsupported instruction (see ggml_add_cpu_backend_features' comment about
+# LTO inlining causing exactly this crash). A rejected variant is unloaded before any kernel runs.
+set(GGML_CPU_ALL_VARIANTS ON CACHE BOOL "" FORCE)
+set(GGML_BACKEND_DL ON CACHE BOOL "" FORCE)
 
 add_subdirectory(../../../../../llama.cpp llama.cpp)
+
+# Drop the armv9 CPU variants (#187). GGML_CPU_ALL_VARIANTS generates seven Android variants;
+# these three are excluded from packaging because ggml would actively prefer them and be slower
+# for it. Its ggml_backend_score() counts CPU features rather than measuring throughput, so any
+# device reporting SVE2 scores armv9.0_1 (55) above armv8.6_1 (23) -- confirmed in this app's own
+# logcat on a Pixel 10a. Measured with llama-bench on that same device (Q4_0, 6 threads, pp128):
+# armv8.6_1 688.35 t/s vs armv9.0_1 447.88 t/s, i.e. the "better" variant is 1.45x slower,
+# because SVE is 128-bit on this core -- no wider than the NEON path it replaces. SVE-capable
+# devices fall back to armv8.6_1, which is exactly the kernel set shipping today.
+#
+# The actual exclusion is done by app/build.gradle.kts's packaging.jniLibs.excludes, not here:
+# AGP builds native targets by explicit name, so EXCLUDE_FROM_ALL doesn't stop them being built
+# or packaged. This block only fails the build if upstream's variant names change, so the
+# exclusion list and kCpuVariantLibs in LLMInference.cpp can't silently drift out of sync with
+# the submodule.
+foreach(variant ggml-cpu-android_armv9.0_1 ggml-cpu-android_armv9.2_1 ggml-cpu-android_armv9.2_2)
+    if (NOT TARGET ${variant})
+        message(FATAL_ERROR "Expected ggml CPU variant target ${variant} not found -- the \
+llama.cpp submodule's Android variant list changed. Re-check ggml/src/CMakeLists.txt, then update \
+packaging.jniLibs.excludes in app/build.gradle.kts and kCpuVariantLibs in LLMInference.cpp.")
+    endif()
+endforeach()
 
 # Real fix for the GGML_COMMIT non-determinism (F-Droid MR re-re-verification, 2026-07-16):
 # the GIT_EXE-NOTFOUND pin above cannot block find_program() from re-discovering a real `git`

--- a/app/src/main/cpp/llama_cleanup/LLMInference.cpp
+++ b/app/src/main/cpp/llama_cleanup/LLMInference.cpp
@@ -29,12 +29,112 @@
 #include "LLMInference.h"
 #include <android/log.h>
 #include <cstring>
+#include <dlfcn.h>
 #include <iomanip>
 #include <iostream>
 
 #define TAG "[SmolLMAndroid-Cpp]"
 #define LOGi(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
 #define LOGe(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+namespace {
+
+// Runtime CPU backend selection (#187).
+//
+// The native build uses GGML_CPU_ALL_VARIANTS (see this directory's CMakeLists.txt), which
+// compiles one ggml-cpu library per ARM feature level so a pre-ARMv8.2 device can't SIGILL on
+// dotprod/i8mm/fp16 instructions it doesn't implement. That option requires GGML_BACKEND_DL, so
+// ggml-cpu is no longer linked in -- it must be dlopen'ed and registered before any model load.
+//
+// ggml's own ggml_backend_load_all() cannot find them here. It scans two directories
+// (ggml-backend-reg.cpp: the executable's directory and the process CWD), which for an Android
+// app are /system/bin -- /proc/self/exe resolves to app_process64 -- and /. Neither contains our
+// libraries. Worse, the app ships extractNativeLibs="false" (Google's default and recommendation
+// since AGP 4.2: smaller installs, atomic updates), so the .so files are never unpacked to a real
+// directory at all; they live uncompressed and page-aligned INSIDE base.apk, and
+// nativeLibraryDir is empty. There is no directory for a scan to walk.
+//
+// Android's dynamic linker handles this case natively: dlopen() with a bare soname (no slash)
+// resolves through the calling namespace's library search path, which for an app includes the
+// APK's uncompressed lib/<abi>/ entries. So we ask for each variant by name rather than by path.
+//
+// Selection mirrors ggml_backend_load_best: probe every candidate, keep the highest
+// ggml_backend_score(), then hand that one name to ggml_backend_load() to register. Scoring is
+// safe on any CPU -- each variant's score function comes from ggml-cpu/arch/arm/cpu-feats.cpp,
+// which upstream deliberately compiles without the variant's -march flags and with -fno-lto so it
+// can only ever read AT_HWCAP/AT_HWCAP2 via getauxval and return 0 for an unsupported variant.
+// A variant that scores 0 is closed here and never gets to run a kernel.
+//
+// Names and order match ggml/src/CMakeLists.txt's Android branch (ggml_add_cpu_backend_variant
+// under CMAKE_SYSTEM_NAME MATCHES "Android"); keep them in sync when the submodule pin moves.
+//
+// The three armv9 variants upstream also generates are deliberately EXCLUDED, both here and from
+// the build (see this directory's CMakeLists.txt). ggml's score is a feature-count heuristic, not
+// a speed measurement, so on a device that reports SVE2 the armv9 build always outscores
+// armv8.6_1 and wins selection -- but measured on a Pixel 10a (Tensor G5) it is 1.45x SLOWER on
+// prompt eval than armv8.6_1 (447.88 vs 688.35 t/s, llama-bench pp128, 6 threads, Q4_0), because
+// SVE on this core is 128-bit, exactly NEON's width, so the SVE kernels add overhead without
+// adding throughput. Shipping them would regress every modern device to fix old ones. Devices
+// with SVE still get armv8.6_1's NEON+i8mm path, which is what ships today.
+constexpr const char * kCpuVariantLibs[] = {
+    "libggml-cpu-android_armv8.0_1.so",
+    "libggml-cpu-android_armv8.2_1.so",
+    "libggml-cpu-android_armv8.2_2.so",
+    "libggml-cpu-android_armv8.6_1.so",
+};
+
+typedef int (*ggml_backend_score_fn)(void);
+
+void loadBestCpuBackend() {
+    // Registering twice would add a second, redundant CPU device; loadModel can run repeatedly
+    // over an app session (one call per cleanup) while the registry is process-global.
+    static bool loaded = false;
+    if (loaded) {
+        return;
+    }
+
+    const char * bestName  = nullptr;
+    int          bestScore = 0;
+
+    for (const char * name : kCpuVariantLibs) {
+        void * handle = dlopen(name, RTLD_NOW | RTLD_LOCAL);
+        if (!handle) {
+            // Expected for any variant not present in this build.
+            LOGi("cpu variant %s not loadable: %s", name, dlerror());
+            continue;
+        }
+
+        auto score_fn = reinterpret_cast<ggml_backend_score_fn>(dlsym(handle, "ggml_backend_score"));
+        const int score = score_fn ? score_fn() : 0;
+        LOGi("cpu variant %s score=%d", name, score);
+
+        if (score > bestScore) {
+            bestScore = score;
+            bestName  = name;
+        }
+        // Close every probe, including the winner: ggml_backend_load() dlopen()s it again below
+        // and owns the handle it registers. dlopen/dlclose are refcounted, so the winning library
+        // is simply re-opened rather than reloaded.
+        dlclose(handle);
+    }
+
+    if (!bestName) {
+        // Nothing scored above zero. Throwing here surfaces as an IllegalStateException through
+        // llama_cleanup_jni.cpp's existing catch, which the Kotlin side already reports as a
+        // cleanup failure with the raw text preserved (#175) -- a bad cleanup, not a dead app.
+        LOGe("no compatible ggml CPU backend for this device");
+        throw std::runtime_error("no compatible CPU backend for this device");
+    }
+
+    LOGi("selected cpu variant %s (score=%d)", bestName, bestScore);
+    if (!ggml_backend_load(bestName)) {
+        LOGe("failed to register cpu backend %s", bestName);
+        throw std::runtime_error("failed to load CPU backend");
+    }
+    loaded = true;
+}
+
+}  // namespace
 
 void
 LLMInference::loadModel(const char *model_path, float minP, float temperature, bool storeChats, long contextSize,
@@ -51,8 +151,10 @@ LLMInference::loadModel(const char *model_path, float minP, float temperature, b
          "\n\tuseMlock = %d",
          model_path, minP, temperature, storeChats, contextSize, chatTemplate, nThreads, useMmap, useMlock);
 
-    // load dynamic backends
-    ggml_backend_load_all();
+    // Select and register the CPU backend matching this device's actual ARM features (#187).
+    // Replaces ggml_backend_load_all(), whose directory scan cannot locate the variant libraries
+    // inside an APK -- see loadBestCpuBackend above.
+    loadBestCpuBackend();
 
     // create an instance of llama_model
     llama_model_params model_params = llama_model_default_params();


### PR DESCRIPTION
## Summary

Fixes the SIGILL on pre-ARMv8.2 ARM64 devices by replacing the hardcoded `-march` with ggml's runtime CPU dispatch.

The native build pinned `GGML_CPU_ARM_ARCH=armv8.6-a+dotprod+i8mm+fp16` to match a Pixel. With no runtime fallback, the first Q4_0 matmul on an older ARM64 CPU executes an unimplemented instruction and the process dies with SIGILL — a native crash, so the #175 cleanup-failure path can't report it. Dictation works, then local cleanup kills the app. The reviewer's Redmi Note 8T (Snapdragon 665 / Cortex-A73, ARMv8.0) is exactly this case.

Disassembly of the shipped `libggml-cpu.so` found **516** `sdot`/`udot`, **125** `smmla`/`ummla`/`usmmla` and **7** fp16-arithmetic instructions, with no `getauxval`/`AT_HWCAP` guard anywhere. The unsupported instructions sit in live Q4_0 kernels (`ggml_vec_dot_q4_0_q8_0`, `ggml_gemm_q4_0_4x4_q8_0`, `ggml_gemm_q4_0_4x8_q8_0`).

## Why not just compile `armv8-a`

Measured, then rejected. Pixel 10a, llama-bench, Q4_0, 6 threads:

| Model | Test | v8.6 t/s | v8.0 t/s | slowdown |
|---|---|---:|---:|---:|
| lfm2.5-350m | pp128 | 647.48 | 136.98 | 4.73x |
| lfm2.5-350m | tg64 | 89.97 | 42.83 | 2.10x |
| mumble-cleanup | pp128 | 405.96 | 104.40 | 3.89x |
| mumble-cleanup | tg64 | 64.02 | 32.23 | 1.99x |

That turns a crash fix into a timeout on the same old hardware it's meant to rescue.

## Approach

`GGML_CPU_ALL_VARIANTS` — one library per ARM feature level, best supported one chosen at runtime. Each exports `ggml_backend_score()` from `cpu-feats.cpp`, which reads `AT_HWCAP`/`AT_HWCAP2` via `getauxval` and scores 0 when a required feature is absent. Upstream compiles that file without the variant's `-march` flags and with `-fno-lto` precisely so detection can't itself SIGILL. Rejected variants are closed before any kernel runs.

Three things this needed beyond flipping the flag:

**Loading.** `GGML_CPU_ALL_VARIANTS` requires `GGML_BACKEND_DL`, so ggml-cpu is dlopen'ed rather than linked — and `ggml_backend_load_all()` cannot find the libraries here. It scans the executable's directory (`/proc/self/exe` is `app_process64` → `/system/bin`) and the process CWD (`/`). Neither contains them, and with `extractNativeLibs=false` they're never unpacked to a directory at all: they live uncompressed inside `base.apk` and `nativeLibraryDir` is empty. Android's linker resolves a bare soname through the app's namespace including in-APK entries, so `LLMInference.cpp` asks for each variant by name, scores it, registers the winner. Reverting to `useLegacyPackaging` was rejected — it undoes Google's default packaging and inflates the installed footprint of a ~57MB native payload.

**16KB alignment.** `ggml_add_backend_library()` creates each variant with `add_library(... MODULE ...)`, and CMake applies `CMAKE_MODULE_LINKER_FLAGS` — not `CMAKE_SHARED_LINKER_FLAGS` — to MODULE targets, so the #44 alignment fix silently missed them. They linked at the 4KB default while every other APK library was 16KB, and Android's on-device compatibility dialog listed exactly those and nothing else.

**armv9 variants excluded.** `ggml_backend_score()` counts CPU *features*, not speed, so any SVE2-capable device scores `armv9.0_1` (55) over `armv8.6_1` (23) and picks it — measured **447.88 vs 688.35 t/s** pp128, **1.45x slower**, because SVE on this core is 128-bit, no wider than the NEON path it displaces. Shipping them would regress every modern device to fix old ones. SVE devices now fall back to `armv8.6_1`, the same kernels shipping today. Saves 4.6MB.

## Verification

On-device (Pixel 10a, serial 63141JEA320614), from the app's own logcat:

```
cpu variant libggml-cpu-android_armv8.0_1.so score=1
cpu variant libggml-cpu-android_armv8.2_1.so score=3
cpu variant libggml-cpu-android_armv8.2_2.so score=7
cpu variant libggml-cpu-android_armv8.6_1.so score=23
selected cpu variant libggml-cpu-android_armv8.6_1.so (score=23)
Model load took 873ms
perf: prompt eval 751.21ms / 106 tokens | gen 1993.61ms / 14 tokens
CleanupWaterfallExecutor: Cleanup step LOCAL_LLM succeeded at +3839ms
```

Release APK asserted separately (it's the artifact that ships, and uses a different `.cxx` config):

- 4 CPU variants packaged, armv9 absent, old monolithic `libggml-cpu.so` gone
- all 12 native libs 16KB aligned (`0x4000`), all `Stored` — `extractNativeLibs=false` preserved
- `armv8.0_1` disassembles to **0** dotprod / **0** i8mm / **0** fp16 — safe on Cortex-A73
- `ggml_backend_score()` in `armv8.6_1` free of gated instructions; `getauxval` imported
- release `armv8.6_1` carries 839/158/299 — identical to the benchmarked build
- no crashes in `logcat -b crash`; 16KB compatibility dialog gone
- unit tests pass

## Not verified

No real ARMv8.0 hardware was available. The instruction audit proves `armv8.0_1` **cannot** SIGILL; it does not prove it's fast enough there. Projected ~6-8s from the v8.0 benchmarks, inside the 12s cleanup budget, but unconfirmed on actual old silicon. The current build hard-crashes on those devices, so this is strictly better either way.

Refs #187
