### PR TITLE
Audit slice 6: pipeline hardening (dead 180s trap, LOCAL fall-through, thread hygiene, multi-window injection, wakelock)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,12 @@
     <!-- Install-time, no user prompt: needed to register the default-network callback that
          resets the cleanup waterfall cursor on SSID/VPN changes (#61, ADR-0001). -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Install-time, no user prompt (M6 audit, 2026-08-26): holds a bounded PARTIAL_WAKE_LOCK
+         ("ramblr:transcription") across the recording+transcription window so a screen-off long
+         dictation isn't CPU-throttled mid local decode. Acquired when recording starts, released
+         when the pipeline reaches a terminal state (resetToIdle/onDestroy), with a hard acquire
+         timeout as a leak backstop; see WhisperAccessibilityService.acquireTranscriptionWakeLock. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
@@ -2,6 +2,7 @@ package com.trevornk.ramblr
 
 import android.content.Context
 import java.io.File
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 import org.json.JSONObject
 
@@ -127,6 +128,19 @@ object BenchmarkLogger {
 
     private const val FILE_NAME = "benchmark_log.jsonl"
 
+    /**
+     * All file I/O ([log]'s append + [rotateIfNeeded]'s up-to-[ROTATE_AT_BYTES] read/rewrite)
+     * runs here instead of on the caller's thread (M1 audit, 2026-08-26): finishInjection calls
+     * [log] on the MAIN thread, and a rotation there synchronously read 3MB and rewrote the file
+     * mid-injection. Logging is fire-and-forget, so callers never need the result -- but write
+     * ORDER matters for a line-oriented log, which is why this is a single thread and not a
+     * pool: submissions execute strictly in submission order. Daemon so a lingering queued write
+     * can never hold the process alive.
+     */
+    private val ioExecutor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "BenchmarkLogger-io").apply { isDaemon = true }
+    }
+
     /** Once the log file exceeds this size, it's rotated down to [KEEP_BYTES_AFTER_ROTATION] of
      *  its newest (tail) content rather than growing unbounded across many real-world sessions. */
     const val ROTATE_AT_BYTES = 3 * 1024 * 1024L
@@ -155,6 +169,10 @@ object BenchmarkLogger {
      * All file I/O is wrapped in `runCatching`: this is a diagnostics-only side channel for
      * later analysis, and must never be allowed to crash or block Trevor's actual dictation --
      * a full disk or a transient I/O error here should be silently swallowed, not surfaced.
+     * Since M1 the I/O also runs asynchronously on [ioExecutor], so a caller on the main thread
+     * (finishInjection's pipeline line) pays only for building the JSON line, never for the
+     * append or a 3MB rotation. Timestamp and line content are captured synchronously at call
+     * time; only the disk write is deferred.
      */
     fun log(
         context: Context,
@@ -176,8 +194,12 @@ object BenchmarkLogger {
                 pipeline = pipeline,
             )
             val file = logFile(context)
-            rotateIfNeeded(file)
-            file.appendText(line + "\n")
+            ioExecutor.execute {
+                runCatching {
+                    rotateIfNeeded(file)
+                    file.appendText(line + "\n")
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
@@ -1,16 +1,10 @@
 package com.trevornk.ramblr
 
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.IOException
 
 object PostProcessor {
     data class Result(val text: String?, val error: String?)
-
-    private val client = NetworkClients.shared
 
     /** Default OpenAI-compatible base URL, used when the user hasn't configured a custom one (see #4). */
     const val DEFAULT_BASE_URL = "https://api.openai.com/v1"
@@ -307,64 +301,13 @@ explanations, headers, or comments about your edits.
         }
     }
 
-    fun process(
-        text: String,
-        prompt: String,
-        apiKey: String,
-        cancelHolder: InFlightCall,
-        baseUrl: String = DEFAULT_BASE_URL,
-        model: String = DEFAULT_MODEL,
-        callback: (Result) -> Unit
-    ) {
-        val body = buildRequestBody(text, prompt, model).toString().toRequestBody("application/json".toMediaType())
-
-        // A malformed base URL (or one OkHttp otherwise rejects) throws IllegalArgumentException
-        // from Request.Builder().url() rather than failing the call — caught here so a bad custom
-        // endpoint reports through the same Result/callback path as a network failure, instead of
-        // crashing. See #4.
-        val request = try {
-            Request.Builder()
-                .url(endpointUrl(baseUrl))
-                .header("Authorization", "Bearer $apiKey")
-                .post(body)
-                .build()
-        } catch (e: IllegalArgumentException) {
-            callback(Result(null, "Invalid cleanup endpoint: ${e.message}"))
-            return
-        }
-
-        val call = client.newCall(request)
-        cancelHolder.set(call)
-        call.enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                cancelHolder.clear(call)
-                callback(Result(null, e.message))
-            }
-
-            override fun onResponse(call: Call, response: Response) {
-                cancelHolder.clear(call)
-                // Read via HttpBodyReader (#62): a body read that throws inside onResponse is
-                // swallowed by OkHttp (onFailure never fires), so this callback would otherwise
-                // never be invoked and the dictation would hang until the watchdog.
-                val responseBody = HttpBodyReader.read(response).getOrElse { e ->
-                    callback(Result(null, e.message))
-                    return
-                }
-                if (!response.isSuccessful && responseBody.isBlank()) {
-                    callback(Result(null, "HTTP ${response.code}"))
-                    return
-                }
-                callback(parseResponse(responseBody))
-            }
-        })
-    }
-
     /**
      * Provider-chain entry point for Phase 2 (#95). Every chain -- including a single OPENAI
      * entry -- is adapted to [CleanupWaterfall] and executed by [CleanupWaterfallExecutor],
      * preserving its fail-fast grouping, cursor resume, timeout discipline, and bounded
      * local-inference deadline behavior (#105: a one-step waterfall was previously special-cased
-     * to call [process] directly via [NetworkClients.shared]'s much longer timeouts, bypassing
+     * to call a since-deleted `process()` helper directly via [NetworkClients.shared]'s much
+     * longer timeouts (180s call cap -- the M4 audit trap, removed 2026-08-26), bypassing
      * [CleanupWaterfallExecutor]'s tighter [CleanupStepTimeouts] and hard cap; see
      * [CleanupWaterfallPlanner.groupConsecutive] for why a single-step waterfall is already
      * handled correctly here without any special case).

--- a/app/src/main/kotlin/com/trevornk/ramblr/TranscriptionChain.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/TranscriptionChain.kt
@@ -35,4 +35,23 @@ object TranscriptionChain {
 
     /** True when a candidate after [index] exists in a chain of [candidateCount] candidates. */
     fun hasNextCandidate(index: Int, candidateCount: Int): Boolean = index + 1 < candidateCount
+
+    /**
+     * Whether the PCM recording may be deleted after candidate [candidateIndex]'s outcome (M5
+     * audit, 2026-08-26). The PCM is the *only* copy of the user's audio: once it's gone, no
+     * later candidate can retry, so it must stay alive for exactly as long as the walk might
+     * still need it --
+     *
+     *  - success: the transcript exists, nothing downstream needs audio -- delete.
+     *  - failure with a candidate remaining: the next candidate needs the audio -- keep.
+     *  - failure on the last candidate: the chain is exhausted, the dictation is over -- delete.
+     *
+     * Before M5, `transcribeLocal` deleted the PCM in its `finally` unconditionally, so a LOCAL
+     * candidate that failed post-load took the audio down with it and a configured cloud
+     * candidate after it in the chain had nothing left to transcribe -- the dictation died with
+     * "Local error: ..." instead of falling through. This is the pinned contract that prevents
+     * that class of bug for every candidate kind.
+     */
+    fun shouldDeletePcm(candidateIndex: Int, candidateCount: Int, success: Boolean): Boolean =
+        success || !hasNextCandidate(candidateIndex, candidateCount)
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2493,8 +2493,16 @@ class WhisperAccessibilityService : AccessibilityService() {
      * would otherwise lose local transcription entirely. Short takes are unaffected either way.
      * Since #139 this path also provisions that model itself, so the fallback is a transient
      * state for local-transcription users rather than a permanent one.
+     *
+     * PCM lifetime (M5 audit, 2026-08-26): [file] is deleted here on success (the transcript
+     * exists, nothing downstream needs audio) and on failure of the *direct* pure-local path
+     * ([onChainFailure] null -- nothing could retry, so keeping it would only leak cache). When
+     * the provider-chain walk calls this as a candidate it passes [onChainFailure], taking the
+     * failure-path PCM lifetime for itself: the file is kept alive so the next candidate can
+     * still transcribe it, and [transcribeApi]'s `advanceOrGiveUp` deletes it once the chain is
+     * exhausted -- the [TranscriptionChain.shouldDeletePcm] contract.
      */
-    private fun transcribeLocal(file: File, token: Int) {
+    private fun transcribeLocal(file: File, token: Int, onChainFailure: ((String) -> Unit)? = null) {
         thread {
             // Benchmark-log timing starts before the read/decode too, so a failure there (rare,
             // but possible on a corrupt/truncated PCM file) still gets an honest latency instead
@@ -2533,8 +2541,10 @@ class WhisperAccessibilityService : AccessibilityService() {
                     } ?: throw IllegalStateException("Local model was unloaded during transcription")
                 } finally {
                     vad?.close()
-                    file.delete()
                 }
+                // Success: the transcript exists, so no candidate (chain or otherwise) needs the
+                // audio anymore -- mirrors the delete-on-success the cloud candidates do (M5).
+                file.delete()
                 val ms = System.currentTimeMillis() - t0
                 Log.i(TAG, "Local transcription: ${ms}ms, ${durationSeconds}s audio")
                 BenchmarkLogger.log(
@@ -2582,17 +2592,24 @@ class WhisperAccessibilityService : AccessibilityService() {
                         model = localTranscriptionModelId(),
                     ),
                 )
-                // Local transcription's audio file is already gone (read-then-delete
-                // above), so a cloud fallback here needs the raw PCM again -- but re-reading a
-                // deleted file isn't possible. Since local transcription failure this late
-                // (post-decode) is rare and re-recording is cheap, cloud fallback for
-                // transcription is only wired at the "model not loaded yet" branch in
-                // continueTranscription, not this in-flight-failure path; report the error
-                // honestly instead of silently retrying without audio.
-                handler.post {
-                    if (!guard.isCurrent(token)) return@post // cancelled or watchdog already reset the UI
-                    toast("Local error: ${e.message}")
-                    resetToIdle()
+                if (onChainFailure != null) {
+                    // Chain-candidate path (M5): the PCM is deliberately NOT deleted -- the walk
+                    // owns its lifetime now (see kdoc above), so the next candidate can still
+                    // upload it. advanceOrGiveUp hops to main, re-checks the guard, and either
+                    // advances or deletes the audio and surfaces this error at chain exhaustion.
+                    onChainFailure("Local error: ${e.message}")
+                } else {
+                    // Direct pure-local path (continueTranscription): no chain walk owns the PCM
+                    // and nothing can retry without one, so delete it here and report honestly.
+                    // Cloud fallback for this path is only wired at the "model not loaded yet"
+                    // branch in continueTranscription -- a post-load failure this late is rare
+                    // and re-recording is cheap.
+                    file.delete()
+                    handler.post {
+                        if (!guard.isCurrent(token)) return@post // cancelled or watchdog already reset the UI
+                        toast("Local error: ${e.message}")
+                        resetToIdle()
+                    }
                 }
             }
         }
@@ -2622,10 +2639,18 @@ class WhisperAccessibilityService : AccessibilityService() {
             return
         }
 
+        // M5: which compressed .m4a copy (if any) the walk still holds. A LOCAL candidate never
+        // uploads, so its branch deletes the compressed copy and nulls this -- and now that LOCAL
+        // can *fail through* to a later cloud candidate (see its branch below), that candidate
+        // must see null (upload raw PCM) rather than a File pointing at deleted bytes. Only ever
+        // written before a candidate runs and read after its completion posts back, so the
+        // walk's existing thread handoffs (thread{}/handler.post) order every access.
+        var remainingCompressedFile: File? = compressedFile
+
         fun attempt(index: Int) {
             if (index >= candidates.size) {
                 file.delete()
-                compressedFile?.delete()
+                remainingCompressedFile?.delete()
                 reset("Set API key in Ramblr app")
                 return
             }
@@ -2644,7 +2669,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                         // Cancelled or watchdog already reset the UI: nothing more to try, but the
                         // PCM is still ours to clean up.
                         file.delete()
-                        compressedFile?.delete()
+                        remainingCompressedFile?.delete()
                         return@post
                     }
                     if (TranscriptionChain.hasNextCandidate(index, candidates.size)) {
@@ -2652,7 +2677,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                         attempt(index + 1)
                     } else {
                         file.delete()
-                        compressedFile?.delete()
+                        remainingCompressedFile?.delete()
                         reset("Error: ${error ?: "transcription failed"}")
                     }
                 }
@@ -2695,12 +2720,16 @@ class WhisperAccessibilityService : AccessibilityService() {
                     // #114 parts 1/2: bias transcription itself toward the user's vocabulary, not
                     // just the cleanup stage -- same terms already read below at the cleanup call
                     // site (see vocabularyTerms()).
+                    // M5: capture the compressed copy this attempt actually uploads as a local
+                    // (the #193 locals-capture pattern) -- remainingCompressedFile can be nulled
+                    // by a LOCAL candidate, and this callback must report/delete what IT sent.
+                    val uploadCompressedFile = remainingCompressedFile
                     TranscriberClient.transcribe(
                         file, apiKey, inFlightCall,
                         baseUrl = entry.baseUrlOverride ?: PostProcessor.DEFAULT_BASE_URL,
                         model = entry.transcriptionModel?.ifBlank { null } ?: TranscriberClient.DEFAULT_MODEL,
                         vocabularyTerms = vocabularyTerms(),
-                        compressedFile = compressedFile,
+                        compressedFile = uploadCompressedFile,
                     ) { result ->
                         val roundTripMs = System.currentTimeMillis() - transcribeStartMs
                         Log.i(TAG, "OpenAI transcription HTTP round-trip took ${roundTripMs}ms")
@@ -2713,7 +2742,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                                 model = entry.transcriptionModel?.ifBlank { null } ?: TranscriberClient.DEFAULT_MODEL,
                                 latencyMs = roundTripMs,
                                 success = success,
-                                compressedUpload = compressedFile != null,
+                                compressedUpload = uploadCompressedFile != null,
                                 // #138: a provider error envelope yields blank text, so this
                                 // records success=false; without the reason a bad key, a rate
                                 // limit and a timeout are indistinguishable after logcat rotates.
@@ -2732,7 +2761,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                         )
                         if (success) {
                             file.delete()
-                            compressedFile?.delete()
+                            uploadCompressedFile?.delete()
                             handleTranscriptionResult(result.text, token)
                         } else {
                             advanceOrGiveUp(result.error ?: "empty transcript")
@@ -2741,8 +2770,17 @@ class WhisperAccessibilityService : AccessibilityService() {
                 }
                 ProviderKind.LOCAL -> {
                     Log.i(TAG, "Transcription via ProviderChain provider=${entry.kind}")
-                    compressedFile?.delete()
-                    transcribeLocal(file, token)
+                    // The local transcriber reads raw PCM, never an upload (#109) -- but null the
+                    // walk-level handle too (M5), so a cloud candidate reached via LOCAL's new
+                    // fail-through below uploads the raw PCM instead of a deleted .m4a path.
+                    remainingCompressedFile?.delete()
+                    remainingCompressedFile = null
+                    // M5: as a chain candidate, LOCAL's failure must behave like any cloud
+                    // candidate's -- keep the PCM alive and walk on via advanceOrGiveUp (which
+                    // deletes it at chain exhaustion) instead of transcribeLocal's direct-path
+                    // delete-and-reset. See transcribeLocal's PCM-lifetime kdoc and
+                    // TranscriptionChain.shouldDeletePcm.
+                    transcribeLocal(file, token, onChainFailure = { error -> advanceOrGiveUp(error) })
                 }
                 ProviderKind.GEMINI -> {
                     val apiKey = ProviderCredentialStore.get(this, ProviderKind.GEMINI)
@@ -2761,10 +2799,12 @@ class WhisperAccessibilityService : AccessibilityService() {
                         Log.i(TAG, "Cloud transcription via ProviderChain provider=${entry.kind} (Gemini generateContent audio)")
                         val geminiModel = entry.transcriptionModel?.ifBlank { null } ?: GeminiTranscriberClient.DEFAULT_MODEL
                         val geminiStartMs = System.currentTimeMillis()
+                        // M5: same locals-capture as the OpenAI branch above.
+                        val uploadCompressedFile = remainingCompressedFile
                         GeminiTranscriberClient.transcribe(
                             file, apiKey, geminiModel, inFlightCall,
                             vocabularyTerms = vocabularyTerms(),
-                            compressedFile = compressedFile,
+                            compressedFile = uploadCompressedFile,
                         ) { result ->
                             val success = result.text != null && result.text.isNotBlank()
                             BenchmarkLogger.log(
@@ -2775,7 +2815,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                                     model = geminiModel,
                                     latencyMs = System.currentTimeMillis() - geminiStartMs,
                                     success = success,
-                                    compressedUpload = compressedFile != null,
+                                    compressedUpload = uploadCompressedFile != null,
                                     // #138: same as the OpenAI path -- Gemini reports failure as
                                     // an error envelope with blank text, not an exception.
                                     error = sanitizeError(result.error),
@@ -2793,7 +2833,7 @@ class WhisperAccessibilityService : AccessibilityService() {
                             )
                             if (success) {
                                 file.delete()
-                                compressedFile?.delete()
+                                uploadCompressedFile?.delete()
                                 handleTranscriptionResult(result.text, token)
                             } else {
                                 advanceOrGiveUp(result.error ?: "empty transcript")

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -2674,7 +2674,17 @@ class WhisperAccessibilityService : AccessibilityService() {
                     }
                     if (TranscriptionChain.hasNextCandidate(index, candidates.size)) {
                         Log.w(TAG, "Transcription candidate #$index (${entry.kind}) failed: ${error ?: "unusable"}; trying next candidate")
-                        attempt(index + 1)
+                        // M2 (2026-08-25 audit): the guard re-check above belongs on main, but
+                        // attempt() itself must not run there -- a fallback candidate's request
+                        // prep is real work (a GEMINI candidate readBytes()es the whole PCM, up
+                        // to ~10MB, and base64s it to ~13MB inside GeminiTranscriberClient before
+                        // OkHttp ever sees it). Mirrors the thread { continueTranscription(...) }
+                        // hop resolveLateRecordingOnMain/startMaxDurationTranscription already
+                        // use: attempt(0) already runs on that reader thread, so everything
+                        // attempt() touches is exercised off-main today -- the thread{}/
+                        // handler.post handoffs order every access to the walk's shared state
+                        // (remainingCompressedFile, guard, candidates).
+                        thread { attempt(index + 1) }
                     } else {
                         file.delete()
                         remainingCompressedFile?.delete()

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -357,6 +357,49 @@ class WhisperAccessibilityService : AccessibilityService() {
      *  MediaMuxer) is ever created. */
     @Volatile private var aacEncoderSession: AacEncoderSession? = null
     private val guard = TranscriptionGuard()
+    /**
+     * Bounded partial wakelock across the recording+transcription window (M6 audit, 2026-08-26).
+     * Screen-off long dictations otherwise risk the CPU being throttled mid local decode (the
+     * multi-minute sherpa path), and OEM battery managers are quicker to silence the mic for an
+     * app holding no wakelock. Lazily created once (PowerManager.newWakeLock), then reused for
+     * every dictation; non-reference-counted so acquire/release are idempotent under the rapid
+     * cancel->restart races #193 documents -- a re-acquire simply refreshes the timeout, and a
+     * second release is a no-op instead of a RuntimeException.
+     *
+     * Deliberately minimal scope: a full foregroundServiceType="microphone" FGS migration is the
+     * robust fix for OEM mic silencing and is tracked as future work in #204 -- this is the
+     * bounded, low-risk slice of it.
+     */
+    private var transcriptionWakeLock: android.os.PowerManager.WakeLock? = null
+
+    /** Leak backstop for [transcriptionWakeLock]: recording caps at 10 min and a worst-case
+     *  local decode adds multi-minute tail, so 20 min comfortably covers one dictation while
+     *  guaranteeing the OS drops the lock even if every release path were somehow missed. Each
+     *  [acquireTranscriptionWakeLock] refreshes this window for the new dictation. */
+    private val TRANSCRIPTION_WAKELOCK_TIMEOUT_MS = 20 * 60 * 1000L
+
+    /** Acquires (or refreshes) the bounded partial wakelock for a dictation that just started
+     *  recording. Main thread only (called from [startRecording]). Any failure is swallowed:
+     *  a wakelock is an optimization for screen-off reliability, never worth failing a
+     *  dictation over. */
+    private fun acquireTranscriptionWakeLock() {
+        runCatching {
+            val lock = transcriptionWakeLock ?: (getSystemService(Context.POWER_SERVICE) as android.os.PowerManager)
+                .newWakeLock(android.os.PowerManager.PARTIAL_WAKE_LOCK, "ramblr:transcription")
+                .apply { setReferenceCounted(false) }
+                .also { transcriptionWakeLock = it }
+            lock.acquire(TRANSCRIPTION_WAKELOCK_TIMEOUT_MS)
+        }.onFailure { Log.w(TAG, "Couldn't acquire transcription wakelock", it) }
+    }
+
+    /** Releases the wakelock at a pipeline terminal state. isHeld-guarded (and the lock is
+     *  non-reference-counted), so calling this from multiple teardown paths -- [resetToIdle]'s
+     *  always-runs funnel and [onDestroy]'s belt-and-suspenders -- is safe. */
+    private fun releaseTranscriptionWakeLock() {
+        runCatching {
+            transcriptionWakeLock?.takeIf { it.isHeld }?.release()
+        }.onFailure { Log.w(TAG, "Couldn't release transcription wakelock", it) }
+    }
     /** Per-process-launch unique prefix for [correlationIdFor] (real bug fix, 2026-07-17):
      *  [guard]'s underlying token is an in-process [java.util.concurrent.atomic.AtomicInteger]
      *  that always restarts at 1 on a fresh accessibility-service process (app update, OS memory
@@ -635,6 +678,9 @@ class WhisperAccessibilityService : AccessibilityService() {
         cancelWatchdog()
         guard.cancel()
         inFlightCall.cancel()
+        // M6 belt-and-suspenders: service teardown is terminal for any in-flight dictation, and
+        // resetToIdle() may never run for it. isHeld-guarded, so a no-dictation destroy is a no-op.
+        releaseTranscriptionWakeLock()
         // The cancel above makes any in-flight local completion abort at its next piece check
         // (#83), so the holder's daemon thread can close the cached ~1 GB cleanup model promptly
         // without this main-thread teardown waiting on it (#74).
@@ -2186,6 +2232,10 @@ class WhisperAccessibilityService : AccessibilityService() {
         }
 
         recordingEngine = engine
+        // M6: recording is genuinely live -- open the bounded wakelock window that spans
+        // recording + transcription; resetToIdle() (the terminal-state funnel) closes it.
+        // Placed after the `started` check so a failed recorder start never acquires.
+        acquireTranscriptionWakeLock()
         setBusy(false)
         // Deferred (Trevor-reported bug fix, see animateRingX's kdoc): with SingleTapRestoreToggle
         // on, this exact call site can run while restoreFromPeek()'s animator is still mid-flight
@@ -2315,6 +2365,12 @@ class WhisperAccessibilityService : AccessibilityService() {
         cancelWatchdog()
         guard.cancel()
         activeToken = 0
+        // M6: the pipeline is terminal here -- injection finished, cancel, watchdog, or error
+        // (reset(msg) funnels here too) -- so the recording+transcription wakelock window ends.
+        // isHeld-guarded and non-reference-counted, so the paths where no dictation was running
+        // (e.g. preview-before-inject's early resetToIdle) are harmless no-ops or early releases
+        // that the next startRecording() re-acquires.
+        releaseTranscriptionWakeLock()
         // #115: deliberately NOT abandoned here. resetToIdle() runs immediately after beginPreview()
         // too (preview-before-inject, #40) -- well before the real injectText() call that resolves
         // the preview, possibly seconds later on a timeout. Abandoning here would silently drop

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -3608,6 +3608,12 @@ class WhisperAccessibilityService : AccessibilityService() {
         }
 
         windows
+            // H3: this scan only went live 2026-08-26, when flagRetrieveInteractiveWindows was
+            // first declared in accessibility_service_config.xml -- before that getWindows()
+            // always returned empty and only rootInActiveWindow above ever produced candidates.
+            // Parent will regression-test IME/keyboard behavior on-device before merge (baseline:
+            // a 2026-08-25 investigation proved a Chrome NTP keyboard-hide bug was NOT Ramblr --
+            // it reproduced with ALL accessibility services disabled).
             ?.filter { it.isActive || it.isFocused }
             ?.forEach { window ->
                 val root = window.root ?: return@forEach

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- accessibilityFlags (H3 audit, declared 2026-08-26): flagRetrieveInteractiveWindows is what
+     makes AccessibilityService.getWindows() return anything at all; without it the framework
+     always hands back an empty list, and WhisperAccessibilityService.findInjectionCandidates()'s
+     multi-window scan (dialogs, popups, split-screen) was dead code, silently degrading those
+     targets to clipboard fallback. Deliberately NOT flagDefault: no flags were declared before
+     (effective flags = 0), and flagDefault would newly make Ramblr the default handler for its
+     feedbackGeneric type, a behavior change unrelated to the window scan. -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeViewFocused"
     android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"
     android:notificationTimeout="100"
     android:description="@string/accessibility_description" />

--- a/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorProviderChainRoutingTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/PostProcessorProviderChainRoutingTest.kt
@@ -8,7 +8,8 @@ import org.junit.Test
  * Covers which execution path [PostProcessor.processProviderChain] dispatches a chain down (#105).
  *
  * The bug: a single-OpenAI cleanup chain -- the most common configuration in production -- was
- * special-cased to call [PostProcessor.process] directly through `NetworkClients.shared`
+ * special-cased to call a since-deleted `PostProcessor.process()` helper directly through
+ * `NetworkClients.shared`
  * (20s connect / 120s read / 180s call), bypassing [CleanupWaterfallExecutor]'s far tighter
  * [CleanupStepTimeouts] and hard cap. A stalled cleanup on the default config could therefore hang
  * for minutes instead of failing over to raw-text injection in seconds, and benchmark correlation
@@ -63,7 +64,8 @@ class PostProcessorProviderChainRoutingTest {
         val (transport, result) = run(chain)
 
         // Reaching the injected transport at all is the assertion: the old special case called
-        // PostProcessor.process(), which builds its own OkHttp call and would never touch this.
+        // the now-deleted PostProcessor.process() (removed as dead code, M4 audit 2026-08-26),
+        // which built its own OkHttp call and would never touch this.
         assertEquals(1, transport.urls.size)
         assertEquals("cleaned", result.text)
     }

--- a/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionChainTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/TranscriptionChainTest.kt
@@ -101,4 +101,25 @@ class TranscriptionChainTest {
 
         assertEquals(listOf(0, 1), attempted) // reached the LOCAL floor after OpenAI failed
     }
+
+    // --- shouldDeletePcm: the M5 PCM-lifetime contract ---
+
+    @Test fun `success always deletes the PCM, wherever in the chain it happened`() {
+        assertTrue(TranscriptionChain.shouldDeletePcm(candidateIndex = 0, candidateCount = 2, success = true))
+        assertTrue(TranscriptionChain.shouldDeletePcm(candidateIndex = 1, candidateCount = 2, success = true))
+        assertTrue(TranscriptionChain.shouldDeletePcm(candidateIndex = 0, candidateCount = 1, success = true))
+    }
+
+    @Test fun `a mid-chain failure keeps the PCM alive for the next candidate`() {
+        // The M5 bug: LOCAL at index 0 of [LOCAL, OPENAI] failed post-decode and deleted the
+        // PCM in its finally, so OPENAI had nothing left to transcribe. The contract: a failing
+        // candidate with a successor must NOT delete the audio.
+        assertFalse(TranscriptionChain.shouldDeletePcm(candidateIndex = 0, candidateCount = 2, success = false))
+        assertFalse(TranscriptionChain.shouldDeletePcm(candidateIndex = 1, candidateCount = 3, success = false))
+    }
+
+    @Test fun `failure on the last candidate deletes the PCM -- the chain is exhausted`() {
+        assertTrue(TranscriptionChain.shouldDeletePcm(candidateIndex = 1, candidateCount = 2, success = false))
+        assertTrue(TranscriptionChain.shouldDeletePcm(candidateIndex = 0, candidateCount = 1, success = false))
+    }
 }


### PR DESCRIPTION
Implements audit slice 6 from the 2026-08-25 read-only pipeline audit. One commit per unit, one issue per unit.

## Units

### 1. Delete dead `PostProcessor.process()` 180s trap (closes #200) — b5c47df
`process()` had zero production callers (grep-verified; every live cleanup path routes through `processProviderChain` → `CleanupWaterfallExecutor` since #105) but built its call on `NetworkClients.shared`'s 180s callTimeout, silently bypassing the 8s `CLEANUP_WATERFALL_HARD_CAP_MS` discipline. Deleted outright with its orphaned okhttp imports and private client field; stale comment references in `processProviderChain`'s kdoc and `PostProcessorProviderChainRoutingTest` updated.

### 2. LOCAL transcription mid-chain failure falls through to remaining candidates (closes #201) — fc93ae0
With chain [LOCAL, OPENAI], a post-load local decode failure killed the dictation ("Local error: …") while a healthy cloud candidate sat unused — the PCM was already deleted in `transcribeLocal`'s `finally`, so nothing could have retried anyway. Now:
- `transcribeLocal` gains an optional `onChainFailure` callback; the chain walk passes it, keeping the PCM alive on failure and routing into the same `advanceOrGiveUp` walk cloud candidates use. The existing user-facing error surfaces only at chain exhaustion.
- PCM-lifetime decision pinned as pure `TranscriptionChain.shouldDeletePcm(candidateIndex, candidateCount, success)` with unit tests.
- Walk-level `remainingCompressedFile` handle: LOCAL's branch deletes+nulls the .m4a, so a cloud candidate reached via LOCAL fail-through uploads raw PCM instead of a deleted file path; cloud branches capture their upload copy as locals (the #193 pattern).
- Direct pure-local path (`continueTranscription`) keeps its documented delete-and-report tradeoff; comment updated.

### 3. Off-main-thread hygiene: BenchmarkLogger I/O + fallback dispatch (closes #202) — dc71811
- **M1**: `BenchmarkLogger.log` (called from `finishInjection` on main) now defers append + up-to-3MB rotation to a single-threaded daemon executor owned by BenchmarkLogger — single thread (not a pool) preserves JSONL write order; line content/timestamps still captured synchronously. `QualityLogger` examined: shares the rotation pattern but every call site is already off-main, so deliberately left synchronous.
- **M2**: `advanceOrGiveUp` keeps its guard re-check on main but dispatches `attempt(index+1)` via `thread {}` (mirroring `resolveLateRecordingOnMain`'s pattern), so a fallback candidate's request prep (GEMINI: ~10MB `readBytes()` + ~13MB base64) never runs on main. `attempt(0)` already runs on the recording reader thread, so `attempt()` was always exercised off-main; shared state is ordered by the existing thread{}/handler.post handoffs.

### 4. Declare `flagRetrieveInteractiveWindows` (closes #203) — f1bfbe9
`accessibility_service_config.xml` declared no `android:accessibilityFlags`, so `getWindows()` always returned empty and the multi-window candidate loop in `findInjectionCandidates` was dead — dialogs/popups/split-screen silently degraded to clipboard fallback. Added `android:accessibilityFlags="flagRetrieveInteractiveWindows"` (minimal change: previous effective flags were 0; `flagDefault` deliberately omitted — it would newly register Ramblr as default handler for its feedback type, an unrelated behavior change). Comment at the scan loop notes the flag went live 2026-08-26.

### 5. Bounded partial wakelock across recording+transcription (closes #204) — 221311d
`WAKE_LOCK` permission + one non-reference-counted `PARTIAL_WAKE_LOCK` ("ramblr:transcription"): `acquire(20 min)` in `startRecording` after the engine-start success check; released in `resetToIdle` (verified as the single always-runs terminal funnel — completion, cancel, watchdog, no-speech, and every `reset(msg)` path end there) plus an isHeld-guarded belt-and-suspenders release in `onDestroy`. Idempotent under rapid cancel→restart (re-acquire refreshes the timeout; double release is a no-op). **Future work noted in #204**: full `foregroundServiceType="microphone"` FGS migration.

No unit test for the wakelock: `PowerManager.WakeLock` is a framework final class with no existing seam, and adding a mocking library for one test was out of scope.

## Gates (all run locally on this branch)
- `./gradlew testGithubDebugUnitTest` — **BUILD SUCCESSFUL, 1399 tests, 0 failures, 0 skipped**
- `./gradlew assembleGithubDebug` — BUILD SUCCESSFUL
- `./gradlew assembleGithubRelease` — BUILD SUCCESSFUL

## Manual on-device verification (parent)
- [ ] Keyboard/IME regression test with `flagRetrieveInteractiveWindows` live (baseline: 2026-08-25 investigation proved the Chrome NTP keyboard-hide bug was NOT Ramblr — reproduced with all a11y services disabled). Note: the flag change requires toggling the accessibility service off/on (or reinstall) to take effect.
- [ ] Dictation into a dialog / popup / split-screen secondary window (the newly-live multi-window scan).
- [ ] Screen-off long dictation: verify `adb shell dumpsys power | grep ramblr` shows the partial wakelock held during recording+transcription and released after injection/reset; verify no lingering lock after rapid cancel→restart.
- [ ] LOCAL-failure→cloud-fallback smoke test: with chain [LOCAL, OPENAI] and a key configured, force a local decode failure (e.g. corrupt/unload model mid-decode) and confirm the dictation completes via OpenAI instead of dying with "Local error: …".
