### PR TITLE
Add deterministic vocabulary post-correction for local cleanup output

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
@@ -465,24 +465,33 @@ class BehaviorActivity : BaseSettingsActivity() {
         val note = vocabularyLocalOnlyNote()
         val terms = vocabularyTerms()
         val termsPart = if (terms.isEmpty()) "No custom terms" else terms.joinToString(", ")
-        // #185: the raw term list reads as confirmation the terms are in force -- when the
-        // current chain is fully local they aren't, so say so right on the row.
-        return if (note == null) termsPart else "Not used in local-only mode — $termsPart"
+        // #185: the raw term list reads as confirmation the terms are in force -- when nothing
+        // in the current setup applies them (local ASR with cleanup fully off, since #182's
+        // post-pass made local cleanup vocabulary-capable) they aren't, so say so on the row.
+        return if (note == null) termsPart else "Not used while cleanup is off — $termsPart"
     }
 
     /** Non-null when the user's current configuration ignores the vocabulary entirely (#185):
-     *  cloud transcription off AND no active cloud cleanup path. Mirrors the real runtime gates:
-     *  transcription's `use_local` pref, cleanup's master toggle, [CloudFeatureToggle]'s cloud
-     *  gate, and whether the chain still has a cloud-capable cleanup entry at all. */
+     *  cloud transcription off AND no active cleanup path of any kind. Mirrors the real runtime
+     *  gates: transcription's `use_local` pref, cleanup's master toggle, [CloudFeatureToggle]'s
+     *  cloud gate, the chain's cleanup-capable entries, and -- for the local path, which applies
+     *  terms via [VocabularyPostCorrector]'s output post-pass since #182 -- an actually
+     *  installed local cleanup model ([ModelDownloader.localCleanupModelFile] non-null, the same
+     *  check the executor's LOCAL_LLM branch fails on). */
     private fun vocabularyLocalOnlyNote(): String? {
         val cloudTranscription = !prefs().getBoolean("use_local", true)
-        val cloudCleanup = PostProcessingToggle.isEnabled(this) &&
+        val cleanupOn = PostProcessingToggle.isEnabled(this)
+        val cleanupEntries = ProviderChainStore.load(this).capableEntriesFor(needsTranscription = false)
+        val cloudCleanup = cleanupOn &&
             CloudFeatureToggle.cleanupEnabled(this) &&
-            ProviderChainStore.load(this).capableEntriesFor(needsTranscription = false)
-                .any { it.kind != ProviderKind.LOCAL }
+            cleanupEntries.any { it.kind != ProviderKind.LOCAL }
+        val localCleanup = cleanupOn &&
+            cleanupEntries.any { it.kind == ProviderKind.LOCAL } &&
+            ModelDownloader.localCleanupModelFile(this, LocalCleanupProvider.selectedModel(this)) != null
         return VocabularyTerms.localOnlyNote(
             cloudTranscriptionActive = cloudTranscription,
             cloudCleanupActive = cloudCleanup,
+            localCleanupActive = localCleanup,
         )
     }
 
@@ -494,15 +503,15 @@ class BehaviorActivity : BaseSettingsActivity() {
             gravity = Gravity.TOP or Gravity.START
             setText(VocabularyTerms.serialize(vocabularyTerms()))
         }
-        // #185: since #182 (local cleanup no longer receives the terms) and #131 (local ASR
-        // hotword biasing not planned), the terms only reach cloud transcription and cloud
-        // cleanup -- the old copy claimed a blanket effect on "the cleanup step", which is
-        // false in fully-local mode. State the real scope, and when the current setup is
-        // local-only, say the terms are inert instead of letting behavior reveal it.
+        // #185/#182: the terms reach cloud transcription, cloud cleanup (prompt interpolation),
+        // and -- since #182's option-2 post-pass -- local cleanup, where they are applied as a
+        // deterministic correction over the model's output rather than in its prompt. Only
+        // local transcription ignores them (#131), so the inert-setting note now fires only
+        // when cleanup is off entirely on a local-transcription setup.
         val message = buildString {
             append(
                 "Project names or jargon that speech-to-text often mishears. One per line.\n\n" +
-                    "Applies to cloud transcription and cloud cleanup."
+                    "Applies to cloud transcription and to cleanup (cloud and local)."
             )
             vocabularyLocalOnlyNote()?.let { append("\n\n").append(it) }
         }

--- a/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutor.kt
@@ -572,6 +572,12 @@ object CleanupWaterfallExecutor {
         // once a properly fine-tuned local cleanup model replaces the current generic one -- is a
         // one-line change here, not a hunt through the executor.
         localPrompt: String = PostProcessor.SIMPLE_PROMPT,
+        // Personal-vocabulary terms applied to LOCAL_LLM output as a deterministic post-pass
+        // (#182 option 2, [VocabularyPostCorrector]). Cloud steps get vocabulary via prompt
+        // interpolation on [prompt] instead, which works there -- the two paths are mutually
+        // exclusive by construction, so terms are never applied twice to one result. Defaulted
+        // empty so existing tests/call sites keep their exact behavior unless they opt in.
+        localVocabulary: List<String> = emptyList(),
         // Injectable wall clock (defaults to the real one) so the hard-cap path is unit-testable
         // without sleeping -- previously it read System.currentTimeMillis() directly, so the
         // "exceeded time budget" branch had no deterministic test (audit test-gap #6). Its siblings
@@ -628,7 +634,7 @@ object CleanupWaterfallExecutor {
                 return
             }
 
-            performStep(steps[index], text, prompt, localPrompt, credentialLookup, transport, localInference, localModelPath, cancelHolder, deadlineAtMs, isLastStep = index == steps.lastIndex) { outcome ->
+            performStep(steps[index], text, prompt, localPrompt, localVocabulary, credentialLookup, transport, localInference, localModelPath, cancelHolder, deadlineAtMs, isLastStep = index == steps.lastIndex) { outcome ->
                 logStepOutcome(steps[index], startedAtMs, outcome, benchmarkContext, benchmarkCorrelationId)
                 when (outcome) {
                     is CleanupStepOutcome.Success -> {
@@ -717,6 +723,7 @@ object CleanupWaterfallExecutor {
         text: String,
         prompt: String,
         localPrompt: String,
+        localVocabulary: List<String>,
         credentialLookup: (CleanupCredentialSlot) -> String,
         transport: CleanupHttpTransport,
         localInference: LocalInferenceEngine,
@@ -762,7 +769,13 @@ object CleanupWaterfallExecutor {
                             trimmed.isEmpty() -> CleanupStepOutcome.StepFailed("Local model produced an empty response")
                             NumericPreservationVerifier.verify(normalization, trimmed) is NumericPreservation.Rejected ->
                                 CleanupStepOutcome.StepFailed("Local cleanup output rejected (NUMERIC_DIVERGENCE)")
-                            else -> CleanupStepOutcome.Success(trimmed)
+                            // #182 option 2: personal vocabulary reaches local cleanup as a
+                            // deterministic post-pass over ACCEPTED output, never as prompt
+                            // text (which made LFM2.5 echo the term list). Runs after the
+                            // validator and the numeric check so corrections are applied to
+                            // output that has already earned acceptance -- and never to text
+                            // that is about to be discarded for a fallback step.
+                            else -> CleanupStepOutcome.Success(VocabularyPostCorrector.correct(trimmed, localVocabulary))
                         }
                     }
                     is LocalInferenceResult.Failure -> CleanupStepOutcome.StepFailed(result.message)

--- a/app/src/main/kotlin/com/trevornk/ramblr/CommonEnglishWords.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CommonEnglishWords.kt
@@ -1,0 +1,101 @@
+package com.trevornk.ramblr
+
+/**
+ * A small embedded list of everyday English words, used exclusively as
+ * [VocabularyPostCorrector]'s false-positive guard (#182): a word in local cleanup output that
+ * only FUZZILY matches a vocabulary term (edit distance > 0) is never rewritten when it is
+ * itself an ordinary English word. "code" is one deletion from the default term "Codex", "fast"
+ * one from "fast.ai's" first core, "answer" is the first word-core of "Answer.AI" -- without
+ * this guard the corrector would rewrite normal prose into the user's jargon, which is exactly
+ * the corruption the pass's conservatism contract forbids. Exact (case-insensitive) matches
+ * bypass the guard entirely, so a user who deliberately configures a common word as a term
+ * ("Pi") still gets recasing.
+ *
+ * Deliberately NOT a comprehensive dictionary: it needs to cover words a speaker plausibly says
+ * that sit within edit distance 1-2 of typical project/name jargon, and the cost of a missing
+ * word is one wrong correction only when it ALSO clears the first-letter and edit-distance
+ * gates. ~1000 high-frequency lemmas plus common inflections is the right size for that job
+ * without dragging a wordlist asset or a library dependency into the app (pure Kotlin, checked
+ * in O(1) per candidate).
+ */
+object CommonEnglishWords {
+
+    fun contains(word: String): Boolean = WORDS.contains(word.lowercase())
+
+    private val WORDS: Set<String> = buildSet {
+        val base = """
+            the be to of and a in that have i it for not on with he as you do at this but his by
+            from they we say her she or an will my one all would there their what so up out if
+            about who get which go me when make can like time no just him know take people into
+            year your good some could them see other than then now look only come its over think
+            also back after use two how our work first well way even new want because any these
+            give day most us is was are were been has had did says said gets got made makes went
+            gone knows knew known takes took taken comes came sees saw seen looks looked uses
+            used works worked wants wanted gives gave given days years ways things thing life
+            child children world school state family student group country problem hand part
+            place case week company system program question government number night point home
+            water room mother area money story fact month lot right study book eye job word
+            business issue side kind head house service friend father power hour game line end
+            member law car city community name president team minute idea body information
+            back parent face others level office door health person art war history party result
+            change morning reason research girl guy moment air teacher force education foot boy
+            age policy process music market sense nation plan college interest death experience
+            effect class control care field development role effort rate heart drug show leader
+            light voice wife whole police mind price report decision son view relationship town
+            road arm difference value building action model season society tax director position
+            player record paper space ground form event official matter center couple site
+            project activity table court american oil situation cost industry figure street
+            image phone data picture practice piece land product doctor wall patient worker news
+            test movie north love support technology step baby computer type attention film tree
+            source kind truth top current wind fire future site loss bank west sport board
+            subject officer rule case management goal bed order growth listen letter condition
+            choice single dinner rock salt fun horse target prison guard terms demand reporting
+            capital model factor coach energy nice quite sort army bill dog bird lead read write
+            written wrote reads writes reading writing run ran runs running walk walked walking
+            talk talked talking called call calls calling ask asked asking asks need needed
+            needs needing feel felt feels feeling become became becomes leave left leaves let
+            lets put puts mean meant means keep kept keeps begin began begins seem seemed seems
+            help helped helps show showed shows hear heard hears play played plays move moved
+            moves live lived lives believe believed believes bring brought brings happen
+            happened happens must might shall may stand stood stands lose lost loses pay paid
+            pays meet met meets include included includes continue continued continues set sets
+            learn learned learns lead leads understand understood understands watch watched
+            watches follow followed follows stop stopped stops create created creates speak
+            spoke speaks spoken allow allowed allows add added adds spend spent spends grow grew
+            grows grown open opened opens win won wins offer offered offers remember remembered
+            remembers consider considered considers appear appeared appears buy bought buys wait
+            waited waits serve served serves die died dies send sent sends expect expected
+            expects build built builds stay stayed stays fall fell falls fallen cut cuts reach
+            reached reaches kill killed kills remain remained remains suggest suggested suggests
+            raise raised raises pass passed passes sell sold sells require required requires
+            report reported reports decide decided decides pull pulled pulls return returned
+            returns explain explained explains hope hoped hopes develop developed develops carry
+            carried carries break broke breaks broken receive received receives agree agreed
+            agrees support supported supports hit hits produce produced produces eat ate eats
+            eaten cover covered covers catch caught catches draw drew draws drawn choose chose
+            chooses chosen cause caused causes point pointed points fight fought fights
+            provide provided provides turn turned turns start started starts hold held holds
+            big small large great high low long short old young early late important public bad
+            same able best better sure free true full special easy clear recent certain
+            personal open red white black hard possible whole real major military national
+            human local late strong past political available economic social little less least
+            different following international difficult simple both several final main
+            beautiful nice happy serious ready common poor natural significant similar hot cold
+            entire likely federal wrong tough deep dark various entire physical private
+            medical top only close legal religious cold final green nearby blue fine popular
+            traditional cultural fast slow faster slower quick quickly slowly really very too
+            still even also never always often sometimes usually again once twice here where
+            everywhere anywhere together alone almost enough far near away around behind above
+            below between among during before after under since until while against without
+            within along across toward towards perhaps maybe actually probably certainly
+            clearly finally suddenly recently especially instead however although though yet
+            code codes coded coding fast faster answer answers answered answering pie pit pin
+            pine pip pig fasten fascia fashion caste cast paste taste vast last mast past
+            answering clause clawed cloud clouds clout applaud claw claws played plot
+            heaven hessian hasten headset henna herds hedges nab nabbed dev devs debit devote
+            fascism fasted fastest court corked cortex context convex complex coded codecs
+            solve solves solved solving solvent salute pieces piece
+        """.trimIndent()
+        base.split(Regex("\\s+")).forEach { if (it.isNotBlank()) add(it) }
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalCleanupProvider.kt
@@ -64,10 +64,12 @@ object LocalCleanupProvider {
      *
      * Note this is not a regression for the other catalog entry: `mumble-cleanup-2stage` declares
      * its own [Model.localSystemPrompt], which carries no [PostProcessor.VOCABULARY_PLACEHOLDER],
-     * so interpolation was always a no-op for it. Local cleanup has therefore never actually
-     * delivered this feature -- it either did nothing or did harm. Making vocabulary work
-     * on-device needs a deterministic post-processing pass over the model's output rather than a
-     * prompt instruction; that is tracked separately in #182.
+     * so interpolation was always a no-op for it. Vocabulary support for local cleanup is instead
+     * delivered by [VocabularyPostCorrector] (#182 option 2): a deterministic fuzzy-match
+     * correction pass applied to the model's ACCEPTED output in the executor's LOCAL_LLM branch.
+     * Being output-side and model-agnostic, it works identically for both catalog entries and
+     * cannot contaminate any prompt -- which is why this function must keep interpolating an
+     * empty list forever.
      *
      * The placeholder must still be *removed* rather than left in the string. Shipping a literal
      * `{{vocabulary}}` to the model was the original on-device bug: LFM2.5 echoed it back as the

--- a/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/PostProcessor.kt
@@ -324,6 +324,11 @@ explanations, headers, or comments about your edits.
         // a fine-tuned local model (e.g. mumble-cleanup-2stage) can override SIMPLE_PROMPT with its
         // own required training prompt via [LocalCleanupProvider.selectedSystemPrompt].
         localPrompt: String = SIMPLE_PROMPT,
+        // Personal-vocabulary terms for the LOCAL_LLM step's deterministic output post-pass
+        // (#182 option 2) -- passed straight through to [CleanupWaterfallExecutor.execute]'s
+        // localVocabulary; see its kdoc for why local gets a post-pass while cloud steps keep
+        // prompt interpolation.
+        localVocabulary: List<String> = emptyList(),
         // Optional benchmark/quality-log correlation (GH #100, #102), passed straight through to
         // [CleanupWaterfallExecutor.execute] -- see its own kdoc on these same param names.
         benchmarkContext: android.content.Context? = null,
@@ -351,6 +356,7 @@ explanations, headers, or comments about your edits.
             transport = transport,
             localModelPath = localModelPath,
             localPrompt = localPrompt,
+            localVocabulary = localVocabulary,
             benchmarkContext = benchmarkContext,
             benchmarkCorrelationId = benchmarkCorrelationId,
             callback = callback,

--- a/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ProcessTextActivity.kt
@@ -175,6 +175,9 @@ class ProcessTextActivity : Activity() {
                     credentialLookup = { kind -> ProviderCredentialStore.get(this, kind) },
                     localModelPath = { localModelPath },
                     localPrompt = localPrompt,
+                    // #182 option 2: local cleanup applies the same terms as a deterministic
+                    // post-pass over its output instead of in its prompt (which broke LFM2.5).
+                    localVocabulary = vocabulary,
                     // Deliberately no benchmarkContext/correlationId: BenchmarkLogger and
                     // QualityLogger exist to correlate a cleanup stage with the transcription
                     // stage of the same dictation (#100/#105), and a selection-menu cleanup has

--- a/app/src/main/kotlin/com/trevornk/ramblr/VocabularyPostCorrector.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/VocabularyPostCorrector.kt
@@ -1,0 +1,274 @@
+package com.trevornk.ramblr
+
+/**
+ * Deterministic personal-vocabulary correction pass over LOCAL cleanup output (#182, option 2).
+ *
+ * Why post-process instead of prompt: interpolating the vocabulary clause into the local system
+ * prompt made LFM2.5-350M echo the term list back as the "cleaned" transcript (valid-output rate
+ * fell 8/10 -> 2/10 with 22 terms), and `mumble-cleanup-2stage` declares its own training prompt
+ * with no vocabulary placeholder at all -- so prompting delivered the feature for neither local
+ * model. This pass runs AFTER the model, on plain text, so it cannot contaminate the prompt, works
+ * identically for every local model, and is a pure deterministic function that is trivially
+ * unit-testable. Cloud cleanup keeps its prompt interpolation ([PostProcessor.interpolateVocabulary]),
+ * where it demonstrably works; this pass must therefore only be applied to on-device output,
+ * never stacked on a cloud result.
+ *
+ * Design bias: a false positive (rewriting a legitimate word into a vocabulary term) is much
+ * worse than a false negative (leaving a mishearing uncorrected), so every knob here is set
+ * conservatively:
+ *
+ *  - **Word-boundary aware.** Matching operates on whole word tokens, never substrings, so
+ *    "Pi" can never fire inside "spin" and "fastcore" can never rewrite part of "fastcorean".
+ *  - **Bounded edit distance, scaled to length.** Per word: alphanumeric length <= 3 requires an
+ *    exact (case-insensitive) match, 4-6 allows Damerau-Levenshtein distance 1, >= 7 allows 2.
+ *    Multi-word terms additionally cap the summed distance at the whole-term budget.
+ *  - **First letter must agree** (case-insensitively). ASR mishearings of proper nouns almost
+ *    always preserve the initial sound/letter; requiring it removes a large class of accidental
+ *    near-misses ("codex" vs "rodex"-style coincidences) at negligible recall cost.
+ *  - **Common English words are never rewritten.** A fuzzy (distance > 0) candidate that is
+ *    itself an everyday dictionary word ([CommonEnglishWords.contains]) is left alone: "code"
+ *    is one deletion from "Codex", and rewriting it would corrupt ordinary sentences. Exact
+ *    case-insensitive matches bypass this guard -- if the user configured the term "Pi", a
+ *    lowercase "pi" in the output is exactly what they asked to have recased.
+ *  - **Terms containing digits or '@' match exactly only** (case-insensitive). An email address
+ *    or versioned name is high-consequence to guess at; the only correction applied is recasing
+ *    to the canonical spelling.
+ *  - **Ambiguity aborts.** If two different terms match one window at the same best distance,
+ *    neither is applied.
+ *
+ * Replacement preserves nothing of the matched surface except its position: the term's canonical
+ * casing is substituted verbatim. Text that already matches a term exactly (including case) is
+ * left byte-for-byte untouched, which also makes the pass idempotent.
+ */
+object VocabularyPostCorrector {
+
+    /** Per-word Damerau-Levenshtein budget: exact for short words, 1 for medium, 2 for long.
+     *  Length is counted in letters/digits only, so "fast.ai" budgets as 6, not 7. */
+    fun editBudgetFor(alnumLength: Int): Int = when {
+        alnumLength <= 3 -> 0
+        alnumLength <= 6 -> 1
+        else -> 2
+    }
+
+    /**
+     * Applies the correction pass: every near-miss occurrence of a configured term in [text] is
+     * replaced with that term's canonical spelling. Returns [text] unchanged (same instance) when
+     * [terms] is empty or nothing matched. Pure function of its inputs.
+     */
+    fun correct(text: String, terms: List<String>): String {
+        if (terms.isEmpty() || text.isBlank()) return text
+        val specs = terms.mapNotNull(::termSpec)
+        if (specs.isEmpty()) return text
+        val maxWords = specs.maxOf { it.words.size }
+        val tokens = tokenize(text)
+        if (tokens.isEmpty()) return text
+
+        val consumed = BooleanArray(tokens.size)
+        // (startOffset, endOffset, replacementText), non-overlapping, in ascending order.
+        val replacements = ArrayList<Replacement>()
+        var i = 0
+        while (i < tokens.size) {
+            if (consumed[i]) {
+                i++
+                continue
+            }
+            var advancedTo = -1
+            // Longest window first so "Claude Code" wins over a hypothetical "Claude" term.
+            for (n in minOf(maxWords, tokens.size - i) downTo 1) {
+                if ((i until i + n).any { consumed[it] }) continue
+                if (!windowIsAdjacent(text, tokens, i, n)) continue
+                val candidate = List(n) { tokens[i + it].core }
+                val best = bestMatch(candidate, specs) ?: continue
+                val start = tokens[i].coreStart
+                val end = tokens[i + n - 1].coreEnd
+                val surface = text.substring(start, end)
+                if (surface != best.canonical) {
+                    replacements += Replacement(start, end, best.canonical)
+                }
+                for (k in i until i + n) consumed[k] = true
+                advancedTo = i + n
+                break
+            }
+            i = if (advancedTo >= 0) advancedTo else i + 1
+        }
+
+        if (replacements.isEmpty()) return text
+        val out = StringBuilder(text.length + 16)
+        var cursor = 0
+        for (r in replacements) {
+            out.append(text, cursor, r.start).append(r.replacement)
+            cursor = r.end
+        }
+        out.append(text, cursor, text.length)
+        return out.toString()
+    }
+
+    // --- internals ------------------------------------------------------------------------------
+
+    private data class Replacement(val start: Int, val end: Int, val replacement: String)
+
+    /** One word token of the output text. [core] is the token with leading/trailing punctuation
+     *  trimmed (so "Hetzner," matches the term "Hetzner"); [coreStart]/[coreEnd] index [core]'s
+     *  span in the original text, which is the exact span a replacement overwrites -- surrounding
+     *  punctuation survives untouched. */
+    private data class Token(val coreStart: Int, val coreEnd: Int, val core: String)
+
+    /** Characters that may appear INSIDE a word token in addition to letters/digits. Covers the
+     *  shapes real vocabulary terms take: "fast.ai", "Answer.AI", "trevor@nashkellermedia.com",
+     *  "Nash-Keller", "isn't". */
+    private fun isTokenChar(c: Char): Boolean =
+        c.isLetterOrDigit() || c == '\'' || c == '\u2019' || c == '@' || c == '.' || c == '-' || c == '_'
+
+    private fun tokenize(text: String): List<Token> {
+        val tokens = ArrayList<Token>()
+        var pos = 0
+        while (pos < text.length) {
+            if (!isTokenChar(text[pos])) {
+                pos++
+                continue
+            }
+            val start = pos
+            while (pos < text.length && isTokenChar(text[pos])) pos++
+            // Trim to a core that starts and ends on a letter or digit, so sentence punctuation
+            // glued to a word ("Hetzner.", "'Codex'") doesn't defeat matching.
+            var coreStart = start
+            var coreEnd = pos
+            while (coreStart < coreEnd && !text[coreStart].isLetterOrDigit()) coreStart++
+            while (coreEnd > coreStart && !text[coreEnd - 1].isLetterOrDigit()) coreEnd--
+            // Strip a trailing possessive ('s / \u2019s) from the core so "hetzner's" matches the
+            // term "Hetzner" on its stem and the replacement leaves the possessive suffix in
+            // place ("Hetzner's"), instead of the whole token fuzzy-matching the term and the
+            // correction silently swallowing the apostrophe-s.
+            if (coreEnd - coreStart > 2 &&
+                (text[coreEnd - 1] == 's' || text[coreEnd - 1] == 'S') &&
+                (text[coreEnd - 2] == '\'' || text[coreEnd - 2] == '\u2019')
+            ) {
+                coreEnd -= 2
+            }
+            if (coreEnd > coreStart) {
+                tokens += Token(coreStart, coreEnd, text.substring(coreStart, coreEnd))
+            }
+        }
+        return tokens
+    }
+
+    /** A multi-word window is only a candidate when nothing but whitespace separates its words'
+     *  cores: "Claude Code" spans a plain space, but "Claude. Code" has a sentence boundary
+     *  between the cores and must not be treated as one term occurrence. */
+    private fun windowIsAdjacent(text: String, tokens: List<Token>, first: Int, count: Int): Boolean {
+        for (k in first until first + count - 1) {
+            val gap = text.substring(tokens[k].coreEnd, tokens[k + 1].coreStart)
+            if (gap.isEmpty() || !gap.all { it.isWhitespace() }) return false
+        }
+        return true
+    }
+
+    private class TermSpec(
+        val canonical: String,
+        /** Lowercased word cores of the canonical spelling, split on whitespace. */
+        val words: List<String>,
+        /** Digits/'@' make a term exact-match-only: see class kdoc. */
+        val exactOnly: Boolean,
+        /** Whole-term distance cap (sum across words), from the term's total alnum length. */
+        val totalBudget: Int,
+    )
+
+    private fun termSpec(term: String): TermSpec? {
+        val words = term.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+            .map { word -> word.trim { c -> !c.isLetterOrDigit() }.lowercase() }
+            .filter { it.isNotEmpty() }
+        if (words.isEmpty()) return null
+        val alnumTotal = words.sumOf { w -> w.count { it.isLetterOrDigit() } }
+        val exactOnly = term.any { it.isDigit() || it == '@' }
+        return TermSpec(term.trim(), words, exactOnly, editBudgetFor(alnumTotal))
+    }
+
+    /** The unique best-matching spec for [candidate] (word cores of one window), or null when
+     *  nothing matches or the best distance is shared by two different terms. */
+    private fun bestMatch(candidate: List<String>, specs: List<TermSpec>): TermSpec? {
+        var best: TermSpec? = null
+        var bestDistance = Int.MAX_VALUE
+        var ambiguous = false
+        for (spec in specs) {
+            val d = matchDistance(candidate, spec) ?: continue
+            if (d < bestDistance) {
+                best = spec
+                bestDistance = d
+                ambiguous = false
+            } else if (d == bestDistance && best != null && spec.canonical != best.canonical) {
+                ambiguous = true
+            }
+        }
+        return if (ambiguous) null else best
+    }
+
+    /**
+     * Total edit distance if [candidate] is an acceptable occurrence of [spec], else null.
+     *
+     * Multi-word anchoring: in a multi-word window where at least one word already matches its
+     * term word exactly, the remaining fuzzy words get one extra point of edit budget (capped at
+     * 2) and are allowed to be common English words. The exact sibling is strong contextual
+     * evidence -- "clawed code" is vanishingly unlikely to be legitimate prose, but is a classic
+     * ASR rendering of "Claude Code" -- whereas a lone common word ("code", "fast", "answer")
+     * carries no such evidence and stays protected.
+     */
+    private fun matchDistance(candidate: List<String>, spec: TermSpec): Int? {
+        if (candidate.size != spec.words.size) return null
+        val lowered = candidate.map { it.lowercase() }
+        if (lowered == spec.words) return 0
+        if (spec.exactOnly || spec.totalBudget == 0) return null
+        val anchored = spec.words.size > 1 &&
+            spec.words.indices.any { lowered[it] == spec.words[it] }
+        var total = 0
+        for (j in spec.words.indices) {
+            val cand = lowered[j]
+            val word = spec.words[j]
+            if (cand == word) continue
+            // Mishearings of names/jargon nearly always keep the first letter; requiring it
+            // cheaply eliminates most coincidental near-misses.
+            if (cand.first() != word.first()) return null
+            // A fuzzy candidate that is itself an everyday word must never be rewritten --
+            // "code" -> "Codex" would corrupt ordinary prose -- unless an exact sibling word
+            // anchors the window (see kdoc above). Exact matches returned above.
+            if (!anchored && CommonEnglishWords.contains(cand)) return null
+            val budget = (editBudgetFor(word.count { it.isLetterOrDigit() }) + if (anchored) 1 else 0)
+                .coerceAtMost(2)
+            if (budget == 0) return null
+            val d = boundedDamerauLevenshtein(cand, word, budget) ?: return null
+            total += d
+            if (total > spec.totalBudget) return null
+        }
+        return total
+    }
+
+    /**
+     * Damerau-Levenshtein (optimal string alignment) distance between [a] and [b], or null when
+     * it exceeds [max]. Plain O(len_a * len_b) DP -- inputs are single words, so no banding is
+     * needed. Transposition counts 1 because swapped adjacent letters ("clawed" ~ "claude"'s
+     * "ed"/"de") are a classic ASR/typo shape.
+     */
+    private fun boundedDamerauLevenshtein(a: String, b: String, max: Int): Int? {
+        if (kotlin.math.abs(a.length - b.length) > max) return null
+        val rows = a.length + 1
+        val cols = b.length + 1
+        val d = Array(rows) { IntArray(cols) }
+        for (r in 0 until rows) d[r][0] = r
+        for (c in 0 until cols) d[0][c] = c
+        for (r in 1 until rows) {
+            for (c in 1 until cols) {
+                val cost = if (a[r - 1] == b[c - 1]) 0 else 1
+                var v = minOf(
+                    d[r - 1][c] + 1, // deletion
+                    d[r][c - 1] + 1, // insertion
+                    d[r - 1][c - 1] + cost, // substitution
+                )
+                if (r > 1 && c > 1 && a[r - 1] == b[c - 2] && a[r - 2] == b[c - 1]) {
+                    v = minOf(v, d[r - 2][c - 2] + 1) // transposition
+                }
+                d[r][c] = v
+            }
+        }
+        val result = d[a.length][b.length]
+        return if (result <= max) result else null
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/VocabularyTerms.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/VocabularyTerms.kt
@@ -42,27 +42,42 @@ object VocabularyTerms {
 
     /**
      * Whether the vocabulary terms are actually applied anywhere in the user's current
-     * configuration (#185). After #182 removed the vocabulary clause from local cleanup (it made
-     * LFM2.5 echo the term list) and #131 closed local-ASR hotword biasing as not-planned, the
-     * terms only reach the two CLOUD paths:
+     * configuration (#185, updated for #182 option 2). The terms reach three paths:
      *
      *  - cloud transcription ([TranscriberClient.vocabularyFormParts] / Gemini's inline prompt)
      *  - cloud cleanup ([PostProcessor.interpolateVocabulary] on the persona prompt)
+     *  - LOCAL cleanup, as a deterministic post-pass over the model's output
+     *    ([VocabularyPostCorrector], #182 option 2) -- NOT via the prompt, which made LFM2.5
+     *    echo the term list; the post-pass is model-agnostic, so `mumble-cleanup-2stage` gets
+     *    vocabulary support too despite declaring its own placeholder-free training prompt.
      *
-     * A fully-local setup -- local ASR plus local-only cleanup, the F-Droid-recommended,
-     * privacy-motivated configuration -- ignores every term. The Settings UI uses this to say so
-     * instead of letting users discover it from behavior.
+     * Only local *transcription* still ignores the terms (#131 closed local-ASR hotword biasing
+     * as not-planned). So the fully-local privacy configuration -- local ASR plus local cleanup
+     * -- now DOES apply the vocabulary, at the cleanup stage; the terms are only inert when no
+     * cleanup path is active at all on top of local transcription. The Settings UI uses this to
+     * say so instead of letting users discover it from behavior.
      *
-     * [cloudCleanupActive] must already fold in everything cloud cleanup needs (cleanup on,
-     * the cloud gate enabled, and a cloud-capable chain entry present); this stays a pure
-     * function of the two path-level booleans.
+     * Each `*Active` flag must already fold in everything that path needs to actually run
+     * (toggles, gates, chain entries, an installed model for local cleanup); this stays a pure
+     * function of the three path-level booleans.
      */
-    fun inEffect(cloudTranscriptionActive: Boolean, cloudCleanupActive: Boolean): Boolean =
-        cloudTranscriptionActive || cloudCleanupActive
+    fun inEffect(
+        cloudTranscriptionActive: Boolean,
+        cloudCleanupActive: Boolean,
+        localCleanupActive: Boolean,
+    ): Boolean = cloudTranscriptionActive || cloudCleanupActive || localCleanupActive
 
-    /** The user-facing note shown when [inEffect] is false (#185); null when terms do apply. */
-    fun localOnlyNote(cloudTranscriptionActive: Boolean, cloudCleanupActive: Boolean): String? =
-        if (inEffect(cloudTranscriptionActive, cloudCleanupActive)) null
-        else "Your current setup is fully on-device, so these terms are not used: local " +
-            "transcription and local cleanup don't support vocabulary biasing."
+    /** The user-facing note shown when [inEffect] is false (#185); null when terms do apply.
+     *  Since #182's post-pass made local cleanup vocabulary-capable, this only fires when local
+     *  transcription runs with no active cleanup at all -- the one remaining configuration where
+     *  the terms genuinely do nothing. */
+    fun localOnlyNote(
+        cloudTranscriptionActive: Boolean,
+        cloudCleanupActive: Boolean,
+        localCleanupActive: Boolean,
+    ): String? =
+        if (inEffect(cloudTranscriptionActive, cloudCleanupActive, localCleanupActive)) null
+        else "Your current setup is local transcription with cleanup off, so these terms are " +
+            "not used: local transcription doesn't support vocabulary biasing. They apply " +
+            "once cleanup is enabled."
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -3015,6 +3015,9 @@ class WhisperAccessibilityService : AccessibilityService() {
                 credentialLookup = { kind -> ProviderCredentialStore.get(this, kind) },
                 localModelPath = { ModelDownloader.localCleanupModelFile(this, LocalCleanupProvider.selectedModel(this))?.absolutePath },
                 localPrompt = LocalCleanupProvider.selectedSystemPrompt(this),
+                // #182 option 2: local cleanup applies the same terms as a deterministic
+                // post-pass over its output instead of in its prompt (which broke LFM2.5).
+                localVocabulary = vocabulary,
                 benchmarkContext = this,
                 benchmarkCorrelationId = correlationIdFor(token),
             ) { result ->

--- a/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CleanupWaterfallExecutorTest.kt
@@ -489,6 +489,7 @@ class LocalLlmWaterfallStepTest {
         localModelPath: () -> String?,
         credentialLookup: (CleanupCredentialSlot) -> String = { "" },
         localPrompt: String = PostProcessor.SIMPLE_PROMPT,
+        localVocabulary: List<String> = emptyList(),
         text: String = "raw transcript",
     ): PostProcessor.Result {
         var captured: PostProcessor.Result? = null
@@ -503,6 +504,7 @@ class LocalLlmWaterfallStepTest {
             localInference = localInference,
             localModelPath = localModelPath,
             localPrompt = localPrompt,
+            localVocabulary = localVocabulary,
             callback = { captured = it },
         )
         return captured ?: error("callback never fired")
@@ -549,6 +551,53 @@ class LocalLlmWaterfallStepTest {
 
         assertEquals(1, engine.calls.size)
         assertEquals(PostProcessor.SIMPLE_PROMPT, engine.calls[0].first)
+    }
+
+    // --- #182 option 2: vocabulary post-pass over accepted local output ------------------------
+
+    @Test fun `accepted local output goes through the vocabulary post-pass`() {
+        val transport = FakeCleanupHttpTransport(mutableListOf())
+        val engine = FakeLocalInferenceEngine(mutableListOf(LocalInferenceResult.Success("Deployed it on hetzler last night.")))
+        val waterfall = CleanupWaterfall(listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, LOCAL_CLEANUP_MODEL.archive)))
+
+        val result = execute(
+            waterfall, transport, engine,
+            localModelPath = { "/data/data/app/files/cleanup_models/model.gguf" },
+            localVocabulary = listOf("Hetzner"),
+        )
+
+        assertEquals("Deployed it on Hetzner last night.", result.text)
+        // The terms must reach the model's OUTPUT, never its prompt (#182: prompt interpolation
+        // is what made LFM2.5 echo the term list).
+        assertEquals(PostProcessor.SIMPLE_PROMPT, engine.calls[0].first)
+    }
+
+    @Test fun `the vocabulary post-pass defaults to a no-op when no terms are passed`() {
+        val transport = FakeCleanupHttpTransport(mutableListOf())
+        val engine = FakeLocalInferenceEngine(mutableListOf(LocalInferenceResult.Success("Deployed it on hetzler last night.")))
+        val waterfall = CleanupWaterfall(listOf(CleanupStep(CleanupStepGroup.LOCAL_LLM, LOCAL_CLEANUP_MODEL.archive)))
+
+        val result = execute(waterfall, transport, engine, localModelPath = { "/data/data/app/files/cleanup_models/model.gguf" })
+
+        assertEquals("Deployed it on hetzler last night.", result.text)
+    }
+
+    @Test fun `cloud output is not run through the vocabulary post-pass`() {
+        // Cloud cleanup gets vocabulary via prompt interpolation on [prompt] -- applying the
+        // post-pass there too would double-apply the feature. A cloud result containing a
+        // near-miss must come back verbatim even with localVocabulary configured.
+        val transport = FakeCleanupHttpTransport(mutableListOf(okOutcome("Deployed it on hetzler last night.")))
+        val engine = FakeLocalInferenceEngine(mutableListOf())
+        val waterfall = CleanupWaterfall(listOf(CleanupStep(CleanupStepGroup.OMNIROUTE, "some-model")))
+
+        val result = execute(
+            waterfall, transport, engine,
+            localModelPath = { null },
+            credentialLookup = { "a-key" },
+            localVocabulary = listOf("Hetzner"),
+        )
+
+        assertEquals("Deployed it on hetzler last night.", result.text)
     }
 
     @Test fun `a cancelled local inference stops the waterfall instead of falling through`() {

--- a/app/src/test/kotlin/com/trevornk/ramblr/VocabularyPostCorrectorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/VocabularyPostCorrectorTest.kt
@@ -1,0 +1,273 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Coverage for [VocabularyPostCorrector] (#182 option 2): the deterministic vocabulary
+ * correction pass over local cleanup output that replaced prompt interpolation (which made
+ * LFM2.5-350M echo the term list) and finally delivers vocabulary support for BOTH local models.
+ *
+ * The tests encode the pass's conservatism contract explicitly: a false positive (rewriting
+ * legitimate prose into a vocabulary term) is much worse than a false negative, so the
+ * guard tests here are as load-bearing as the correction tests.
+ */
+class VocabularyPostCorrectorTest {
+
+    private val defaults = VocabularyTerms.DEFAULTS
+
+    // --- no-op cases ---------------------------------------------------------------------------
+
+    @Test fun `empty term list returns the text unchanged, same instance`() {
+        val text = "This is a perfectly normal sentence."
+        assertSame(text, VocabularyPostCorrector.correct(text, emptyList()))
+    }
+
+    @Test fun `blank text is returned unchanged`() {
+        assertEquals("", VocabularyPostCorrector.correct("", defaults))
+        assertEquals("   ", VocabularyPostCorrector.correct("   ", defaults))
+    }
+
+    @Test fun `text already matching a term exactly is untouched`() {
+        val text = "I set up Hetzner with FastHTML yesterday."
+        assertEquals(text, VocabularyPostCorrector.correct(text, defaults))
+    }
+
+    @Test fun `text with no term occurrences at all is untouched`() {
+        val text = "We walked to the store and bought some milk."
+        assertEquals(text, VocabularyPostCorrector.correct(text, defaults))
+    }
+
+    @Test fun `the pass is idempotent`() {
+        val once = VocabularyPostCorrector.correct("I deployed it on hetzler's cloud.", listOf("Hetzner"))
+        assertEquals("I deployed it on Hetzner's cloud.", once)
+        assertEquals(once, VocabularyPostCorrector.correct(once, listOf("Hetzner")))
+    }
+
+    @Test fun `a possessive keeps its apostrophe-s through a recase`() {
+        assertEquals(
+            "Hetzner's dashboard is fine.",
+            VocabularyPostCorrector.correct("hetzner's dashboard is fine.", listOf("Hetzner")),
+        )
+    }
+
+    // --- case preservation ---------------------------------------------------------------------
+
+    @Test fun `a case-insensitive exact match is recased to the canonical spelling`() {
+        assertEquals(
+            "Deployed on Hetzner last night.",
+            VocabularyPostCorrector.correct("Deployed on hetzner last night.", listOf("Hetzner")),
+        )
+    }
+
+    @Test fun `an all-caps mishearing of a term is recased`() {
+        assertEquals(
+            "FastHTML is neat.",
+            VocabularyPostCorrector.correct("FASTHTML is neat.", listOf("FastHTML")),
+        )
+    }
+
+    // --- near-miss single word -----------------------------------------------------------------
+
+    @Test fun `a one-edit mishearing of a medium-length term is corrected`() {
+        // "hetzler" -> "Hetzner": distance 1 (substitution), length 7, first letter matches,
+        // not a common English word.
+        assertEquals(
+            "The server runs on Hetzner now.",
+            VocabularyPostCorrector.correct("The server runs on hetzler now.", listOf("Hetzner")),
+        )
+    }
+
+    @Test fun `a transposition mishearing is corrected`() {
+        // "nbdve" -> "nbdev": adjacent transposition, distance 1.
+        assertEquals(
+            "Published with nbdev today.",
+            VocabularyPostCorrector.correct("Published with nbdve today.", listOf("nbdev")),
+        )
+    }
+
+    @Test fun `a two-edit mishearing of a long term is corrected`() {
+        // "fasthamel" -> "fasthtml": length 8 core allows distance 2.
+        assertEquals(
+            "I built the site in FastHTML.",
+            VocabularyPostCorrector.correct("I built the site in fasthamel.", listOf("FastHTML")),
+        )
+    }
+
+    @Test fun `punctuation glued to the mishearing survives the replacement`() {
+        assertEquals(
+            "We moved to Hetzner, then scaled up.",
+            VocabularyPostCorrector.correct("We moved to hetzler, then scaled up.", listOf("Hetzner")),
+        )
+    }
+
+    // --- multi-word terms ----------------------------------------------------------------------
+
+    @Test fun `a two-word term with one misheard word is corrected as a unit`() {
+        // "clawed code" -> "Claude Code": "clawed" is a common word but the exact "code" sibling
+        // anchors the window (see matchDistance kdoc).
+        assertEquals(
+            "I asked Claude Code to fix it.",
+            VocabularyPostCorrector.correct("I asked clawed code to fix it.", listOf("Claude Code")),
+        )
+    }
+
+    @Test fun `a two-word term in the wrong case is recased`() {
+        assertEquals(
+            "Claude Code finished the task.",
+            VocabularyPostCorrector.correct("claude code finished the task.", listOf("Claude Code")),
+        )
+    }
+
+    @Test fun `a multi-word term split by a sentence boundary is not treated as one occurrence`() {
+        // "...Claude. Code..." spans a sentence boundary between the cores -- must not be fused.
+        val text = "I like Claude. Code reviews are separate."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("Claude Code")))
+    }
+
+    @Test fun `the longest matching term wins over a shorter one`() {
+        // Both "Claude" and "Claude Code" configured: the two-word window must be consumed by
+        // the longer term, not corrected word-by-word.
+        assertEquals(
+            "Ask Claude Code about it.",
+            VocabularyPostCorrector.correct("Ask claude code about it.", listOf("Claude", "Claude Code")),
+        )
+    }
+
+    // --- word-boundary safety ------------------------------------------------------------------
+
+    @Test fun `a term is never corrected inside a longer word`() {
+        // "spin" contains "pi"; "fastcorelike" contains "fastcore" but is 4 edits away as a
+        // whole token -- word-boundary tokenization plus the edit budget must leave both alone.
+        val text = "The spin class had a fastcorelike vibe."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("Pi", "fastcore")))
+    }
+
+    @Test fun `a short term requires an exact match`() {
+        // "Pi" (length 2) has edit budget 0: "pie" and "pin" must survive, exact "pi" is recased.
+        assertEquals(
+            "Pi is running, the pie is baking, the pin is set.",
+            VocabularyPostCorrector.correct("pi is running, the pie is baking, the pin is set.", listOf("Pi")),
+        )
+    }
+
+    // --- false-positive guards (the conservatism contract) -------------------------------------
+
+    @Test fun `a common English word near a term is never rewritten`() {
+        // "code" is distance 1 from "Codex" and "fast" is the core of "fast.ai"'s first token --
+        // both are everyday words and must survive. This is the single most important test in
+        // the file: without the common-word guard the pass corrupts ordinary prose.
+        val text = "I write code fast and answer emails."
+        assertEquals(text, VocabularyPostCorrector.correct(text, defaults))
+    }
+
+    @Test fun `a fuzzy candidate with a different first letter is never rewritten`() {
+        // "rodex" is distance 1 from "codex" but starts differently -- mishearings keep the
+        // initial sound, so this is a coincidence, not a mishearing.
+        val text = "The rodex was on the desk."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("Codex")))
+    }
+
+    @Test fun `two terms tying at the same distance abort the correction`() {
+        // "hetzfer" is distance 1 from both fictional terms; ambiguity must yield no rewrite.
+        val text = "It runs on hetzfer today."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("Hetzner", "Hetzler")))
+    }
+
+    @Test fun `codex mishearing is corrected while the word code is preserved in the same sentence`() {
+        // "codix" -> "Codex" (distance 1, not an English word) while "code" (a common word one
+        // deletion from "Codex") survives in the same sentence.
+        assertEquals(
+            "Codex wrote the code for me.",
+            VocabularyPostCorrector.correct("codix wrote the code for me.", listOf("Codex")),
+        )
+    }
+
+    // --- punctuated and email terms ------------------------------------------------------------
+
+    @Test fun `a dotted term is corrected from a near-miss`() {
+        // "fast.ay" -> "fast.ai": the dotted term tokenizes as one core, distance 1.
+        assertEquals(
+            "The fast.ai course is great.",
+            VocabularyPostCorrector.correct("The fast.ay course is great.", listOf("fast.ai")),
+        )
+    }
+
+    @Test fun `a dotted term is recased on an exact case-insensitive match`() {
+        assertEquals(
+            "Answer.AI shipped a model.",
+            VocabularyPostCorrector.correct("answer.ai shipped a model.", listOf("Answer.AI")),
+        )
+    }
+
+    @Test fun `an email term only matches exactly -- near misses are left alone`() {
+        // '@' makes the term exact-only: guessing at email corrections is high-consequence.
+        val text = "Mail trevor@nashkellermedio.com about it."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("trevor@nashkellermedia.com")))
+    }
+
+    @Test fun `an email term is recased on an exact case-insensitive match`() {
+        assertEquals(
+            "Mail trevor@nashkellermedia.com today.",
+            VocabularyPostCorrector.correct("Mail Trevor@NashKellerMedia.com today.", listOf("trevor@nashkellermedia.com")),
+        )
+    }
+
+    @Test fun `a term containing digits only matches exactly`() {
+        val text = "The lfm3 model is loaded."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("LFM2")))
+        assertEquals(
+            "The LFM2 model is loaded.",
+            VocabularyPostCorrector.correct("The lfm2 model is loaded.", listOf("LFM2")),
+        )
+    }
+
+    @Test fun `a hyphenated name is corrected from a near-miss`() {
+        assertEquals(
+            "Send it to Nash-Keller today.",
+            VocabularyPostCorrector.correct("Send it to nash-kellar today.", listOf("Nash-Keller")),
+        )
+    }
+
+    // --- structure preservation ----------------------------------------------------------------
+
+    @Test fun `multiple corrections in one text all apply and surrounding text is untouched`() {
+        assertEquals(
+            "Hetzner hosts it; nbdev builds it, and FastHTML renders it.",
+            VocabularyPostCorrector.correct(
+                "hetzler hosts it; nbdve builds it, and fasthamel renders it.",
+                listOf("Hetzner", "nbdev", "FastHTML"),
+            ),
+        )
+    }
+
+    @Test fun `whitespace and newlines around corrections are preserved`() {
+        assertEquals(
+            "Line one Hetzner.\nLine two  nbdev.",
+            VocabularyPostCorrector.correct("Line one hetzler.\nLine two  nbdve.", listOf("Hetzner", "nbdev")),
+        )
+    }
+
+    @Test fun `blank and whitespace-only terms are ignored`() {
+        val text = "Nothing should change here."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("", "   ")))
+    }
+
+    // --- edit budget pinning -------------------------------------------------------------------
+
+    @Test fun `edit budget scales with term length`() {
+        assertEquals(0, VocabularyPostCorrector.editBudgetFor(2))
+        assertEquals(0, VocabularyPostCorrector.editBudgetFor(3))
+        assertEquals(1, VocabularyPostCorrector.editBudgetFor(4))
+        assertEquals(1, VocabularyPostCorrector.editBudgetFor(6))
+        assertEquals(2, VocabularyPostCorrector.editBudgetFor(7))
+        assertEquals(2, VocabularyPostCorrector.editBudgetFor(20))
+    }
+
+    @Test fun `a candidate past the edit budget is not corrected`() {
+        // "hetlanders" is distance 4 from "hetzner" -- way past budget 2.
+        val text = "The hetlanders arrived early."
+        assertEquals(text, VocabularyPostCorrector.correct(text, listOf("Hetzner")))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/VocabularyTermsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/VocabularyTermsTest.kt
@@ -76,44 +76,62 @@ class VocabularyTermsTest {
         }
     }
 
-    // --- inEffect / localOnlyNote (#185) ---
+    // --- inEffect / localOnlyNote (#185, updated for #182 option 2) ---
 
     @Test
     fun inEffectWhenCloudTranscriptionIsActive() {
-        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = false))
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = false, localCleanupActive = false))
     }
 
     @Test
     fun inEffectWhenCloudCleanupIsActive() {
-        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = true))
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = true, localCleanupActive = false))
     }
 
     @Test
-    fun inEffectWhenBothCloudPathsAreActive() {
-        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = true))
+    fun inEffectWhenLocalCleanupIsActive() {
+        // #182 option 2: local cleanup applies the terms via VocabularyPostCorrector's output
+        // post-pass, so the F-Droid-recommended fully-local configuration (local ASR + local
+        // cleanup) now genuinely uses the vocabulary -- the exact gap #185's note used to admit.
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = false, localCleanupActive = true))
     }
 
     @Test
-    fun notInEffectInFullyLocalMode() {
-        // The F-Droid-recommended privacy configuration: local ASR + local cleanup. After #182
-        // (local cleanup no longer receives the terms) and #131 (local ASR hotword biasing not
-        // planned), no path applies the vocabulary here.
-        assertFalse(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = false))
+    fun inEffectWhenEveryPathIsActive() {
+        assertTrue(VocabularyTerms.inEffect(cloudTranscriptionActive = true, cloudCleanupActive = true, localCleanupActive = true))
+    }
+
+    @Test
+    fun notInEffectWithLocalTranscriptionAndNoCleanupAtAll() {
+        // The one remaining inert configuration: local ASR (no hotword biasing, #131) with
+        // cleanup fully off -- no cleanup stage exists to run the #182 post-pass.
+        assertFalse(VocabularyTerms.inEffect(cloudTranscriptionActive = false, cloudCleanupActive = false, localCleanupActive = false))
     }
 
     @Test
     fun localOnlyNoteIsNullWheneverTermsApply() {
-        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = false))
-        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = true))
-        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = true))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = false, localCleanupActive = false))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = true, localCleanupActive = false))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = false, localCleanupActive = true))
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = true, cloudCleanupActive = true, localCleanupActive = true))
     }
 
     @Test
-    fun localOnlyNoteExplainsTheInertSettingInFullyLocalMode() {
-        val note = VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = false)
+    fun localOnlyNoteIsNullInFullyLocalModeWithLocalCleanupActive() {
+        // Regression pin for the #182 semantics change: local ASR + working local cleanup used
+        // to show the "not used" note; the post-pass makes that claim false, so no note.
+        assertNull(VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = false, localCleanupActive = true))
+    }
+
+    @Test
+    fun localOnlyNoteExplainsTheInertSettingWhenNoPathApplies() {
+        val note = VocabularyTerms.localOnlyNote(cloudTranscriptionActive = false, cloudCleanupActive = false, localCleanupActive = false)
         assertNotNull(note)
         // The note must say the terms are NOT used -- that's the whole point of #185: the
-        // setting must stop misrepresenting itself in local-only mode.
+        // setting must stop misrepresenting itself when nothing applies it. It must also not
+        // blame local cleanup anymore -- since #182's post-pass, local cleanup DOES support
+        // the vocabulary; only transcription lacks it.
         assertTrue(note!!.contains("not used"))
+        assertFalse(note.contains("local cleanup don't"))
     }
 }


### PR DESCRIPTION
VocabularyPostCorrector applies the user's personal vocabulary as a
fuzzy-match correction pass over local cleanup output -- issue #182's
option 2, the only route that delivers vocabulary support for both
local models. Prompt interpolation made LFM2.5-350M echo the term list
(8/10 -> 2/10 valid with 22 terms) and mumble-cleanup-2stage's training
prompt has no placeholder, so the prompt path served neither.

The pass is deliberately conservative -- a false positive (rewriting
legitimate prose into a term) is much worse than a false negative:

- word-boundary tokenization; never touches substrings of longer words
- bounded Damerau-Levenshtein distance scaled to term length
  (<=3 alnum chars: exact only; 4-6: distance 1; >=7: distance 2)
- first letter must match case-insensitively
- fuzzy candidates that are themselves common English words are never
  rewritten (CommonEnglishWords guard), unless a multi-word window is
  anchored by an exact sibling word ("clawed code" -> "Claude Code")
- terms containing digits or '@' (emails) match exactly only
- ambiguity between two terms at the same distance aborts the rewrite
- exact-case matches are untouched; the pass is idempotent

Pure Kotlin stdlib, no new dependencies; deterministic object functions
mirroring VocabularyTerms/PostProcessingToggle style.

Advances #182
