### PR TITLE
Make onboarding step 4's "Skip (leave off)" actually turn cleanup off

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -601,7 +601,17 @@ class MainActivity : BaseSettingsActivity() {
                 dismissOnboarding()
                 enableOnboardingCleanupLocal(recommendedLocal) { showOnboardingStreamingStep() }
             }
-            .setNeutralButton("Skip (leave off)") { _, _ -> dismissOnboarding(); showOnboardingStreamingStep() }
+            // #174: the label asserts an end state ("leave off"), so the handler must actually
+            // write it. A pure no-op diverged from the label whenever onboarding re-ran on a
+            // device with cleanup already on (Advanced -> "Redo setup walkthrough"): the user
+            // picked "leave off" and finished with cleanup still enabled. A user re-running
+            // setup and choosing this option is expressing intent about the end state, not
+            // asking to preserve whatever was configured before.
+            .setNeutralButton("Skip (leave off)") { _, _ ->
+                dismissOnboarding()
+                PostProcessingToggle.setEnabled(this, false)
+                showOnboardingStreamingStep()
+            }
             .show()
     }
 


### PR DESCRIPTION
The neutral button's label asserts an end state but the handler was a
pure no-op. On a fresh install those coincide, but via Advanced ->
"Redo setup walkthrough" a user with cleanup already enabled who
deliberately picked "Skip (leave off)" finished onboarding with cleanup
still on and still pointed at the previous model -- the setting silently
contradicted the choice they just made (confirmed on a Pixel 10a).

Write the asserted state explicitly through PostProcessingToggle, the
same global gate the Settings switch and overlay badge use.

Fixes #174
