### PR TITLE
Stop the vocabulary dialog claiming effect in local-only mode

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
@@ -462,8 +462,28 @@ class BehaviorActivity : BaseSettingsActivity() {
     )
 
     private fun vocabularySummary(): String {
+        val note = vocabularyLocalOnlyNote()
         val terms = vocabularyTerms()
-        return if (terms.isEmpty()) "No custom terms" else terms.joinToString(", ")
+        val termsPart = if (terms.isEmpty()) "No custom terms" else terms.joinToString(", ")
+        // #185: the raw term list reads as confirmation the terms are in force -- when the
+        // current chain is fully local they aren't, so say so right on the row.
+        return if (note == null) termsPart else "Not used in local-only mode — $termsPart"
+    }
+
+    /** Non-null when the user's current configuration ignores the vocabulary entirely (#185):
+     *  cloud transcription off AND no active cloud cleanup path. Mirrors the real runtime gates:
+     *  transcription's `use_local` pref, cleanup's master toggle, [CloudFeatureToggle]'s cloud
+     *  gate, and whether the chain still has a cloud-capable cleanup entry at all. */
+    private fun vocabularyLocalOnlyNote(): String? {
+        val cloudTranscription = !prefs().getBoolean("use_local", true)
+        val cloudCleanup = PostProcessingToggle.isEnabled(this) &&
+            CloudFeatureToggle.cleanupEnabled(this) &&
+            ProviderChainStore.load(this).capableEntriesFor(needsTranscription = false)
+                .any { it.kind != ProviderKind.LOCAL }
+        return VocabularyTerms.localOnlyNote(
+            cloudTranscriptionActive = cloudTranscription,
+            cloudCleanupActive = cloudCleanup,
+        )
     }
 
     private fun promptVocabulary() {
@@ -474,9 +494,21 @@ class BehaviorActivity : BaseSettingsActivity() {
             gravity = Gravity.TOP or Gravity.START
             setText(VocabularyTerms.serialize(vocabularyTerms()))
         }
+        // #185: since #182 (local cleanup no longer receives the terms) and #131 (local ASR
+        // hotword biasing not planned), the terms only reach cloud transcription and cloud
+        // cleanup -- the old copy claimed a blanket effect on "the cleanup step", which is
+        // false in fully-local mode. State the real scope, and when the current setup is
+        // local-only, say the terms are inert instead of letting behavior reveal it.
+        val message = buildString {
+            append(
+                "Project names or jargon that speech-to-text often mishears. One per line.\n\n" +
+                    "Applies to cloud transcription and cloud cleanup."
+            )
+            vocabularyLocalOnlyNote()?.let { append("\n\n").append(it) }
+        }
         android.app.AlertDialog.Builder(this)
             .setTitle("Personal vocabulary")
-            .setMessage("Project names or jargon the cleanup step often mishears. One per line.")
+            .setMessage(message)
             .setView(input.apply { setPadding(dp(24), dp(8), dp(24), dp(8)) })
             .setPositiveButton("Save") { _, _ ->
                 val terms = VocabularyTerms.parse(input.text.toString())

--- a/app/src/main/kotlin/com/trevornk/ramblr/VocabularyTerms.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/VocabularyTerms.kt
@@ -39,4 +39,30 @@ object VocabularyTerms {
      * an empty string when [terms] is empty so callers can skip sending anything.
      */
     fun asTranscriptionPrompt(terms: List<String>): String = terms.joinToString(", ")
+
+    /**
+     * Whether the vocabulary terms are actually applied anywhere in the user's current
+     * configuration (#185). After #182 removed the vocabulary clause from local cleanup (it made
+     * LFM2.5 echo the term list) and #131 closed local-ASR hotword biasing as not-planned, the
+     * terms only reach the two CLOUD paths:
+     *
+     *  - cloud transcription ([TranscriberClient.vocabularyFormParts] / Gemini's inline prompt)
+     *  - cloud cleanup ([PostProcessor.interpolateVocabulary] on the persona prompt)
+     *
+     * A fully-local setup -- local ASR plus local-only cleanup, the F-Droid-recommended,
+     * privacy-motivated configuration -- ignores every term. The Settings UI uses this to say so
+     * instead of letting users discover it from behavior.
+     *
+     * [cloudCleanupActive] must already fold in everything cloud cleanup needs (cleanup on,
+     * the cloud gate enabled, and a cloud-capable chain entry present); this stays a pure
+     * function of the two path-level booleans.
+     */
+    fun inEffect(cloudTranscriptionActive: Boolean, cloudCleanupActive: Boolean): Boolean =
+        cloudTranscriptionActive || cloudCleanupActive
+
+    /** The user-facing note shown when [inEffect] is false (#185); null when terms do apply. */
+    fun localOnlyNote(cloudTranscriptionActive: Boolean, cloudCleanupActive: Boolean): String? =
+        if (inEffect(cloudTranscriptionActive, cloudCleanupActive)) null
+        else "Your current setup is fully on-device, so these terms are not used: local " +
+            "transcription and local cleanup don't support vocabulary biasing."
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/VocabularyTermsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/VocabularyTermsTest.kt
@@ -1,6 +1,9 @@
 package com.trevornk.ramblr
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -71,5 +74,46 @@ class VocabularyTermsTest {
         for (term in VocabularyTerms.DEFAULTS) {
             assertTrue(VocabularyTerms.DEFAULT_SERIALIZED.contains(term))
         }
+    }
+
+    // --- inEffect / localOnlyNote (#185) ---
+
+    @Test
+    fun inEffectWhenCloudTranscriptionIsActive() {
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = false))
+    }
+
+    @Test
+    fun inEffectWhenCloudCleanupIsActive() {
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = true))
+    }
+
+    @Test
+    fun inEffectWhenBothCloudPathsAreActive() {
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = true))
+    }
+
+    @Test
+    fun notInEffectInFullyLocalMode() {
+        // The F-Droid-recommended privacy configuration: local ASR + local cleanup. After #182
+        // (local cleanup no longer receives the terms) and #131 (local ASR hotword biasing not
+        // planned), no path applies the vocabulary here.
+        assertFalse(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = false))
+    }
+
+    @Test
+    fun localOnlyNoteIsNullWheneverTermsApply() {
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = false))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = true))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = true))
+    }
+
+    @Test
+    fun localOnlyNoteExplainsTheInertSettingInFullyLocalMode() {
+        val note = VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = false)
+        assertNotNull(note)
+        // The note must say the terms are NOT used -- that's the whole point of #185: the
+        // setting must stop misrepresenting itself in local-only mode.
+        assertTrue(note!!.contains("not used"))
     }
 }


### PR DESCRIPTION
After #182 removed the vocabulary clause from local cleanup and #131
closed local-ASR hotword biasing as not-planned, the terms only reach
cloud transcription and cloud cleanup -- but the dialog still said they
affect "the cleanup step", and the row subtitle listed the terms as if
in force. A fully-local user (the F-Droid-recommended, privacy-motivated
setup) could enter twenty terms and have every one silently ignored.

- Dialog copy now states the real scope (cloud transcription + cloud
  cleanup).
- New pure helpers VocabularyTerms.inEffect/localOnlyNote decide whether
  the current configuration applies the terms at all; BehaviorActivity
  feeds them the real runtime gates (use_local, PostProcessingToggle,
  CloudFeatureToggle, cloud-capable chain entries).
- When the setup is local-only, the dialog gains an explicit "not used"
  note and the row subtitle leads with "Not used in local-only mode"
  instead of reading as confirmation.

No logic change to any pipeline path; display/copy only. Tests cover the
new helpers including the fully-local case.

Fixes #185
