### PR TITLE
Guard the shipped CPU variant sonames at configure time (refs #187)

### DIFF
--- a/app/src/main/cpp/llama_cleanup/CMakeLists.txt
+++ b/app/src/main/cpp/llama_cleanup/CMakeLists.txt
@@ -148,7 +148,17 @@ add_subdirectory(../../../../../llama.cpp llama.cpp)
 # or packaged. This block only fails the build if upstream's variant names change, so the
 # exclusion list and kCpuVariantLibs in LLMInference.cpp can't silently drift out of sync with
 # the submodule.
-foreach(variant ggml-cpu-android_armv9.0_1 ggml-cpu-android_armv9.2_1 ggml-cpu-android_armv9.2_2)
+#
+# Guard the KEPT variants too, not just the excluded ones (#187 follow-up): kCpuVariantLibs in
+# LLMInference.cpp dlopen()s the four shipped variants by hardcoded soname. If a submodule bump
+# renamed those targets, this build would still succeed -- the renamed libraries would package
+# under new names, every dlopen would miss, and loadBestCpuBackend() would throw "no compatible
+# CPU backend" on every device at runtime. Failing configure here turns that runtime regression
+# into a build error pointing at the two lists that need updating.
+foreach(variant
+        ggml-cpu-android_armv8.0_1 ggml-cpu-android_armv8.2_1
+        ggml-cpu-android_armv8.2_2 ggml-cpu-android_armv8.6_1
+        ggml-cpu-android_armv9.0_1 ggml-cpu-android_armv9.2_1 ggml-cpu-android_armv9.2_2)
     if (NOT TARGET ${variant})
         message(FATAL_ERROR "Expected ggml CPU variant target ${variant} not found -- the \
 llama.cpp submodule's Android variant list changed. Re-check ggml/src/CMakeLists.txt, then update \


### PR DESCRIPTION
Independent re-verification of the #187 runtime-dispatch fix (e063b76) from a
clean worktree at 591bfe9, plus one hardening gap it surfaced.

The gap: the CMake drift guard only asserted the three EXCLUDED armv9 variant
targets exist. The four variants the app actually ships are dlopen()ed by
hardcoded soname in LLMInference.cpp's kCpuVariantLibs; if a llama.cpp
submodule bump renamed those targets, the build would still succeed, the
renamed libraries would package under new names, every dlopen would miss, and
loadBestCpuBackend() would throw "no compatible CPU backend" on every device
at runtime -- local cleanup broken everywhere, caught only on-device. Extend
the guard to all seven Android variant names so that submodule drift fails
the configure step instead, with the error message already pointing at the
two lists (jniLibs.excludes, kCpuVariantLibs) that must move in lockstep.

Verification performed against real artifacts built from this tree
(assembleGithubRelease, llama.cpp submodule 152d337fa / b9867):

- Packaged variant set is exactly armv8.0_1 / 8.2_1 / 8.2_2 / 8.6_1; the
  three armv9 variants are excluded; all libs 16KB-aligned LOAD segments,
  all Stored (extractNativeLibs=false compatible).
- llvm-objdump instruction audit per variant (dotprod / i8mm / fp16-arith):
  armv8.0_1 = 0/0/0, armv8.2_1 = 839/0/0, armv8.2_2 = 839/0/299,
  armv8.6_1 = 839/158/299. The baseline a Cortex-A73 would select contains
  zero ARMv8.2+ instructions.
- The v1.0.25 release APK's single libggml-cpu.so (pre-fix baseline) audits
  at 839/158/299 with no getauxval import -- the SIGILL the issue reported.
- Every packaged variant exports ggml_backend_score(); the score function's
  own body disassembles clean (no gated instructions) and calls getauxval,
  so selection itself cannot SIGILL.
- libllama-cleanup-jni.so embeds all four variant sonames and imports
  dlopen + ggml_backend_load (runtime selection plumbing intact).
- APK delta vs v1.0.25 github-release: 57,905,292 -> 60,326,350 bytes
  (+2.42 MB, +4.2%), of which +2.38 MB is the variant matrix.
- testGithubDebugUnitTest: 1410 tests, 0 failures. assembleGithubDebug
  packages the same four-variant set.

Still unverifiable off-device: that a real pre-ARMv8.2 CPU scores/selects
armv8.0_1. The disassembly proves that variant cannot SIGILL; the selection
logic reads AT_HWCAP via getauxval and is the same code path proven working
on ARMv8.6 hardware.
