### PR TITLE
Audit 2026-08-25: privacy gate, timing/race fixes, cleanup model refresh

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -59,6 +59,17 @@ on-device, in the app's private storage, and is excluded from Android backups an
 device-to-device transfer. It is never uploaded anywhere. You can turn history off in Settings, and
 you can delete recorded entries from the history screen.
 
+## Quality log (off by default)
+
+Ramblr has an optional diagnostic "quality log" for comparing transcription/cleanup providers. When
+— and only when — you enable it in Settings → Data & Logs, each dictation's raw transcript and
+cleaned-up text, along with the provider and model that produced them, are appended to a file in
+the app's private on-device storage. It is **off by default**: nothing is written unless you turn
+it on. The log never leaves the device on its own — it is excluded from Android backups, from
+device-to-device transfer, and from the app's own manual backup files; the only way it leaves the
+device is if you explicitly share it with the "Share quality log" button. Turning the toggle off
+offers to delete the already-saved log, and uninstalling the app removes it.
+
 ## Android backup and device transfer
 
 Ramblr participates in Android's backup and "Copy your data" device-transfer flows, but on a

--- a/app/src/main/kotlin/com/trevornk/ramblr/BackupManager.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BackupManager.kt
@@ -13,10 +13,12 @@ import org.w3c.dom.Element
 /**
  * Manual, on-demand backup/restore of the on-device data that's NOT already covered by Android's
  * automatic backup mechanism (see backup_rules.xml / data_extraction_rules.xml, which only ever
- * carry `ramblr.xml` + `overlay_icon.png`) -- specifically `dictation_history.jsonl`,
- * `benchmark_log.jsonl`, and `quality_log.jsonl` (GH #103). Prompted by a real scenario: a
+ * carry `ramblr.xml` + `overlay_icon.png`) -- specifically `dictation_history.jsonl` and
+ * `benchmark_log.jsonl` (GH #103). Prompted by a real scenario: a
  * signature-key change (debug -> release signed APK) forces an uninstall, which would otherwise
- * silently lose all three.
+ * silently lose them. (`quality_log.jsonl` was originally included too, but is excluded since
+ * #191: it stores verbatim dictation text behind an off-by-default toggle, so it stays strictly
+ * on-device.)
  *
  * Deliberately excludes the three EncryptedSharedPreferences files (`ramblr_secure.xml`,
  * `ramblr_cleanup_credentials.xml`, `ramblr_provider_credentials.xml`) -- same reasoning already
@@ -41,6 +43,11 @@ import org.w3c.dom.Element
 object BackupManager {
     const val ENTRY_DICTATION_HISTORY = "dictation_history.jsonl"
     const val ENTRY_BENCHMARK_LOG = "benchmark_log.jsonl"
+
+    /** No longer written to new backups (#191: the quality log stores verbatim dictation text
+     *  behind an off-by-default toggle, so it must not silently ride along in backup zips), but
+     *  the constant stays so a legacy backup containing this entry is still *recognized* — it
+     *  now falls into [RestoreResult.skippedEntries] instead of being restored. */
     const val ENTRY_QUALITY_LOG = "quality_log.jsonl"
     const val ENTRY_PREFS = "ramblr_prefs.xml"
 
@@ -55,7 +62,9 @@ object BackupManager {
     fun targetFiles(context: Context): Map<String, File> = mapOf(
         ENTRY_DICTATION_HISTORY to File(context.filesDir, ENTRY_DICTATION_HISTORY),
         ENTRY_BENCHMARK_LOG to BenchmarkLogger.logFile(context),
-        ENTRY_QUALITY_LOG to QualityLogger.logFile(context),
+        // ENTRY_QUALITY_LOG is deliberately absent (#191): quality_log.jsonl holds verbatim
+        // dictation text and is opt-in-only, so it neither leaves the device in a backup zip
+        // nor gets overwritten by a restore.
         // SharedPreferences XML files live in a fixed sibling of filesDir, one directory up:
         // <filesDir>/../shared_prefs/<name>.xml. There's no public Context accessor for this
         // path (only for the parsed SharedPreferences object itself), but the location is a

--- a/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
@@ -47,7 +47,8 @@ const val MAX_ERROR_DETAIL_CHARS = 200
  * Scrubs a provider failure message for the length-only benchmark log (#138).
  *
  * [BenchmarkLogger] stores lengths, timings and model ids -- never transcript content -- which is
- * why raw/cleaned text pairs live in the separate, opt-in [QualityLogger] instead. A provider's
+ * why raw/cleaned text pairs live in the separate [QualityLogger] instead, itself gated behind an
+ * off-by-default toggle (`quality_log_enabled`, #191). A provider's
  * error body can quote the request that caused it.
  *
  * **What this does and does not guarantee.** Collapsing whitespace is a correctness guarantee:

--- a/app/src/main/kotlin/com/trevornk/ramblr/DataLogsActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DataLogsActivity.kt
@@ -25,6 +25,7 @@ import kotlin.concurrent.thread
 class DataLogsActivity : BaseSettingsActivity() {
 
     private lateinit var historyEnabledSwitch: com.google.android.material.materialswitch.MaterialSwitch
+    private lateinit var qualityLogEnabledSwitch: com.google.android.material.materialswitch.MaterialSwitch
     private lateinit var backupRowSub: TextView
 
     /** SAF file picker for restore (#103): OpenDocument (not GetContent) so the returned Uri
@@ -65,10 +66,11 @@ class DataLogsActivity : BaseSettingsActivity() {
         // --- Backup / restore (#103) ---
         root.addView(sectionHeader("Backup & restore"))
         root.addView(TextView(this).apply {
-            text = "Saves dictation history, benchmark log, quality log, and settings to a file " +
+            text = "Saves dictation history, benchmark log, and settings to a file " +
                 "you choose where to send. API keys are never included -- they're encrypted to " +
                 "this device's hardware Keystore and can't be restored elsewhere, so you'll " +
-                "re-enter them once on a new device."
+                "re-enter them once on a new device. The quality log is never included either: " +
+                "it contains your actual dictated text, so it stays strictly on this device."
             textSize = 14f
             setTextColor(attrColor(android.R.attr.textColorSecondary))
             setPadding(dp(24), 0, dp(24), dp(8))
@@ -76,14 +78,14 @@ class DataLogsActivity : BaseSettingsActivity() {
 
         val backupRow = settingsRow(
             "Backup all data",
-            "Share a backup file containing history, logs, and settings"
+            "Share a backup file containing history, the benchmark log, and settings"
         ) { createAndShareBackup() }
         backupRowSub = backupRow.findViewWithTag("subtitle")
         root.addView(backupRow)
 
         root.addView(settingsRow(
             "Restore from backup",
-            "Pick a backup file to restore. This overwrites existing history, logs, and settings"
+            "Pick a backup file to restore. This overwrites existing history, benchmark log, and settings"
         ) { pickRestoreFile.launch(arrayOf("application/zip", "application/octet-stream")) })
 
         // --- Benchmark / quality logs ---
@@ -93,6 +95,16 @@ class DataLogsActivity : BaseSettingsActivity() {
             "Share benchmark log",
             "Send the on-device transcription/cleanup benchmark log (timings and model ids only, no dictation text) to any app"
         ) { shareBenchmarkLog() })
+
+        qualityLogEnabledSwitch = com.google.android.material.materialswitch.MaterialSwitch(this).apply {
+            isChecked = QualityLogger.isEnabled(this@DataLogsActivity)
+            isClickable = false
+        }
+        root.addView(settingsRow(
+            "Save quality log",
+            "Keeps the raw and cleaned text of every dictation on-device for provider/model quality review. Off by default",
+            qualityLogEnabledSwitch
+        ) { onQualityLogToggle(!qualityLogEnabledSwitch.isChecked) })
 
         root.addView(settingsRow(
             "Share quality log",
@@ -114,6 +126,7 @@ class DataLogsActivity : BaseSettingsActivity() {
 
     private fun refresh() {
         historyEnabledSwitch.isChecked = prefs().getBoolean(KEY_HISTORY_ENABLED, true)
+        qualityLogEnabledSwitch.isChecked = QualityLogger.isEnabled(this)
     }
 
     // --- Backup / restore (#103) ---
@@ -169,7 +182,7 @@ class DataLogsActivity : BaseSettingsActivity() {
         android.app.AlertDialog.Builder(this)
             .setTitle("Restore from backup?")
             .setMessage(
-                "This overwrites the dictation history, benchmark log, quality log, and " +
+                "This overwrites the dictation history, benchmark log, and " +
                     "settings currently on this device with the contents of the selected file. " +
                     "This can't be undone."
             )
@@ -204,6 +217,33 @@ class DataLogsActivity : BaseSettingsActivity() {
                 refresh()
             }
         }
+    }
+
+    // --- Quality log opt-in (#191) ---
+
+    /** Mirrors [onHistoryToggle]'s shape: enabling is immediate, disabling offers to also delete
+     *  the transcript text already on disk — the log stores verbatim dictations, so turning the
+     *  feature off is exactly when a user is most likely to want the existing file gone too. */
+    private fun onQualityLogToggle(enabled: Boolean) {
+        if (enabled) {
+            QualityLogger.setEnabled(this, true)
+            refresh()
+            return
+        }
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Turn off quality logging")
+            .setMessage("New dictations won't be added to the quality log. Delete the transcript text already saved in it?")
+            .setPositiveButton("Delete log") { _, _ ->
+                QualityLogger.setEnabled(this, false)
+                QualityLogger.logFile(this).delete()
+                refresh()
+            }
+            .setNegativeButton("Keep log") { _, _ ->
+                QualityLogger.setEnabled(this, false)
+                refresh()
+            }
+            .setOnCancelListener { refresh() }
+            .show()
     }
 
     // --- Dictation History (#25) ---

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationGates.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationGates.kt
@@ -1,0 +1,42 @@
+package com.trevornk.ramblr
+
+/**
+ * Cheap pre-pipeline gates for dictations that cannot possibly produce useful text (M3, #192).
+ *
+ * Both are pure functions living outside [WhisperAccessibilityService] so they're directly
+ * unit-testable (same extraction pattern as [resolveLateRecording]/[TranscriptionChain]): the
+ * service decides *where* to apply them, this file owns *what* they mean.
+ */
+
+/** Recordings shorter than this cannot contain usable speech: a tap-tap dictation with ~0.2s of
+ *  near-silence previously still paid for a full local decode or cloud upload only to produce a
+ *  blank transcript (M3a). 300ms is comfortably below any real one-word utterance. */
+const val MIN_RECORDING_DURATION_MS = 300L
+
+/**
+ * True when a PCM recording of [pcmByteCount] bytes is under [MIN_RECORDING_DURATION_MS] of
+ * audio. Duration is derived from the byte count of the raw capture format --
+ * [bytesPerSampleFrame] defaults to 16-bit mono ([RecordingEngine]'s fixed
+ * `ENCODING_PCM_16BIT`/`CHANNEL_IN_MONO` configuration), i.e. 32 bytes per millisecond at 16kHz.
+ */
+fun isBelowMinimumDuration(
+    pcmByteCount: Long,
+    sampleRateHz: Int,
+    bytesPerSampleFrame: Int = 2,
+): Boolean {
+    val bytesPerMs = sampleRateHz.toLong() * bytesPerSampleFrame / 1000L
+    return pcmByteCount < MIN_RECORDING_DURATION_MS * bytesPerMs
+}
+
+/**
+ * True when a non-blank transcript is content-free junk that must skip the cleanup waterfall and
+ * be injected raw instead (M3b): ASR hallucinations like "." or "…" pass `isNotBlank()` but have
+ * nothing for a cleanup model to improve, so running the full waterfall (network calls,
+ * LOCAL_LLM load) on them is pure waste. Junk means: no letter or digit anywhere, or fewer than
+ * 2 non-whitespace-trimmed chars. Deliberately conservative -- any transcript with real content
+ * ("ok", "a 5") is untouched.
+ */
+fun isJunkTranscript(transcript: String): Boolean {
+    val trimmed = transcript.trim()
+    return trimmed.length < 2 || trimmed.none { it.isLetterOrDigit() }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiCleanupProvider.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiCleanupProvider.kt
@@ -29,10 +29,12 @@ object GeminiCleanupProvider {
      *  key out of the URL entirely, mirroring [AnthropicCleanupProvider.headers]'s `x-api-key`. */
     fun headers(key: String): Map<String, String> = mapOf("x-goog-api-key" to key)
 
-    // gemini-2.5-flash -> gemini-3.1-flash-lite: 2.5-flash is on Google's deprecation path
-    // (shutdown Oct 16, 2026); 3.1-flash-lite is Google's own documented replacement for the
-    // flash-lite tier and matches ModelCatalogEntry's RECOMMENDED Gemini pick (2026-07-10).
-    const val DEFAULT_MODEL = "gemini-3.1-flash-lite"
+    // gemini-3.1-flash-lite -> gemini-3.5-flash-lite (2026-08-25): 3.5-flash-lite (GA July 2026)
+    // is the current cheapest Gemini tier and the catalog's RECOMMENDED cleanup pick. CLEANUP
+    // ONLY: [GeminiTranscriberClient.DEFAULT_MODEL] deliberately stays gemini-3.1-flash-lite --
+    // 3.5-flash-lite measures ~3x slower on audio input, so the audio path keeps the faster
+    // model on purpose (see ModelCatalogEntry's Gemini section).
+    const val DEFAULT_MODEL = "gemini-3.5-flash-lite"
 
     /**
      * Builds the generateContent request body: [prompt] as `systemInstruction`, [text] as the

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiTranscriberClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiTranscriberClient.kt
@@ -29,7 +29,9 @@ object GeminiTranscriberClient {
     // gemini-2.5-flash -> gemini-3.1-flash-lite: 2.5-flash is on Google's deprecation path
     // (shutdown Oct 16, 2026). 3.1-flash-lite's own model card documents explicit "improved
     // audio input... for ASR" gains and lists transcription as a first-class use case, so it's
-    // safe for this multimodal audio-in path too (2026-07-10).
+    // safe for this multimodal audio-in path too (2026-07-10). DELIBERATELY NOT bumped to
+    // gemini-3.5-flash-lite alongside the 2026-08-25 cleanup-default refresh: 3.5-flash-lite
+    // measures ~3x slower on audio input, so the transcription path keeps the faster model.
     const val DEFAULT_MODEL = "gemini-3.1-flash-lite"
     const val TRANSCRIBE_PROMPT = "Transcribe this audio exactly as spoken. Return only the transcript text, with no commentary, labels, or extra formatting."
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/ModelCatalogEntry.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ModelCatalogEntry.kt
@@ -84,9 +84,9 @@ val BUNDLED_DEFAULT_MODEL_CATALOG: List<ModelCatalogEntry> = listOf(
     // to the transcription endpoint). ---
     ModelCatalogEntry(
         provider = ProviderKind.OPENAI,
-        modelId = "gpt-5.4-nano",
-        displayName = "GPT-5.4 Nano",
-        description = "Fastest, cheapest — benchmark-confirmed indistinguishable from Mini for cleanup quality.",
+        modelId = "gpt-5.6-luna",
+        displayName = "GPT-5.6 Luna",
+        description = "OpenAI's current cheapest tier (successor of GPT-5.4 Nano) — fastest and cheapest for cleanup.",
         tier = ModelTier.RECOMMENDED,
         useCase = ModelUseCase.CLEANUP,
         costPer1MInputUsd = 0.05,
@@ -96,7 +96,7 @@ val BUNDLED_DEFAULT_MODEL_CATALOG: List<ModelCatalogEntry> = listOf(
         provider = ProviderKind.OPENAI,
         modelId = "gpt-5.4-mini",
         displayName = "GPT-5.4 Mini",
-        description = "One tier up from Nano — same real-world cleanup quality, costs more.",
+        description = "Previous-generation mid tier — same real-world cleanup quality, costs more.",
         tier = ModelTier.GOOD,
         useCase = ModelUseCase.CLEANUP,
         costPer1MInputUsd = 0.25,
@@ -139,19 +139,29 @@ val BUNDLED_DEFAULT_MODEL_CATALOG: List<ModelCatalogEntry> = listOf(
     ),
 
     // --- Gemini: only direct provider that's transcription-capable (multimodal audio-in) as
-    // well as cleanup-capable, so its entries are tagged BOTH. 2.5-flash/-lite -> 3.1-flash-lite/
-    // 3.5-flash (2026-07-10): 2.5-flash and 2.5-flash-lite are both on Google's deprecation path
-    // (shutdown Oct 16, 2026); Google's own deprecation table maps 2.5-flash-lite ->
-    // 3.1-flash-lite and 2.5-flash -> 3.5-flash. 3.1-flash-lite's model card documents explicit
-    // "improved audio input... for ASR" gains, confirming it's safe for the transcription use
-    // case too. Note 3.5-flash carries a real ~6x price jump over 3.1-flash-lite (not a smooth
-    // one-tier step like the old 2.5-flash/-lite pair) -- flagged honestly below rather than
-    // understated, but it's still the officially documented stable migration target. ---
+    // well as cleanup-capable. Cleanup and transcription defaults deliberately DIVERGE here
+    // (2026-08-25): 3.5-flash-lite (GA July 2026) is the current cheapest tier and the cleanup
+    // RECOMMENDED pick, but it measures ~3x slower than 3.1-flash-lite on audio input, so
+    // 3.1-flash-lite stays the transcription RECOMMENDED pick (and
+    // GeminiTranscriberClient.DEFAULT_MODEL) on purpose -- 3.5-flash-lite is tagged CLEANUP so
+    // the transcription picker never offers the slower model as its default. Note 3.5-flash
+    // still carries a real ~6x price jump over the lite tier (not a smooth one-tier step) --
+    // flagged honestly below rather than understated. ---
+    ModelCatalogEntry(
+        provider = ProviderKind.GEMINI,
+        modelId = "gemini-3.5-flash-lite",
+        displayName = "Gemini 3.5 Flash-Lite",
+        description = "Cheapest Gemini tier (GA July 2026) — current cleanup pick. Deliberately not used for transcription: it's ~3x slower than 3.1 Flash-Lite on audio input.",
+        tier = ModelTier.RECOMMENDED,
+        useCase = ModelUseCase.CLEANUP,
+        costPer1MInputUsd = 0.25,
+        costPer1MOutputUsd = 1.50,
+    ),
     ModelCatalogEntry(
         provider = ProviderKind.GEMINI,
         modelId = "gemini-3.1-flash-lite",
         displayName = "Gemini 3.1 Flash-Lite",
-        description = "Cheapest Gemini tier — Google's documented replacement for 2.5 Flash-Lite (which is deprecating); improved audio input for ASR, handles transcription too.",
+        description = "Recommended for transcription — much faster than 3.5 Flash-Lite on audio input; improved audio input for ASR. Still fine for cleanup too.",
         tier = ModelTier.RECOMMENDED,
         useCase = ModelUseCase.BOTH,
         costPer1MInputUsd = 0.25,

--- a/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
@@ -22,6 +22,20 @@ object PostProcessor {
 
     val ENDPOINT_URL = "$DEFAULT_BASE_URL/chat/completions"
 
+    /** OpenAI model families that reject a non-default `temperature` outright (#106) -- see
+     *  [buildRequestBody]'s kdoc for the exact error. An explicit prefix list rather than a broad
+     *  regex (mirrors the eval harness's TEMPERATURE_REJECTING_OPENAI_PREFIXES): a false negative
+     *  fails loudly at call time with a clear "Unsupported value" error needing a one-line
+     *  addition, which is safer than a false positive silently omitting temperature from a model
+     *  that wanted it. */
+    private val TEMPERATURE_REJECTING_MODEL_PREFIXES = listOf("o1", "o3", "o4", "gpt-5.6")
+
+    /** True when [model] is in a family that rejects `temperature` (#106), so request builders
+     *  must omit the field. Public so the eval harness and any future call path can share the
+     *  single production list instead of drifting copies. */
+    fun rejectsTemperature(model: String): Boolean =
+        TEMPERATURE_REJECTING_MODEL_PREFIXES.any { model.startsWith(it) }
+
     /** Host cleanup requests are actually sent to by default, for use in UI copy. See #23. */
     val DESTINATION_HOST: String = java.net.URI(ENDPOINT_URL).host
 
@@ -261,14 +275,19 @@ explanations, headers, or comments about your edits.
      * [omitTemperature] (#106): OpenAI's GPT-5.6 family (confirmed live for gpt-5.6-terra) and
      * the older o1/o3/o4 reasoning-model families reject a non-default `temperature` value
      * outright -- "Unsupported value: 'temperature' does not support 0 with this model. Only
-     * the default (1) value is supported." -- unlike gpt-5.4-nano/gpt-5.4-mini (the current
-     * shipped defaults), which accept temperature=0.0 fine. Defaults to false (temperature
-     * included) so every existing call site's behavior is unchanged; pass true explicitly for a
-     * model known to be in a temperature-rejecting family. See [CleanupWaterfallExecutor] if a
-     * temperature-rejecting model is ever adopted as a shipped default -- it will need to pass
-     * this too, not just the eval harness.
+     * the default (1) value is supported." -- unlike gpt-5.4-nano/gpt-5.4-mini (the previous
+     * shipped defaults), which accept temperature=0.0 fine. Defaults to
+     * [rejectsTemperature] of the effective model, so every call site -- including
+     * [CleanupWaterfallExecutor]'s production path -- automatically omits temperature for a
+     * temperature-rejecting family now that one (gpt-5.6-luna, 2026-08-25) is a shipped
+     * default. Pass an explicit value only to override the detection.
      */
-    fun buildRequestBody(text: String, prompt: String, model: String, omitTemperature: Boolean = false): JSONObject {
+    fun buildRequestBody(
+        text: String,
+        prompt: String,
+        model: String,
+        omitTemperature: Boolean = rejectsTemperature(model.ifBlank { DEFAULT_MODEL }),
+    ): JSONObject {
         val messages = JSONArray().apply {
             put(JSONObject().apply {
                 put("role", "system")

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProviderChainMigration.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProviderChainMigration.kt
@@ -38,7 +38,7 @@ object ProviderChainMigration {
      * every version between the device's last-applied version and this one, so a device that
      * skipped several app updates still picks up every intermediate mapping in order.
      */
-    private const val MIGRATION_VERSION = 3
+    private const val MIGRATION_VERSION = 4
 
     /**
      * (provider, old shipped-default model id) -> new shipped-default model id. Only exact
@@ -56,6 +56,20 @@ object ProviderChainMigration {
         // a device whose single `model` field held gpt-4o-transcribe (e.g. via the v1
         // whisper-1 rewrite applied when gpt-4o-transcribe was the current default).
         (ProviderKind.OPENAI to "gpt-4o-transcribe") to TranscriberClient.DEFAULT_MODEL,
+        // v4 (2026-08-25): cleanup-default refresh (#194).
+        // - gpt-5.4-nano was the catalog's RECOMMENDED OpenAI cleanup pick (what the picker and
+        //   onboarding seeded on every configured device) until superseded by gpt-5.6-luna,
+        //   OpenAI's current cheapest tier. The new id is a literal here because the shipped
+        //   value lives in BUNDLED_DEFAULT_MODEL_CATALOG, not a DEFAULT_MODEL constant.
+        (ProviderKind.OPENAI to "gpt-5.4-nano") to "gpt-5.6-luna",
+        // - gemini-3.1-flash-lite -> gemini-3.5-flash-lite for the CLEANUP `model` field only.
+        //   Audio safety: even for pre-#101 shared-field-era chains this can't flip anyone's
+        //   transcription path to the ~3x-slower 3.5-flash-lite -- the Gemini audio call reads
+        //   `transcriptionModel ?: GeminiTranscriberClient.DEFAULT_MODEL` (never `model`), this
+        //   migration's null-seeding uses GeminiTranscriberClient.DEFAULT_MODEL (still
+        //   3.1-flash-lite), and SUPERSEDED_TRANSCRIPTION_MODELS deliberately has NO entry for
+        //   3.1-flash-lite, so every non-null transcriptionModel keeps its value.
+        (ProviderKind.GEMINI to "gemini-3.1-flash-lite") to GeminiCleanupProvider.DEFAULT_MODEL,
     )
 
     /**

--- a/app/src/main/kotlin/com/trevornk/ramblr/QualityLogger.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/QualityLogger.kt
@@ -1,6 +1,7 @@
 package com.trevornk.ramblr
 
 import android.content.Context
+import android.content.SharedPreferences
 import java.io.File
 import org.json.JSONObject
 
@@ -21,6 +22,11 @@ data class QualityStage(
  * device over several days (GH #105). One line per completed dictation stage, each line a
  * self-contained JSON object -- deliberately NOT a JSON array, so a crash or a concurrent read
  * mid-write can never corrupt lines already flushed, and a consumer can stream-parse it.
+ *
+ * Off by default (#191): because this log stores the *actual text* of every dictation, [log]
+ * writes nothing unless the user explicitly flips the quality-logging toggle in
+ * [DataLogsActivity] ([KEY_ENABLED]). It is also deliberately excluded from [BackupManager]
+ * backup zips for the same reason.
  *
  * This is [BenchmarkLogger]'s deliberate complement, not a replacement or a merge target:
  * [BenchmarkLogger] intentionally never logs actual dictated text (a considered privacy decision
@@ -44,6 +50,28 @@ object QualityLogger {
 
     private const val FILE_NAME = "quality_log.jsonl"
 
+    /** Same plain prefs file every other Settings toggle uses ([DebugVisibilityToggle],
+     *  [DataLogsActivity]'s history toggle, ...). */
+    private const val PREFS_NAME = "ramblr"
+
+    /** Gates [log] (#191). Default **off**: quality logging stores verbatim raw/cleaned dictation
+     *  text on disk, so it must be an explicit opt-in — mirroring how `dictation_history_enabled`
+     *  gates history, except this one defaults to disabled because it's a diagnostics tool, not a
+     *  user-facing safety net. */
+    const val KEY_ENABLED = "quality_log_enabled"
+    const val ENABLED_DEFAULT = false
+
+    fun isEnabled(prefs: SharedPreferences): Boolean = prefs.getBoolean(KEY_ENABLED, ENABLED_DEFAULT)
+
+    fun isEnabled(context: Context): Boolean = isEnabled(prefs(context))
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
     /** Once the log file exceeds this size, it's rotated down to [KEEP_BYTES_AFTER_ROTATION] of
      *  its newest (tail) content rather than growing unbounded across many real-world sessions.
      *  Set generously larger than [BenchmarkLogger.ROTATE_AT_BYTES]: this log stores real (but
@@ -63,6 +91,9 @@ object QualityLogger {
      * e.g. a transcription-only call site that has no cleanup outcome yet, or a cleanup-only call
      * site logging just the cleaned side of an already-logged transcription.
      *
+     * No-ops unless the user has explicitly enabled quality logging ([KEY_ENABLED], default off,
+     * #191): this file stores verbatim dictation text, so nothing may be written without opt-in.
+     *
      * All file I/O is wrapped in `runCatching`: this is a diagnostics-only side channel for
      * later manual review, and must never be allowed to crash or block Trevor's actual dictation
      * -- a full disk or a transient I/O error here should be silently swallowed, not surfaced.
@@ -76,6 +107,24 @@ object QualityLogger {
         cleanedText: String? = null,
     ) {
         runCatching {
+            log(prefs(context), logFile(context), correlationId, transcription, cleanup, rawText, cleanedText)
+        }
+    }
+
+    /** [log]'s prefs+file core, split out (same spirit as [buildLine]) so the enabled-gate is
+     *  directly unit-testable against a fake [SharedPreferences] and a temp file without a real
+     *  [Context]. */
+    fun log(
+        prefs: SharedPreferences,
+        file: File,
+        correlationId: String,
+        transcription: QualityStage? = null,
+        cleanup: QualityStage? = null,
+        rawText: String? = null,
+        cleanedText: String? = null,
+    ) {
+        if (!isEnabled(prefs)) return
+        runCatching {
             val line = buildLine(
                 timestamp = System.currentTimeMillis(),
                 correlationId = correlationId,
@@ -84,7 +133,6 @@ object QualityLogger {
                 rawText = rawText,
                 cleanedText = cleanedText,
             )
-            val file = logFile(context)
             rotateIfNeeded(file)
             file.appendText(line + "\n")
         }

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -85,6 +85,41 @@ data class PipelineTiming(
 )
 
 /**
+ * Holder for the current dictation's [PipelineTiming] with explicit lifecycle verbs (H2, #192).
+ *
+ * The previous bare `@Volatile var` field was only ever cleared by [consume] (in
+ * `finishInjection`) or overwritten by the next dictation's [start] -- so a dictation that ended
+ * on a NON-happy path (no speech detected, long-press cancel, watchdog timeout, transcription
+ * error) left its timing populated, and the next unrelated `injectText()` call (e.g. the feedback
+ * bubble's raw-text retry) consumed it and wrote a benchmark line whose
+ * `injectionAttemptMs`/`totalMs` were measured from the *previous, abandoned* dictation's stop
+ * tap. [abandon] is the missing verb: every non-happy-path exit drops the timeline so it can
+ * never be misattributed later.
+ *
+ * Same memory semantics as the field it replaces (a single volatile reference, no CAS): exactly
+ * one dictation is ever in flight at a time -- `guard`/`activeToken` enforce that invariant --
+ * and the one benign cross-thread copy race (reader-thread [markDrained] vs a simultaneous
+ * main-thread write, audit L6) is unchanged.
+ */
+class PipelineTimingSlot {
+    @Volatile private var timing: PipelineTiming? = null
+
+    /** Anchors a fresh dictation timeline, overwriting anything left behind. */
+    fun start(timing: PipelineTiming) { this.timing = timing }
+
+    /** Stamps the reader-drain instant onto the active timeline; no-op when none is active. */
+    fun markDrained(nowMs: Long) { timing = timing?.copy(drainAtMs = nowMs) }
+
+    /** Returns the active timeline and clears it -- consume-exactly-once, or null when the
+     *  dictation this injection belongs to never had / already used / abandoned its timing. */
+    fun consume(): PipelineTiming? = timing.also { timing = null }
+
+    /** Drops the timeline on a non-happy-path exit (no-speech, cancel, watchdog, transcription
+     *  error) so a later, unrelated injection can never consume stale timing (H2, #192). */
+    fun abandon() { timing = null }
+}
+
+/**
  * #118: the default "Copied to clipboard" feedback is only true when the text really did land on
  * the clipboard for the user to paste -- a DIRECT (ACTION_SET_TEXT) injection never reads the
  * clipboard at all, so showing that message there is misleading noise. Any caller-supplied,
@@ -353,14 +388,16 @@ class WhisperAccessibilityService : AccessibilityService() {
     private var screenStateReceiver: android.content.BroadcastReceiver? = null
     @Volatile private var activeToken: Int = 0
     /** #115: wall-clock markers for the current dictation's user-perceived, stop-tap-to-injection
-     *  timeline. Set the instant [activeToken] is minted (stop tap, or the max-duration auto-stop
-     *  path's synthetic "stop") and consumed once in [finishInjection] to write the end-to-end
-     *  [PipelineStage] benchmark line, then cleared so a later, unrelated retry-tap injectText()
-     *  call (e.g. [onFeedbackTapped]'s raw-text retry) doesn't attribute stale timing to itself.
-     *  A plain field (not a per-token map) is safe here because exactly one dictation is ever
-     *  in flight at a time -- [guard]/[activeToken] already enforce that invariant everywhere
-     *  else in this class. */
-    @Volatile private var pipelineTiming: PipelineTiming? = null
+     *  timeline. Started the instant [activeToken] is minted (stop tap, or the max-duration
+     *  auto-stop path's synthetic "stop") and consumed once in [finishInjection] to write the
+     *  end-to-end [PipelineStage] benchmark line. Every non-happy-path exit -- no speech
+     *  detected, long-press cancel, watchdog timeout, transcription-chain failure -- abandons the
+     *  timeline instead of leaving it populated (H2, #192), so a later, unrelated injectText()
+     *  call (e.g. [onFeedbackTapped]'s raw-text retry) can never attribute stale timing to
+     *  itself. A single slot (not a per-token map) is safe here because exactly one dictation is
+     *  ever in flight at a time -- [guard]/[activeToken] already enforce that invariant
+     *  everywhere else in this class. */
+    private val pipelineTiming = PipelineTimingSlot()
     private val handler = Handler(Looper.getMainLooper())
     private val hideFeedback = Runnable {
         setFeedbackTouchable(false)
@@ -2159,7 +2196,7 @@ class WhisperAccessibilityService : AccessibilityService() {
     private fun stopAndTranscribe() {
         if (!stateMachine.tryStartTranscribing()) return
         activeToken = guard.start()
-        pipelineTiming = PipelineTiming(stopTapAtMs = System.currentTimeMillis(), correlationId = correlationIdFor(activeToken))
+        pipelineTiming.start(PipelineTiming(stopTapAtMs = System.currentTimeMillis(), correlationId = correlationIdFor(activeToken)))
         armWatchdog(activeToken)
         enterTranscribingUi()
     }
@@ -2232,6 +2269,9 @@ class WhisperAccessibilityService : AccessibilityService() {
     private fun cancelTranscription() {
         if (stateMachine.current() != RecordingStateMachine.State.TRANSCRIBING) return
         inFlightCall.cancel()
+        // H2 (#192): this dictation will never reach finishInjection, so drop its timeline now --
+        // otherwise the next unrelated injection would consume it as its own.
+        pipelineTiming.abandon()
         resetToIdle()
         toast("Transcription cancelled")
     }
@@ -2247,6 +2287,9 @@ class WhisperAccessibilityService : AccessibilityService() {
             watchdogRunnable = null
             if (guard.isCurrent(token)) {
                 inFlightCall.cancel()
+                // H2 (#192): a timed-out dictation never reaches finishInjection; drop its
+                // timeline so a later unrelated injection can't consume it.
+                pipelineTiming.abandon()
                 resetToIdle()
                 toast("Transcription timed out")
             }
@@ -2265,13 +2308,12 @@ class WhisperAccessibilityService : AccessibilityService() {
         cancelWatchdog()
         guard.cancel()
         activeToken = 0
-        // #115: deliberately NOT cleared here. resetToIdle() runs immediately after beginPreview()
+        // #115: deliberately NOT abandoned here. resetToIdle() runs immediately after beginPreview()
         // too (preview-before-inject, #40) -- well before the real injectText() call that resolves
-        // the preview, possibly seconds later on a timeout. Clearing here would silently drop
-        // pipeline timing for every previewed dictation. Left to be consumed once by
-        // finishInjection() (which nulls it after reading) or naturally overwritten by the next
-        // dictation's stopAndTranscribe()/startMaxDurationTranscription() -- see pipelineTiming's
-        // kdoc for why a stale value can never be misattributed to an unrelated injectText() call.
+        // the preview, possibly seconds later on a timeout. Abandoning here would silently drop
+        // pipeline timing for every previewed dictation. Instead each non-happy-path exit
+        // (cancel, watchdog, no-speech, reset(msg)) calls pipelineTiming.abandon() itself (H2,
+        // #192), and the happy path consumes exactly once in finishInjection().
         stateMachine.reset()
         setBusy(false)
         setAppearance(COLOR_IDLE)
@@ -2290,7 +2332,7 @@ class WhisperAccessibilityService : AccessibilityService() {
         // this reader thread, rather than waiting for the main-thread token resolution below --
         // resolveLateRecordingOnMain's hop can add a real, variable delay that would otherwise be
         // silently folded into this measurement.
-        pipelineTiming = pipelineTiming?.copy(drainAtMs = System.currentTimeMillis())
+        pipelineTiming.markDrained(System.currentTimeMillis())
 
         val token = when {
             activeToken != 0 && guard.isCurrent(activeToken) -> activeToken
@@ -2352,7 +2394,7 @@ class WhisperAccessibilityService : AccessibilityService() {
             // happened (this whole branch runs after onRecordingFinished already returned) before
             // any pipelineTiming existed to record it against.
             val nowMs = System.currentTimeMillis()
-            pipelineTiming = PipelineTiming(stopTapAtMs = nowMs, correlationId = correlationIdFor(token), drainAtMs = nowMs)
+            pipelineTiming.start(PipelineTiming(stopTapAtMs = nowMs, correlationId = correlationIdFor(token), drainAtMs = nowMs))
             armWatchdog(token)
             enterTranscribingUi()
             toast("Recording limit reached (10 min) — transcribing…")
@@ -2364,6 +2406,17 @@ class WhisperAccessibilityService : AccessibilityService() {
         val file = result.pcmFile
         if (file == null) { reset("No audio captured"); return }
         if (result.errorMessage != null) Log.e(TAG, "Recording ended with error: ${result.errorMessage}")
+
+        // M3a (#192): a recording under the minimum duration floor (~300ms of PCM) cannot contain
+        // usable speech -- discard it with the existing "No speech detected" UX *before* paying
+        // for a full local decode or cloud upload that would only ever produce a blank transcript.
+        if (isBelowMinimumDuration(file.length(), SAMPLE_RATE)) {
+            Log.i(TAG, "Recording below ${MIN_RECORDING_DURATION_MS}ms floor (${file.length()} bytes); discarding")
+            file.delete()
+            result.compressedFile?.delete()
+            reset("No speech detected")
+            return
+        }
 
         val useLocal = prefs().getBoolean("use_local", true)
         val allowCloudFallback = DictationModeToggle.allowCloudFallback(this)
@@ -2750,9 +2803,26 @@ class WhisperAccessibilityService : AccessibilityService() {
 
     private fun handleTranscriptionResult(text: String?, token: Int) {
         if (text.isNullOrBlank()) {
+            // H2 (#192): a no-speech dictation never reaches finishInjection -- abandon its
+            // timing so a later unrelated injection (e.g. feedback-bubble raw-text retry) can't
+            // consume it and write a garbage benchmark line.
+            pipelineTiming.abandon()
             handler.post {
                 if (!guard.isCurrent(token)) return@post
                 toast("No speech detected")
+                resetToIdle()
+            }
+            return
+        }
+
+        // M3b (#192): a non-blank but content-free transcript (ASR hallucinations like "." or
+        // "you"-length fragments) has nothing for a cleanup model to improve -- running the full
+        // waterfall (network calls, LOCAL_LLM load) on it is pure waste. Inject it raw directly.
+        if (isJunkTranscript(text)) {
+            Log.i(TAG, "Transcript is content-free (len=${text.length}); skipping cleanup waterfall")
+            handler.post {
+                if (!guard.isCurrent(token)) return@post
+                injectText(text)
                 resetToIdle()
             }
             return
@@ -2949,6 +3019,10 @@ class WhisperAccessibilityService : AccessibilityService() {
      *  bytes captured, or missing API key) -- so it hops (#72). */
     private fun reset(msg: String) {
         toast(msg)
+        // H2 (#192): every reset(msg) call site is a terminal error/give-up exit (no audio, chain
+        // exhausted, recording error, ...) after which no finishInjection will run for this
+        // dictation -- abandon its timing so it can't be misattributed to a later injection.
+        pipelineTiming.abandon()
         handler.post { resetToIdle() }
     }
 
@@ -3236,8 +3310,7 @@ class WhisperAccessibilityService : AccessibilityService() {
         // nulled right after reading) so a later, unrelated retry-tap injectText() call (e.g.
         // onFeedbackTapped's raw-text retry, or a preview commit that runs well after the
         // original stop tap) never attributes this dictation's stale timing to itself.
-        pipelineTiming?.let { timing ->
-            pipelineTiming = null
+        pipelineTiming.consume()?.let { timing ->
             val nowMs = System.currentTimeMillis()
             BenchmarkLogger.log(
                 context = this,

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2156,11 +2156,18 @@ class WhisperAccessibilityService : AccessibilityService() {
         val engine = RecordingEngine(cacheDir, stateMachine)
         val started = engine.start(
             onFinished = { result ->
-                silenceAutoStopSession?.release()
-                silenceAutoStopSession = null
-                val compressedFile = aacEncoderSession?.finish()
-                aacEncoderSession?.release()
-                aacEncoderSession = null
+                // H1 (#193): release the per-recording LOCALS captured by this closure, never the
+                // fields. A reader stalled in AudioRecord.read() can outlive a rapid
+                // cancel->restart; by the time its onFinished runs, the fields already hold the
+                // NEW recording's sessions, and releasing those would kill the new recording's
+                // silence auto-stop and finalize its AAC encoder mid-recording. The fields are
+                // only nulled when they still reference these exact instances -- the same
+                // identity-guard pattern onRecordingFinished uses for `recordingEngine === engine`.
+                autoStopSession?.release()
+                if (silenceAutoStopSession === autoStopSession) silenceAutoStopSession = null
+                val compressedFile = aacSession?.finish()
+                aacSession?.release()
+                if (aacEncoderSession === aacSession) aacEncoderSession = null
                 val finalResult = if (compressedFile != null) result.copy(compressedFile = compressedFile) else result
                 onRecordingFinished(engine, finalResult)
             },

--- a/app/src/test/kotlin/com/trevornk/ramblr/BackupManagerTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/BackupManagerTest.kt
@@ -124,6 +124,8 @@ class BackupManagerTest {
         // targetFiles() is the single source of truth for what a backup contains; this asserts
         // its key set directly rather than exercising I/O, so it fails loudly if a future edit
         // ever adds one of the excluded encrypted stores to the map (GH #103 constraint).
+        // ENTRY_QUALITY_LOG is deliberately NOT in this set since #191: the quality log stores
+        // verbatim dictation text and never rides along in backups.
         val excluded = setOf(
             "ramblr_secure.xml",
             "ramblr_cleanup_credentials.xml",
@@ -132,10 +134,30 @@ class BackupManagerTest {
         val includedKeys = setOf(
             BackupManager.ENTRY_DICTATION_HISTORY,
             BackupManager.ENTRY_BENCHMARK_LOG,
-            BackupManager.ENTRY_QUALITY_LOG,
             BackupManager.ENTRY_PREFS,
         )
         assertTrue(excluded.none { it in includedKeys })
+    }
+
+    @Test fun `a legacy backup containing a quality log entry is skipped on restore, not written (#191)`() {
+        // Old backups (pre-#191) legitimately contain quality_log.jsonl. Restoring one against
+        // the current target set must report that entry as skipped rather than resurrecting
+        // transcript text onto a device whose quality logging may be (and defaults to) off.
+        val legacyQualityLog = tempFile("legacy_quality", "{\"rawText\":\"old dictated words\"}\n")
+        val dest = File.createTempFile("backup", ".zip").apply { deleteOnExit(); delete() }
+        BackupManager.zipFiles(dest, mapOf(BackupManager.ENTRY_QUALITY_LOG to legacyQualityLog))
+
+        val restoreTarget = File.createTempFile("restore_quality", ".tmp").apply { deleteOnExit(); delete() }
+        val result = dest.inputStream().use { input ->
+            // Mirror targetFiles()' current key set: no ENTRY_QUALITY_LOG key.
+            BackupManager.unzipToTargets(input, mapOf(BackupManager.ENTRY_PREFS to restoreTarget))
+        }
+
+        assertTrue(result.restoredEntries.isEmpty())
+        assertEquals(setOf(BackupManager.ENTRY_QUALITY_LOG), result.skippedEntries)
+        assertFalse(restoreTarget.exists())
+
+        legacyQualityLog.delete(); dest.delete()
     }
 
     // --- parsePrefsXml (regression: restore silently returning seeded defaults, #103 follow-up) ---

--- a/app/src/test/kotlin/com/trevornk/ramblr/DictationGatesTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/DictationGatesTest.kt
@@ -1,0 +1,82 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** M3 (#192): the cheap pre-pipeline gates for dictations that can't produce useful text. */
+class DictationGatesTest {
+
+    // --- isBelowMinimumDuration (M3a): 16kHz mono 16-bit PCM = 32 bytes per ms ---
+
+    private val sampleRate = RecordingEngine.SAMPLE_RATE
+
+    @Test fun `zero bytes is below the floor`() {
+        assertTrue(isBelowMinimumDuration(0L, sampleRate))
+    }
+
+    @Test fun `a 200ms recording is below the 300ms floor`() {
+        val bytes200ms = 200L * 32
+        assertTrue(isBelowMinimumDuration(bytes200ms, sampleRate))
+    }
+
+    @Test fun `one byte under the floor is still below it`() {
+        val floorBytes = MIN_RECORDING_DURATION_MS * 32
+        assertTrue(isBelowMinimumDuration(floorBytes - 1, sampleRate))
+    }
+
+    @Test fun `exactly the floor is not below it`() {
+        val floorBytes = MIN_RECORDING_DURATION_MS * 32
+        assertFalse(isBelowMinimumDuration(floorBytes, sampleRate))
+    }
+
+    @Test fun `a normal 3s dictation clears the floor easily`() {
+        assertFalse(isBelowMinimumDuration(3_000L * 32, sampleRate))
+    }
+
+    @Test fun `floor scales with the sample rate, not a hardcoded byte count`() {
+        // At 8kHz (16 bytes/ms) the same byte count holds twice the audio.
+        val bytes200msAt16k = 200L * 32
+        assertFalse("200ms of 16kHz bytes is 400ms at 8kHz", isBelowMinimumDuration(bytes200msAt16k, 8_000))
+    }
+
+    // --- isJunkTranscript (M3b): content-free transcripts skip the cleanup waterfall ---
+
+    @Test fun `punctuation-only hallucinations are junk`() {
+        assertTrue(isJunkTranscript("."))
+        assertTrue(isJunkTranscript("…"))
+        assertTrue(isJunkTranscript("?!"))
+        assertTrue(isJunkTranscript(" . "))
+        assertTrue(isJunkTranscript("- --"))
+    }
+
+    @Test fun `single characters are junk even when alphanumeric`() {
+        assertTrue(isJunkTranscript("a"))
+        assertTrue(isJunkTranscript("5"))
+        assertTrue(isJunkTranscript(" a "))
+    }
+
+    @Test fun `real short words are not junk`() {
+        assertFalse(isJunkTranscript("ok"))
+        assertFalse(isJunkTranscript("no"))
+        assertFalse(isJunkTranscript("you"))
+    }
+
+    @Test fun `two chars with a digit are not junk`() {
+        assertFalse(isJunkTranscript("a 5"))
+        assertFalse(isJunkTranscript("42"))
+    }
+
+    @Test fun `normal sentences are not junk`() {
+        assertFalse(isJunkTranscript("send the report by five"))
+    }
+
+    @Test fun `whitespace padding does not rescue junk`() {
+        assertTrue(isJunkTranscript("   .   "))
+    }
+
+    @Test fun `non-latin letters count as content`() {
+        assertFalse(isJunkTranscript("日本"))
+        assertFalse(isJunkTranscript("да"))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/ModelCatalogResolverTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ModelCatalogResolverTest.kt
@@ -242,9 +242,10 @@ class BundledDefaultModelCatalogTest {
         assertTrue(anthropicTranscription.isEmpty())
     }
 
-    @Test fun `OpenAI's cheapest tier -- nano -- is recommended, not the pricier mini tier`() {
+    @Test fun `OpenAI's cheapest tier -- luna -- is recommended, not the pricier mini tier`() {
+        // v4 (2026-08-25, #194): gpt-5.6-luna superseded gpt-5.4-nano as OpenAI's cheapest tier.
         val recommended = ModelCatalogResolver.recommendedEntryFor(BUNDLED_DEFAULT_MODEL_CATALOG, ProviderKind.OPENAI)
-        assertEquals("gpt-5.4-nano", recommended?.modelId)
+        assertEquals("gpt-5.6-luna", recommended?.modelId)
     }
 
     @Test fun `OpenAI's recommended transcription entry is gpt-transcribe and matches the shipped code default`() {
@@ -258,10 +259,21 @@ class BundledDefaultModelCatalogTest {
         assertEquals(TranscriberClient.DEFAULT_MODEL, recommended[0].modelId)
     }
 
-    @Test fun `Gemini's cheapest tier -- flash-lite -- is recommended and transcription-capable`() {
-        val recommended = ModelCatalogResolver.recommendedEntryFor(BUNDLED_DEFAULT_MODEL_CATALOG, ProviderKind.GEMINI)
-        assertEquals("gemini-3.1-flash-lite", recommended?.modelId)
-        assertTrue(recommended!!.useCase.supportsTranscription())
+    @Test fun `Gemini's recommended cleanup pick matches the shipped cleanup default`() {
+        // v4 (2026-08-25, #194): cleanup and transcription defaults deliberately diverge.
+        // The top CLEANUP entry must match GeminiCleanupProvider.DEFAULT_MODEL...
+        val cleanup = ModelCatalogResolver.entriesFor(BUNDLED_DEFAULT_MODEL_CATALOG, ProviderKind.GEMINI, ModelUseCase.CLEANUP)
+        assertEquals("gemini-3.5-flash-lite", cleanup.first().modelId)
+        assertEquals(GeminiCleanupProvider.DEFAULT_MODEL, cleanup.first().modelId)
+    }
+
+    @Test fun `Gemini's recommended transcription pick stays the faster 3-1-flash-lite and matches the shipped audio default`() {
+        // ...while the top TRANSCRIPTION entry stays gemini-3.1-flash-lite: 3.5-flash-lite is
+        // ~3x slower on audio input, so the audio path deliberately keeps the faster model.
+        val transcription = ModelCatalogResolver.entriesFor(BUNDLED_DEFAULT_MODEL_CATALOG, ProviderKind.GEMINI, ModelUseCase.TRANSCRIPTION)
+        assertEquals("gemini-3.1-flash-lite", transcription.first().modelId)
+        assertEquals(GeminiTranscriberClient.DEFAULT_MODEL, transcription.first().modelId)
+        assertTrue(transcription.first().useCase.supportsTranscription())
     }
 
     @Test fun `the catalog round-trips through JSON serialization unchanged`() {

--- a/app/src/test/kotlin/com/trevornk/ramblr/PipelineTimingSlotTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/PipelineTimingSlotTest.kt
@@ -1,0 +1,94 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * H2 (#192): the pipeline-timing lifecycle. The bug being locked out: a dictation ending on a
+ * non-happy path (no speech, cancel, watchdog, transcription error) left its timing populated,
+ * so the next unrelated injection consumed it and wrote a benchmark line measured from the
+ * previous, abandoned dictation's stop tap.
+ */
+class PipelineTimingSlotTest {
+
+    private fun timing(stopTapAtMs: Long = 1_000L, correlationId: String = "tok-1") =
+        PipelineTiming(stopTapAtMs = stopTapAtMs, correlationId = correlationId)
+
+    @Test fun `consume returns the started timing exactly once`() {
+        val slot = PipelineTimingSlot()
+        val t = timing()
+        slot.start(t)
+        assertEquals(t, slot.consume())
+        assertNull("second consume must return nothing -- consumed exactly once", slot.consume())
+    }
+
+    @Test fun `abandon clears the timing so a later injection consumes nothing`() {
+        // The cancel/watchdog/no-speech/error scenario: timing was started, the dictation died
+        // before finishInjection, and the next injection's consume() must come up empty instead
+        // of inheriting the dead dictation's stop-tap anchor.
+        val slot = PipelineTimingSlot()
+        slot.start(timing(correlationId = "tok-cancelled"))
+        slot.abandon()
+        assertNull(slot.consume())
+    }
+
+    @Test fun `markDrained stamps the drain instant onto the active timing`() {
+        val slot = PipelineTimingSlot()
+        slot.start(timing(stopTapAtMs = 5_000L))
+        slot.markDrained(5_250L)
+        assertEquals(5_250L, slot.consume()?.drainAtMs)
+    }
+
+    @Test fun `markDrained without an active timing is a no-op`() {
+        val slot = PipelineTimingSlot()
+        slot.markDrained(9_999L)
+        assertNull(slot.consume())
+    }
+
+    @Test fun `markDrained after abandon does not resurrect the timing`() {
+        // Reader-thread drain racing a main-thread cancel: the drain marker must not bring a
+        // dead timeline back to life.
+        val slot = PipelineTimingSlot()
+        slot.start(timing())
+        slot.abandon()
+        slot.markDrained(2_000L)
+        assertNull(slot.consume())
+    }
+
+    @Test fun `a new start replaces whatever was left behind`() {
+        val slot = PipelineTimingSlot()
+        slot.start(timing(correlationId = "tok-old"))
+        val fresh = timing(stopTapAtMs = 42L, correlationId = "tok-new")
+        slot.start(fresh)
+        assertEquals(fresh, slot.consume())
+    }
+
+    @Test fun `abandon on an empty slot is safe`() {
+        val slot = PipelineTimingSlot()
+        slot.abandon() // must not throw
+        assertNull(slot.consume())
+    }
+
+    @Test fun `preview flow survives - timing started before a preview is still consumable after it resolves`() {
+        // resetToIdle() deliberately does NOT abandon (#115/#40): a previewed dictation resets to
+        // idle immediately but its real injectText() runs seconds later on commit/timeout. The
+        // slot must hold the timing across that gap; only explicit abandon() drops it.
+        val slot = PipelineTimingSlot()
+        val t = timing(correlationId = "tok-previewed")
+        slot.start(t)
+        slot.markDrained(1_100L)
+        // ... beginPreview() + resetToIdle() happen here, neither touches the slot ...
+        assertEquals(t.copy(drainAtMs = 1_100L), slot.consume())
+    }
+
+    @Test fun `slot state checks used above are self-consistent`() {
+        val slot = PipelineTimingSlot()
+        assertNull(slot.consume())
+        slot.start(timing())
+        assertFalse(slot.consume() == null)
+        assertTrue(slot.consume() == null)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorTest.kt
@@ -194,6 +194,25 @@ class PostProcessorTest {
     }
 
     @Test
+    fun buildRequestBodyAutoOmitsTemperatureForGpt56FamilyByDefault() {
+        // #194: with gpt-5.6-luna now a shipped cleanup default, the production path
+        // (CleanupWaterfallExecutor doesn't pass omitTemperature) must omit temperature for the
+        // 5.6 family automatically, or every cleanup call would fail with "Unsupported value".
+        val body = PostProcessor.buildRequestBody("raw text", "system prompt", "gpt-5.6-luna")
+        assertFalse(body.has("temperature"))
+    }
+
+    @Test
+    fun rejectsTemperatureCoversReasoningFamiliesButNotCurrentDefaults() {
+        assertTrue(PostProcessor.rejectsTemperature("gpt-5.6-luna"))
+        assertTrue(PostProcessor.rejectsTemperature("gpt-5.6-terra"))
+        assertTrue(PostProcessor.rejectsTemperature("o1-mini"))
+        assertFalse(PostProcessor.rejectsTemperature("gpt-5.4-mini"))
+        assertFalse(PostProcessor.rejectsTemperature("gpt-5.4-nano"))
+        assertFalse(PostProcessor.rejectsTemperature("omniroute-local-7b"))
+    }
+
+    @Test
     fun buildRequestBodyIncludesTemperatureByDefaultForBackcompat() {
         // Every existing call site (CleanupWaterfallExecutor) doesn't pass omitTemperature, so
         // the default must keep including it -- this is the real production request shape today.

--- a/app/src/test/kotlin/com/trevornk/ramblr/ProviderChainMigrationTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/ProviderChainMigrationTest.kt
@@ -37,9 +37,11 @@ class ProviderChainMigrationTest {
     }
 
     @Test fun `leaves a deliberate custom advanced model id untouched`() {
-        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano")))
+        // gpt-5.4-nano was this test's stand-in custom id until v4 made it a genuinely
+        // superseded shipped default -- use an id that was never shipped instead.
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "my-finetuned-cleanup-model")))
         val migrated = ProviderChainMigration.migrate(chain)
-        assertEquals("gpt-5.4-nano", migrated.entries[0].model)
+        assertEquals("my-finetuned-cleanup-model", migrated.entries[0].model)
     }
 
     @Test fun `leaves LOCAL and OMNIROUTE entries untouched regardless of model id`() {
@@ -92,7 +94,9 @@ class ProviderChainMigrationTest {
     // --- v2 (#101/#102): transcriptionModel seeding ---
 
     @Test fun `seeds a null transcriptionModel with the current OpenAI transcription default`() {
-        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano")))
+        // gpt-5.6-luna is the current OpenAI cleanup default (v4) -- an id the migration leaves
+        // alone, so this test stays pinned to the transcriptionModel-seeding behavior only.
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna")))
         val migrated = ProviderChainMigration.migrate(chain)
         assertEquals(TranscriberClient.DEFAULT_MODEL, migrated.entries[0].transcriptionModel)
     }
@@ -105,7 +109,7 @@ class ProviderChainMigrationTest {
 
     @Test fun `does not overwrite an already-set transcriptionModel`() {
         val chain = ProviderChain(listOf(
-            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano", transcriptionModel = "whisper-1"),
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna", transcriptionModel = "whisper-1"),
         ))
         val migrated = ProviderChainMigration.migrate(chain)
         assertEquals("whisper-1", migrated.entries[0].transcriptionModel)
@@ -141,16 +145,16 @@ class ProviderChainMigrationTest {
 
     @Test fun `rewrites a v2-seeded gpt-4o-transcribe transcriptionModel to gpt-transcribe`() {
         val chain = ProviderChain(listOf(
-            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano", transcriptionModel = "gpt-4o-transcribe"),
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna", transcriptionModel = "gpt-4o-transcribe"),
         ))
         val migrated = ProviderChainMigration.migrate(chain)
-        assertEquals("gpt-5.4-nano", migrated.entries[0].model) // cleanup model untouched
+        assertEquals("gpt-5.6-luna", migrated.entries[0].model) // cleanup model untouched
         assertEquals("gpt-transcribe", migrated.entries[0].transcriptionModel)
     }
 
     @Test fun `does NOT rewrite a deliberate whisper-1 transcriptionModel -- only the seeded default is superseded`() {
         val chain = ProviderChain(listOf(
-            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano", transcriptionModel = "whisper-1"),
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna", transcriptionModel = "whisper-1"),
         ))
         val migrated = ProviderChainMigration.migrate(chain)
         assertEquals("whisper-1", migrated.entries[0].transcriptionModel)
@@ -158,7 +162,7 @@ class ProviderChainMigrationTest {
 
     @Test fun `an already-current gpt-transcribe transcriptionModel is untouched`() {
         val chain = ProviderChain(listOf(
-            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano", transcriptionModel = "gpt-transcribe"),
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna", transcriptionModel = "gpt-transcribe"),
         ))
         val migrated = ProviderChainMigration.migrate(chain)
         assertEquals(chain, migrated)
@@ -167,7 +171,7 @@ class ProviderChainMigrationTest {
     @Test fun `preserves baseUrlOverride when rewriting the transcriptionModel`() {
         val chain = ProviderChain(listOf(
             ProviderChainEntry(
-                ProviderKind.OPENAI, "gpt-5.4-nano",
+                ProviderKind.OPENAI, "gpt-5.6-luna",
                 baseUrlOverride = "https://example.com/v1",
                 transcriptionModel = "gpt-4o-transcribe",
             ),
@@ -175,5 +179,72 @@ class ProviderChainMigrationTest {
         val migrated = ProviderChainMigration.migrate(chain)
         assertEquals("gpt-transcribe", migrated.entries[0].transcriptionModel)
         assertEquals("https://example.com/v1", migrated.entries[0].baseUrlOverride)
+    }
+
+    // --- v4 (2026-08-25, #194): cleanup-default refresh ---
+
+    @Test fun `rewrites a superseded gpt-5-4-nano cleanup model to gpt-5-6-luna`() {
+        val chain = ProviderChain(listOf(
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-nano", transcriptionModel = "gpt-transcribe"),
+        ))
+        val migrated = ProviderChainMigration.migrate(chain)
+        assertEquals("gpt-5.6-luna", migrated.entries[0].model)
+        // Transcription side untouched by a cleanup-model rewrite.
+        assertEquals("gpt-transcribe", migrated.entries[0].transcriptionModel)
+    }
+
+    @Test fun `rewrites a superseded gemini-3-1-flash-lite cleanup model to the current Gemini cleanup default`() {
+        val chain = ProviderChain(listOf(
+            ProviderChainEntry(ProviderKind.GEMINI, "gemini-3.1-flash-lite", transcriptionModel = "gemini-3.1-flash-lite"),
+        ))
+        val migrated = ProviderChainMigration.migrate(chain)
+        assertEquals(GeminiCleanupProvider.DEFAULT_MODEL, migrated.entries[0].model)
+        assertEquals("gemini-3.5-flash-lite", migrated.entries[0].model)
+    }
+
+    @Test fun `NEVER rewrites a gemini-3-1-flash-lite transcriptionModel -- the audio path deliberately stays on the faster model`() {
+        // The whole point of keeping SUPERSEDED_TRANSCRIPTION_MODELS empty for this refresh:
+        // gemini-3.5-flash-lite is ~3x slower on audio input, so a device's transcription model
+        // (seeded or picked) must keep gemini-3.1-flash-lite even while the cleanup field of the
+        // very same entry is upgraded.
+        val chain = ProviderChain(listOf(
+            ProviderChainEntry(ProviderKind.GEMINI, "gemini-3.1-flash-lite", transcriptionModel = "gemini-3.1-flash-lite"),
+        ))
+        val migrated = ProviderChainMigration.migrate(chain)
+        assertEquals("gemini-3.1-flash-lite", migrated.entries[0].transcriptionModel)
+        assertEquals(GeminiTranscriberClient.DEFAULT_MODEL, migrated.entries[0].transcriptionModel)
+    }
+
+    @Test fun `a Gemini entry rewritten for cleanup still seeds a null transcriptionModel with the FAST audio default`() {
+        // Pre-#101 shared-field-era chain: `model` held gemini-3.1-flash-lite and
+        // transcriptionModel was never set. The cleanup rewrite must not leak into the audio
+        // seeding -- the seeded value comes from GeminiTranscriberClient.DEFAULT_MODEL
+        // (3.1-flash-lite), not from the rewritten cleanup model.
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.GEMINI, "gemini-3.1-flash-lite")))
+        val migrated = ProviderChainMigration.migrate(chain)
+        assertEquals("gemini-3.5-flash-lite", migrated.entries[0].model)
+        assertEquals("gemini-3.1-flash-lite", migrated.entries[0].transcriptionModel)
+    }
+
+    @Test fun `an already-current gpt-5-6-luna cleanup model is untouched`() {
+        val chain = ProviderChain(listOf(
+            ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.6-luna", transcriptionModel = "gpt-transcribe"),
+        ))
+        assertEquals(chain, ProviderChainMigration.migrate(chain))
+    }
+
+    @Test fun `an already-current gemini-3-5-flash-lite cleanup model is untouched`() {
+        val chain = ProviderChain(listOf(
+            ProviderChainEntry(ProviderKind.GEMINI, "gemini-3.5-flash-lite", transcriptionModel = "gemini-3.1-flash-lite"),
+        ))
+        assertEquals(chain, ProviderChainMigration.migrate(chain))
+    }
+
+    @Test fun `v4 does not touch a gpt-5-4-nano id on the WRONG provider kind`() {
+        // Exact (kind, model) matching: an OmniRoute/custom route that happens to carry the same
+        // literal id is not a shipped OpenAI default and must survive untouched.
+        val chain = ProviderChain(listOf(ProviderChainEntry(ProviderKind.OMNIROUTE, "gpt-5.4-nano")))
+        val migrated = ProviderChainMigration.migrate(chain)
+        assertEquals("gpt-5.4-nano", migrated.entries[0].model)
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/QualityLoggerTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/QualityLoggerTest.kt
@@ -138,4 +138,78 @@ class QualityLoggerTest {
         QualityLogger.rotateIfNeeded(file) // must not throw
         assertFalse(file.exists())
     }
+
+    // --- Opt-in gate (#191) ---
+
+    @Test fun `log is disabled by default and writes nothing`() {
+        val file = File.createTempFile("quality_log_gate", ".jsonl").apply { delete() }
+        try {
+            QualityLogger.log(
+                FakeSharedPreferences(), file,
+                correlationId = "tok-gate-1",
+                rawText = "words that must never be persisted without opt-in",
+            )
+            assertFalse("disabled QualityLogger.log must not create the file", file.exists())
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test fun `log writes nothing when the pref is explicitly false`() {
+        val file = File.createTempFile("quality_log_gate", ".jsonl").apply { delete() }
+        try {
+            val prefs = FakeSharedPreferences(mutableMapOf(QualityLogger.KEY_ENABLED to false))
+            QualityLogger.log(prefs, file, correlationId = "tok-gate-2", rawText = "still gated")
+            assertFalse(file.exists())
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test fun `log appends a parseable line when the pref is enabled`() {
+        val file = File.createTempFile("quality_log_gate", ".jsonl").apply { delete() }
+        try {
+            val prefs = FakeSharedPreferences(mutableMapOf(QualityLogger.KEY_ENABLED to true))
+            QualityLogger.log(
+                prefs, file,
+                correlationId = "tok-gate-3",
+                transcription = QualityStage("OPENAI", "gpt-transcribe"),
+                rawText = "opted-in words",
+            )
+            assertTrue("enabled QualityLogger.log must write the file", file.exists())
+            val json = JSONObject(file.readText().trim())
+            assertEquals("tok-gate-3", json.getString("correlationId"))
+            assertEquals("opted-in words", json.getString("rawText"))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test fun `isEnabled defaults to false and reflects the stored value`() {
+        assertFalse(QualityLogger.isEnabled(FakeSharedPreferences()))
+        assertTrue(QualityLogger.isEnabled(FakeSharedPreferences(mutableMapOf(QualityLogger.KEY_ENABLED to true))))
+    }
+
+    /** Minimal in-memory [android.content.SharedPreferences] fake — boolean-only surface,
+     *  mirroring the one in [DebugVisibilityToggleTest]. */
+    private class FakeSharedPreferences(
+        private val values: MutableMap<String, Any?> = mutableMapOf()
+    ) : android.content.SharedPreferences {
+        override fun getAll(): MutableMap<String, *> = values
+        override fun getString(key: String?, defValue: String?): String? = throw UnsupportedOperationException()
+        override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+            throw UnsupportedOperationException()
+        override fun getInt(key: String?, defValue: Int): Int = throw UnsupportedOperationException()
+        override fun getLong(key: String?, defValue: Long): Long = throw UnsupportedOperationException()
+        override fun getFloat(key: String?, defValue: Float): Float = throw UnsupportedOperationException()
+        override fun getBoolean(key: String?, defValue: Boolean): Boolean = values[key] as? Boolean ?: defValue
+        override fun contains(key: String?): Boolean = values.containsKey(key)
+        override fun edit(): android.content.SharedPreferences.Editor = throw UnsupportedOperationException()
+        override fun registerOnSharedPreferenceChangeListener(
+            listener: android.content.SharedPreferences.OnSharedPreferenceChangeListener?
+        ) {}
+        override fun unregisterOnSharedPreferenceChangeListener(
+            listener: android.content.SharedPreferences.OnSharedPreferenceChangeListener?
+        ) {}
+    }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/tools/EvalHarness.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/tools/EvalHarness.kt
@@ -66,15 +66,11 @@ private enum class Provider(val label: String, val apiKeyEnv: String, val models
     GEMINI("gemini", "GEMINI_API_KEY", "GEMINI_EVAL_MODELS", listOf("gemini-2.5-flash-lite", "gemini-2.5-flash")),
 }
 
-/** Model-id prefixes known to reject a non-default `temperature` (#106) -- OpenAI's reasoning
- *  model families (o1/o3/o4, and now GPT-5.6). Deliberately an explicit prefix list rather than
- *  a broad regex: a false negative here just means a benchmark run fails loudly with a clear
- *  "Unsupported value" error and needs a one-line addition, which is much safer than a false
- *  positive silently omitting temperature from a model that actually wanted it. */
-private val TEMPERATURE_REJECTING_OPENAI_PREFIXES = listOf("o1", "o3", "o4", "gpt-5.6")
-
+/** Delegates to the single production list in [PostProcessor.rejectsTemperature] (#106/#194) --
+ *  this harness previously carried its own copy, which is exactly the drift the production
+ *  helper was extracted to prevent. */
 private fun openAiRejectsTemperature(model: String): Boolean =
-    TEMPERATURE_REJECTING_OPENAI_PREFIXES.any { model.startsWith(it) }
+    PostProcessor.rejectsTemperature(model)
 
 /** Calls OpenAI's real `/v1/chat/completions`, reusing [PostProcessor]'s request/response shape. */
 private fun callOpenAi(apiKey: String, model: String, prompt: String, text: String): PostProcessor.Result {

--- a/model-catalog.json
+++ b/model-catalog.json
@@ -4,10 +4,10 @@
     "tier": "RECOMMENDED",
     "costPer1MInputUsd": 0.05,
     "provider": "OPENAI",
-    "modelId": "gpt-5.4-nano",
-    "displayName": "GPT-5.4 Nano",
+    "modelId": "gpt-5.6-luna",
+    "displayName": "GPT-5.6 Luna",
     "costPer1MOutputUsd": 0.4,
-    "description": "Fastest, cheapest \u2014 benchmark-confirmed indistinguishable from Mini for cleanup quality."
+    "description": "OpenAI's current cheapest tier (successor of GPT-5.4 Nano) \u2014 fastest and cheapest for cleanup."
   },
   {
     "useCase": "CLEANUP",
@@ -17,7 +17,7 @@
     "modelId": "gpt-5.4-mini",
     "displayName": "GPT-5.4 Mini",
     "costPer1MOutputUsd": 2,
-    "description": "One tier up from Nano \u2014 same real-world cleanup quality, costs more."
+    "description": "Previous-generation mid tier \u2014 same real-world cleanup quality, costs more."
   },
   {
     "useCase": "TRANSCRIPTION",
@@ -50,6 +50,16 @@
     "description": "OpenAI's original ASR model \u2014 highest error rate of the three; only pick it if you specifically need its legacy output formats."
   },
   {
+    "useCase": "CLEANUP",
+    "tier": "RECOMMENDED",
+    "costPer1MInputUsd": 0.25,
+    "provider": "GEMINI",
+    "modelId": "gemini-3.5-flash-lite",
+    "displayName": "Gemini 3.5 Flash-Lite",
+    "costPer1MOutputUsd": 1.5,
+    "description": "Cheapest Gemini tier (GA July 2026) \u2014 current cleanup pick. Deliberately not used for transcription: it's ~3x slower than 3.1 Flash-Lite on audio input."
+  },
+  {
     "useCase": "BOTH",
     "tier": "RECOMMENDED",
     "costPer1MInputUsd": 0.25,
@@ -57,7 +67,7 @@
     "modelId": "gemini-3.1-flash-lite",
     "displayName": "Gemini 3.1 Flash-Lite",
     "costPer1MOutputUsd": 1.5,
-    "description": "Cheapest Gemini tier \u2014 Google's documented replacement for 2.5 Flash-Lite (which is deprecating); improved audio input for ASR, handles transcription too."
+    "description": "Recommended for transcription \u2014 much faster than 3.5 Flash-Lite on audio input; improved audio input for ASR. Still fine for cleanup too."
   },
   {
     "useCase": "BOTH",


### PR DESCRIPTION
Four focused fix slices from the 2026-08-25 read-only pipeline audit (main @ 593d282), one commit per slice. Full suite green (1388 tests, 0 failures) and `assembleGithubRelease` builds successfully on the branch head.

## Slice 1 — Privacy gate on QualityLogger (a4e2ba6)
Closes #191

QualityLogger persisted every dictation's verbatim raw+cleaned text unconditionally while being described as "opt-in". Now: `quality_log_enabled` pref (default **off**) checked at the top of `log()` via a testable prefs+file seam; a "Save quality log" toggle in Data & Logs (turning it off offers to delete the existing file); `quality_log.jsonl` excluded from backup zips (legacy backups restore it as a skipped entry); PRIVACY.md discloses the log; the stale BenchmarkLogger comment corrected. Tests: gate off-by-default/no-op/enabled paths, backup exclusion + legacy-zip skip.

## Slice 2 — Stale pipelineTiming + junk-dictation gates (ea69069)
Closes #192

**H2:** `pipelineTiming` is now a `PipelineTimingSlot` (start/markDrained/consume/abandon); every non-happy-path exit (cancel, watchdog, no-speech, `reset(msg)` error exits) abandons the timeline, so a later unrelated injection (feedback-bubble raw-text retry etc.) can never consume stale timing and write garbage `injectionAttemptMs`/`totalMs` benchmark lines. Previewed dictations keep their timing across the preview gap (resetToIdle still leaves the slot alone). Kdoc updated to the real lifecycle.

**M3:** new `DictationGates.kt` — recordings under a 300ms PCM floor are discarded with the existing "No speech detected" UX before any transcription; transcripts with no letters/digits or <2 chars skip the cleanup waterfall and inject raw. Tests cover the slot lifecycle and both gates.

## Slice 3 — Superseded-reader session race (44ffa28)
Closes #193

The reader's `onFinished` closure released the session **fields** instead of its own per-recording locals, so a stalled old reader returning after rapid cancel→restart killed the new recording's VAD session and finalized its AAC encoder mid-recording. The closure now releases the captured locals and nulls the fields only under an identity guard (mirrors the existing `recordingEngine === engine` pattern). No new unit test: the closure lives inside the service's recording start path (real AudioRecord/WindowManager deps, no Robolectric in this suite) — noted in the commit message rather than forcing a brittle test.

## Slice 4 — Cloud cleanup default refresh + v4 migration (23b4f98)
Closes #194

- OpenAI cleanup: catalog RECOMMENDED pick `gpt-5.4-nano` → `gpt-5.6-luna`.
- Gemini cleanup: `GeminiCleanupProvider.DEFAULT_MODEL` `gemini-3.1-flash-lite` → `gemini-3.5-flash-lite`, with a new CLEANUP-tagged catalog entry.
- **Transcription deliberately unchanged:** `gpt-transcribe` stays; `GeminiTranscriberClient.DEFAULT_MODEL` stays `gemini-3.1-flash-lite` (3.5-flash-lite is ~3x slower on audio input) — both kdocs document the divergence.
- `ProviderChainMigration` v4: exact-match `SUPERSEDED_MODELS` entries for both old cleanup ids, `MIGRATION_VERSION` → 4, **no** additions to `SUPERSEDED_TRANSCRIPTION_MODELS`. Audio-path safety for pre-#101 shared-field-era chains verified: the Gemini audio call reads `transcriptionModel ?: GeminiTranscriberClient.DEFAULT_MODEL` (never `model`), and a migration test pins that no `transcriptionModel` can ever be flipped to the slower model.
- `gpt-5.6-luna` is in OpenAI's temperature-rejecting 5.6 family (#106), so `PostProcessor.buildRequestBody` now auto-omits temperature via a shared `PostProcessor.rejectsTemperature` helper on the production path (the eval harness's private copy now delegates to it) — the exact follow-up the old kdoc flagged as required before shipping a 5.6-family default.
- `model-catalog.json` regenerated via `ModelCatalogFileSyncTest`.

## Verification
- `./gradlew testGithubDebugUnitTest`: **BUILD SUCCESSFUL — 1388 tests, 0 failures, 0 skipped**
- `./gradlew assembleGithubRelease`: **BUILD SUCCESSFUL** (signed `Ramblr-1.0.25-github-release.apk`, 60.3 MB)
- Not yet verified on hardware: on-device migration proof (saved `provider_chain_entries` JSON + `migration_version` bump via adb) per the migration checklist — no device attached to this run.
