### PR TITLE
Add the OS accessibility-button/shortcut as an invocation surface

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -545,6 +545,7 @@ class WhisperAccessibilityService : AccessibilityService() {
         // was swiped away, this is the first moment we can put the way back on screen again.
         // Runs after showOverlay() so the overlay really is connected by the time we claim it is.
         IconVisibilityNotifications.repostIfMissing(this, overlayConnected = overlayView != null)
+        registerAccessibilityButton()
         registerNetworkCallback()
         registerScreenStateReceiver()
         thread { cleanupOrphanedRecordings() }
@@ -552,6 +553,37 @@ class WhisperAccessibilityService : AccessibilityService() {
         // Try to load local model in background
         thread { initLocalModel() }
         thread { initStreamingModel() }
+    }
+
+    /**
+     * OS accessibility-shortcut trigger (#156, plan §2.5): with `flagRequestAccessibilityButton`
+     * declared in the service XML (static-only for targetSdk > 29), the user can enable a
+     * nav-bar button, floating shortcut, or volume-key hold for Ramblr in the system's
+     * Settings > Accessibility > Ramblr shortcut UI -- an invocation surface that keeps working
+     * with the floating ring hidden and adds no new permission.
+     *
+     * Routes through [requestToggleRecording] rather than [onTap] directly so it shares the QS
+     * tile's #136 guard: never start a recording while the icon is hidden and invisible -- a
+     * silent live mic is a privacy problem, and both non-ring surfaces reach this path with the
+     * ring potentially at alpha=0. [onServiceConnected] can re-fire without a new service
+     * instance; re-registering the same callback object is safe because the framework stores
+     * callbacks in a set keyed per callback instance, and ours lives in a val.
+     */
+    private val accessibilityButtonCallback =
+        object : android.accessibilityservice.AccessibilityButtonController.AccessibilityButtonCallback() {
+            override fun onClicked(controller: android.accessibilityservice.AccessibilityButtonController) {
+                requestToggleRecording()
+            }
+        }
+
+    private fun registerAccessibilityButton() {
+        try {
+            accessibilityButtonController.registerAccessibilityButtonCallback(accessibilityButtonCallback)
+        } catch (e: Exception) {
+            // Some OEM skins bury or omit the accessibility button entirely; failing to register
+            // must never take down the primary ring surface with it.
+            Log.e(TAG, "Could not register accessibility button callback", e)
+        }
     }
 
     /**

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -5,11 +5,19 @@
      multi-window scan (dialogs, popups, split-screen) was dead code, silently degrading those
      targets to clipboard fallback. Deliberately NOT flagDefault: no flags were declared before
      (effective flags = 0), and flagDefault would newly make Ramblr the default handler for its
-     feedbackGeneric type, a behavior change unrelated to the window scan. -->
+     feedbackGeneric type, a behavior change unrelated to the window scan.
+
+     flagRequestAccessibilityButton (#156, plan §2.5): opts Ramblr into the OS-rendered
+     accessibility shortcut (nav-bar button, floating shortcut, or volume-key hold; the user
+     picks in Settings > Accessibility > Ramblr > shortcut). MUST be static XML: with
+     targetSdk > 29 the framework ignores runtime attempts to set this flag
+     (AccessibilityServiceInfo.java:508-511, AOSP). Declaring it only makes the OS offer the
+     shortcut UI; whether the button appears is entirely the user's system-level choice, so this
+     changes nothing for users who never enable it. -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeViewFocused"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagRetrieveInteractiveWindows"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows|flagRequestAccessibilityButton"
     android:canRetrieveWindowContent="true"
     android:notificationTimeout="100"
     android:description="@string/accessibility_description" />


### PR DESCRIPTION
Declares flagRequestAccessibilityButton in the service XML (static-only:
targetSdk > 29 cannot set it at runtime, AccessibilityServiceInfo.java
508-511) and registers an AccessibilityButtonCallback in
onServiceConnected. The callback routes through requestToggleRecording,
sharing the QS tile's #136 restore-before-start guard so a shortcut tap
can never start a silent recording while the ring is hidden.

Users get the nav-bar button, floating shortcut, or volume-key-hold
trigger from the system's own accessibility-shortcut chooser -- an
invocation method that works with the floating ring hidden, at no new
permission. Declaring the flag changes nothing for users who never
enable the shortcut; registration failure is caught so an OEM skin
without the button can't take down the ring surface.

Invocation-methods design plan §2.5 marked this XS 'do this early'
(considered-and-deferred in RamblrQsTileService's kdoc; #156 revisited).

Advances #156
