### PR TITLE
Make Canary source language user-configurable (#177)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
@@ -43,6 +43,7 @@ class BehaviorActivity : BaseSettingsActivity() {
     private var silenceAutoStopPendingEnable = false
     private lateinit var vocabularyRowSub: TextView
     private lateinit var localThreadsRowSub: TextView
+    private lateinit var canaryLanguageRowSub: TextView
     private lateinit var compressedUploadSwitch: MaterialSwitch
     // Built unconditionally and shown/hidden in refresh() (#L16): building it only when hidden at
     // onCreate meant hiding the icon via the overlay while this screen was paused left no way back
@@ -228,6 +229,15 @@ class BehaviorActivity : BaseSettingsActivity() {
         localThreadsRowSub = localThreadsRow.findViewWithTag("subtitle")
         root.addView(localThreadsRow)
 
+        // Canary source language (#177): same developer-ish tuning tier as the threads knob
+        // above. Only the Canary model reads this -- see CanaryLanguage's kdoc for why the
+        // wrong language token doesn't just degrade output but collapses it entirely.
+        val canaryLanguageRow = settingsRow("Canary language", canaryLanguageSummary()) {
+            promptCanaryLanguage()
+        }
+        canaryLanguageRowSub = canaryLanguageRow.findViewWithTag("subtitle")
+        root.addView(canaryLanguageRow)
+
         setContentView(ScrollView(this).apply {
             setBackgroundColor(attrColor(android.R.attr.colorBackground))
             addView(root)
@@ -256,6 +266,7 @@ class BehaviorActivity : BaseSettingsActivity() {
         compressedUploadSwitch.isChecked = CompressedUploadToggle.isEnabled(this)
         vocabularyRowSub.text = vocabularySummary()
         localThreadsRowSub.text = localThreadsSummary()
+        canaryLanguageRowSub.text = canaryLanguageSummary()
         autoPeekDelayRow.findViewWithTag<TextView>("subtitle").text = autoPeekDelaySummary()
         peekSizeRow.findViewWithTag<TextView>("subtitle").text = peekSizeSummary()
     }
@@ -572,6 +583,59 @@ class BehaviorActivity : BaseSettingsActivity() {
             .setCustomTitle(titleView)
             .setSingleChoiceItems(labels, checkedIndex) { dialog, which ->
                 LocalTranscriptionThreads.setThreads(this, presets[which])
+                refresh()
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    // --- Canary source language (#177) ---
+
+    private val canaryLanguageLabels = mapOf(
+        "en" to "English (en)",
+        "es" to "Spanish (es)",
+        "de" to "German (de)",
+        "fr" to "French (fr)",
+    )
+
+    private fun canaryLanguageSummary(): String {
+        val lang = CanaryLanguage.languageOrDefault(this)
+        val label = canaryLanguageLabels[lang] ?: lang
+        return "$label -- the language you speak when dictating with the Canary local model. " +
+            "Only affects Canary; other models ignore this"
+    }
+
+    /** Fixed-list picker modeled on [promptLocalTranscriptionThreads]: exactly the four languages
+     *  the shipped canary-180m-flash model supports, no free-form entry. */
+    private fun promptCanaryLanguage() {
+        // Same AlertDialog gotcha as promptLocalTranscriptionThreads: setMessage() and
+        // setSingleChoiceItems() share the content area, so the explanatory copy must ride in a
+        // custom title view or the language list silently never renders.
+        val languages = CanaryLanguage.SUPPORTED
+        val labels = languages.map { canaryLanguageLabels[it] ?: it }.toTypedArray()
+        val current = CanaryLanguage.languageOrDefault(this)
+        val checkedIndex = languages.indexOf(current).let { if (it < 0) 0 else it }
+        val titleView = vertical(dp(20), dp(20)).apply {
+            addView(TextView(this@BehaviorActivity).apply {
+                text = "Canary language"
+                textSize = 20f
+                setTextColor(attrColor(android.R.attr.textColorPrimary))
+            })
+            addView(TextView(this@BehaviorActivity).apply {
+                text = "The language you speak when dictating with the Canary local model. " +
+                    "Canary needs to be told the source language -- with the wrong one it " +
+                    "produces garbage instead of text. Only affects the Canary model; other " +
+                    "local models detect or fix their language on their own."
+                textSize = 14f
+                setTextColor(attrColor(android.R.attr.textColorSecondary))
+                setPadding(0, dp(8), 0, 0)
+            })
+        }
+        android.app.AlertDialog.Builder(this)
+            .setCustomTitle(titleView)
+            .setSingleChoiceItems(labels, checkedIndex) { dialog, which ->
+                CanaryLanguage.setLanguage(this, languages[which])
                 refresh()
                 dialog.dismiss()
             }

--- a/app/src/main/kotlin/com/trevornk/ramblr/CanaryLanguage.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CanaryLanguage.kt
@@ -1,0 +1,49 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * User-configurable source language for the NeMo Canary local model (#177), wired into the
+ * `srcLang`/`tgtLang` fields of the canary branch in [LocalTranscriber.detectModelConfig].
+ * Only the Canary model consumes this -- every other local model (Whisper, Parakeet, Moonshine,
+ * NeMo CTC) has no language-token concept in its sherpa-onnx config and ignores it entirely.
+ *
+ * Canary is a prompted multilingual model: decoding starts from a source-language token, and the
+ * wrong token doesn't just degrade accuracy -- it collapses output entirely. Measured 2026-08-26
+ * on the Fold: canary-180m-flash's own bundled `de.wav` decodes to degenerate " E E E E…" under
+ * the previously hardcoded `srcLang = "en"`, while `en.wav` is perfect. So non-English speech was
+ * simply broken until the token became configurable.
+ *
+ * Defaults to [DEFAULT] = "en", the value the config was hardcoded to before this setting
+ * existed, so shipping this is purely additive: nobody who never opens the setting sees any
+ * change in behavior. Both `srcLang` and `tgtLang` get the same value -- Canary treats matching
+ * src/tgt as plain transcription; mismatched values mean *translation*, which is out of scope
+ * for a dictation app (#177).
+ */
+object CanaryLanguage {
+    private const val PREFS_NAME = "ramblr"
+    const val KEY = "canary_src_lang"
+    const val DEFAULT = "en"
+
+    /** The exact language set of the shipped canary-180m-flash-en-es-de-fr model -- not a general
+     *  language list. A different Canary variant in the catalog would need its own set. */
+    val SUPPORTED = listOf("en", "es", "de", "fr")
+
+    fun languageOrDefault(prefs: SharedPreferences): String {
+        val stored = prefs.getString(KEY, DEFAULT) ?: DEFAULT
+        // Coerce unknown values (corrupt pref, or a future model's language leaking back onto
+        // this one) to the safe default rather than handing sherpa-onnx a token it can't map.
+        return if (stored in SUPPORTED) stored else DEFAULT
+    }
+
+    fun setLanguage(prefs: SharedPreferences, language: String) {
+        prefs.edit().putString(KEY, if (language in SUPPORTED) language else DEFAULT).apply()
+    }
+
+    fun languageOrDefault(context: Context): String = languageOrDefault(prefs(context))
+
+    fun setLanguage(context: Context, language: String) = setLanguage(prefs(context), language)
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/LocalTranscriber.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/LocalTranscriber.kt
@@ -84,7 +84,8 @@ class LocalTranscriber private constructor(private val recognizer: OfflineRecogn
             }
 
             val numThreads = LocalTranscriptionThreads.threadsOrDefault(ctx)
-            val config = detectModelConfig(modelDir, numThreads) ?: run {
+            val canaryLanguage = CanaryLanguage.languageOrDefault(ctx)
+            val config = detectModelConfig(modelDir, numThreads, canaryLanguage) ?: run {
                 Log.e(TAG, "Could not detect model type in $modelDir")
                 return null
             }
@@ -103,8 +104,14 @@ class LocalTranscriber private constructor(private val recognizer: OfflineRecogn
          *  [LocalTranscriptionThreads.DEFAULT_THREADS] (2, unchanged shipped behavior) so every
          *  existing direct caller -- notably the detectModelConfig-only unit tests, which have no
          *  [Context] to read a setting from -- keeps working without change; [create] passes the
-         *  user-configured value explicitly (#107). */
-        fun detectModelConfig(dir: File, numThreads: Int = LocalTranscriptionThreads.DEFAULT_THREADS): OfflineRecognizerConfig? {
+         *  user-configured value explicitly (#107). [canaryLanguage] follows the same pattern
+         *  (#177): defaults to [CanaryLanguage.DEFAULT] ("en", the previously hardcoded value),
+         *  with [create] passing the user's setting; only the canary branch consumes it. */
+        fun detectModelConfig(
+            dir: File,
+            numThreads: Int = LocalTranscriptionThreads.DEFAULT_THREADS,
+            canaryLanguage: String = CanaryLanguage.DEFAULT,
+        ): OfflineRecognizerConfig? {
             val p = dir.absolutePath
             val tokens = findTokens(p) ?: return null
 
@@ -142,8 +149,13 @@ class LocalTranscriber private constructor(private val recognizer: OfflineRecogn
                             canary = OfflineCanaryModelConfig(
                                 encoder = canaryEncoder,
                                 decoder = canaryDecoder,
-                                srcLang = "en",
-                                tgtLang = "en",
+                                // Canary decoding is prompted by a source-language token; the
+                                // wrong one collapses output to garbage (#177: de.wav under
+                                // srcLang="en" -> " E E E E…"), so this comes from the user's
+                                // CanaryLanguage setting. src == tgt means transcription;
+                                // differing values would mean translation, which is out of scope.
+                                srcLang = canaryLanguage,
+                                tgtLang = canaryLanguage,
                                 usePnc = true,
                             ),
                             tokens = tokens,

--- a/app/src/test/kotlin/com/trevornk/ramblr/CanaryLanguageTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CanaryLanguageTest.kt
@@ -1,0 +1,95 @@
+package com.trevornk.ramblr
+
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Covers #177's settings-backed Canary source language. The two cases that matter most:
+ *  [`defaults to en when never set`] (shipping this must be zero behavior change for existing
+ *  users -- "en" is exactly what was hardcoded before) and [`an unknown stored value coerces to
+ *  en`] (a bad token doesn't degrade Canary output, it collapses it to garbage, so an invalid
+ *  pref must never reach sherpa-onnx). */
+class CanaryLanguageTest {
+
+    @Test fun `defaults to en when never set`() {
+        assertEquals("en", CanaryLanguage.languageOrDefault(FakeSharedPreferences()))
+    }
+
+    @Test fun `default constant is exactly the pre-existing hardcoded value`() {
+        assertEquals("en", CanaryLanguage.DEFAULT)
+    }
+
+    @Test fun `supported languages are exactly the canary-180m-flash set, in order`() {
+        assertEquals(listOf("en", "es", "de", "fr"), CanaryLanguage.SUPPORTED)
+    }
+
+    @Test fun `setLanguage persists and is read back`() {
+        val prefs = FakeSharedPreferences()
+        CanaryLanguage.setLanguage(prefs, "de")
+        assertEquals("de", CanaryLanguage.languageOrDefault(prefs))
+    }
+
+    @Test fun `all four supported values roundtrip`() {
+        val prefs = FakeSharedPreferences()
+        CanaryLanguage.SUPPORTED.forEach { lang ->
+            CanaryLanguage.setLanguage(prefs, lang)
+            assertEquals(lang, CanaryLanguage.languageOrDefault(prefs))
+        }
+    }
+
+    @Test fun `an unknown stored value coerces to en`() {
+        val prefs = FakeSharedPreferences(mutableMapOf(CanaryLanguage.KEY to "xx"))
+        assertEquals("en", CanaryLanguage.languageOrDefault(prefs))
+    }
+
+    @Test fun `setLanguage refuses an unsupported value and stores the default`() {
+        val prefs = FakeSharedPreferences()
+        CanaryLanguage.setLanguage(prefs, "ja")
+        assertEquals("en", CanaryLanguage.languageOrDefault(prefs))
+    }
+
+    /** Minimal in-memory [SharedPreferences] fake — enough surface for a string-only store. */
+    private class FakeSharedPreferences(
+        private val values: MutableMap<String, Any?> = mutableMapOf()
+    ) : SharedPreferences {
+
+        override fun getAll(): MutableMap<String, *> = values
+        override fun getString(key: String?, defValue: String?): String? = values[key] as? String ?: defValue
+        override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+            throw UnsupportedOperationException()
+        override fun getInt(key: String?, defValue: Int): Int = throw UnsupportedOperationException()
+        override fun getLong(key: String?, defValue: Long): Long = throw UnsupportedOperationException()
+        override fun getFloat(key: String?, defValue: Float): Float = throw UnsupportedOperationException()
+        override fun getBoolean(key: String?, defValue: Boolean): Boolean = throw UnsupportedOperationException()
+        override fun contains(key: String?): Boolean = values.containsKey(key)
+
+        override fun edit(): SharedPreferences.Editor = FakeEditor()
+
+        override fun registerOnSharedPreferenceChangeListener(
+            listener: SharedPreferences.OnSharedPreferenceChangeListener?
+        ) {}
+
+        override fun unregisterOnSharedPreferenceChangeListener(
+            listener: SharedPreferences.OnSharedPreferenceChangeListener?
+        ) {}
+
+        private inner class FakeEditor : SharedPreferences.Editor {
+            private val pending = mutableMapOf<String, Any?>()
+
+            override fun putString(key: String?, value: String?): SharedPreferences.Editor =
+                apply { pending[key!!] = value }
+            override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor =
+                throw UnsupportedOperationException()
+            override fun putInt(key: String?, value: Int): SharedPreferences.Editor = throw UnsupportedOperationException()
+            override fun putLong(key: String?, value: Long): SharedPreferences.Editor = throw UnsupportedOperationException()
+            override fun putFloat(key: String?, value: Float): SharedPreferences.Editor = throw UnsupportedOperationException()
+            override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor = throw UnsupportedOperationException()
+
+            override fun remove(key: String?): SharedPreferences.Editor = apply { pending.remove(key) }
+            override fun clear(): SharedPreferences.Editor = apply { values.clear() }
+
+            override fun commit(): Boolean { apply(); return true }
+            override fun apply() { values.putAll(pending) }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/LocalTranscriberDetectModelConfigTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/LocalTranscriberDetectModelConfigTest.kt
@@ -46,6 +46,33 @@ class LocalTranscriberDetectModelConfigTest {
         assertTrue(config.modelConfig.canary.decoder.contains("decoder"))
     }
 
+    @Test fun `canary defaults to en source and target language when none is passed`() {
+        val dir = tempModelDir(
+            "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8",
+            listOf("encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt"),
+        )
+
+        val config = LocalTranscriber.detectModelConfig(dir)
+
+        assertNotNull(config)
+        assertEquals("en", config!!.modelConfig.canary.srcLang)
+        assertEquals("en", config.modelConfig.canary.tgtLang)
+    }
+
+    @Test fun `a passed canary language sets both srcLang and tgtLang`() {
+        // #177: transcription needs src == tgt -- mismatched values would mean translation.
+        val dir = tempModelDir(
+            "sherpa-onnx-nemo-canary-180m-flash-en-es-de-fr-int8",
+            listOf("encoder.int8.onnx", "decoder.int8.onnx", "tokens.txt"),
+        )
+
+        val config = LocalTranscriber.detectModelConfig(dir, canaryLanguage = "de")
+
+        assertNotNull(config)
+        assertEquals("de", config!!.modelConfig.canary.srcLang)
+        assertEquals("de", config.modelConfig.canary.tgtLang)
+    }
+
     @Test fun `a whisper-named directory with encoder plus decoder still detects as whisper`() {
         val dir = tempModelDir(
             "sherpa-onnx-whisper-base.en",


### PR DESCRIPTION
Refs #177 (do not auto-close; on-device verification of non-English decode still pending).

## Problem
Canary 180M Flash supports en/es/de/fr, but `detectModelConfig` hardcoded `srcLang = "en"`, `tgtLang = "en"`. Canary is a prompted model: the wrong source-language token collapses output entirely. On-device test 2026-08-26 (Fold): the model's own bundled `de.wav` decodes to degenerate ` E E E E…` under `srcLang=en`, while `en.wav` is perfect. Non-English dictation with Canary was simply broken.

## Changes
- **CanaryLanguage.kt** (new): settings object mirroring `LocalTranscriptionThreads` — prefs `ramblr`/`canary_src_lang`, default `en` (the previously hardcoded value → zero behavior change out of the box), `SUPPORTED = en/es/de/fr` (exactly this model's set), unknown values coerce to default on read and write.
- **LocalTranscriber.kt**: `detectModelConfig(dir, numThreads, canaryLanguage = CanaryLanguage.DEFAULT)` — defaulted param so existing callers/tests compile unchanged; used for **both** `srcLang` and `tgtLang` (matching src/tgt = transcription; differing = translation, out of scope). `create()` reads the user setting and passes it through, same as the thread count.
- **BehaviorActivity.kt**: "Canary language" row under Advanced tuning, right after the threads row. Picker dialog uses the same `setCustomTitle` + `setSingleChoiceItems` workaround as `promptLocalTranscriptionThreads` (never `setTitle`+`setMessage`+list). Summary shows current language and notes it only affects Canary; refreshed via `refresh()` like the threads summary.
- **Tests**: `CanaryLanguageTest` (default en, set/get roundtrip, unknown → en, all four supported values); `LocalTranscriberDetectModelConfigTest` extended to assert default en/en and that passing `de` yields srcLang=de **and** tgtLang=de.

## Verification
- `./gradlew testGithubDebugUnitTest`: **146 suites, 1457 tests, 0 failures, 0 errors** (CanaryLanguageTest 7/7, LocalTranscriberDetectModelConfigTest 5/5)
- `./gradlew compileGithubDebugKotlin`: BUILD SUCCESSFUL
- `git diff --check`: clean

Not verified here: actual on-device decode of `de.wav` with the new setting — needs a device run before merge.