### PR TITLE
Promote Personal Vocabulary to a top-level settings row

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
@@ -2,7 +2,6 @@ package com.trevornk.ramblr
 
 import android.os.Bundle
 import android.text.InputType
-import android.view.Gravity
 import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
@@ -215,7 +214,9 @@ class BehaviorActivity : BaseSettingsActivity() {
         root.addView(iconHiddenRow)
 
         root.addView(sectionHeader("Vocabulary"))
-        val vocabularyRow = settingsRow("Personal vocabulary", vocabularySummary()) { promptVocabulary() }
+        val vocabularyRow = settingsRow("Personal vocabulary", VocabularyEditor.rowSummary(this)) {
+            VocabularyEditor.prompt(this) { refresh() }
+        }
         vocabularyRowSub = vocabularyRow.findViewWithTag("subtitle")
         root.addView(vocabularyRow)
 
@@ -264,7 +265,7 @@ class BehaviorActivity : BaseSettingsActivity() {
         silenceAutoStopThresholdRow.findViewWithTag<TextView>("subtitle").text = silenceAutoStopThresholdSummary()
         refreshSilenceAutoStopSummary()
         compressedUploadSwitch.isChecked = CompressedUploadToggle.isEnabled(this)
-        vocabularyRowSub.text = vocabularySummary()
+        vocabularyRowSub.text = VocabularyEditor.rowSummary(this)
         localThreadsRowSub.text = localThreadsSummary()
         canaryLanguageRowSub.text = canaryLanguageSummary()
         autoPeekDelayRow.findViewWithTag<TextView>("subtitle").text = autoPeekDelaySummary()
@@ -466,78 +467,8 @@ class BehaviorActivity : BaseSettingsActivity() {
             .show()
     }
 
-    // --- Personal vocabulary (#26) ---
-
-    private fun vocabularyTerms() = VocabularyTerms.parse(
-        prefs().getString("custom_vocabulary_terms", VocabularyTerms.DEFAULT_SERIALIZED)
-    )
-
-    private fun vocabularySummary(): String {
-        val note = vocabularyLocalOnlyNote()
-        val terms = vocabularyTerms()
-        val termsPart = if (terms.isEmpty()) "No custom terms" else terms.joinToString(", ")
-        // #185: the raw term list reads as confirmation the terms are in force -- when nothing
-        // in the current setup applies them (local ASR with cleanup fully off, since #182's
-        // post-pass made local cleanup vocabulary-capable) they aren't, so say so on the row.
-        return if (note == null) termsPart else "Not used while cleanup is off — $termsPart"
-    }
-
-    /** Non-null when the user's current configuration ignores the vocabulary entirely (#185):
-     *  cloud transcription off AND no active cleanup path of any kind. Mirrors the real runtime
-     *  gates: transcription's `use_local` pref, cleanup's master toggle, [CloudFeatureToggle]'s
-     *  cloud gate, the chain's cleanup-capable entries, and -- for the local path, which applies
-     *  terms via [VocabularyPostCorrector]'s output post-pass since #182 -- an actually
-     *  installed local cleanup model ([ModelDownloader.localCleanupModelFile] non-null, the same
-     *  check the executor's LOCAL_LLM branch fails on). */
-    private fun vocabularyLocalOnlyNote(): String? {
-        val cloudTranscription = !prefs().getBoolean("use_local", true)
-        val cleanupOn = PostProcessingToggle.isEnabled(this)
-        val cleanupEntries = ProviderChainStore.load(this).capableEntriesFor(needsTranscription = false)
-        val cloudCleanup = cleanupOn &&
-            CloudFeatureToggle.cleanupEnabled(this) &&
-            cleanupEntries.any { it.kind != ProviderKind.LOCAL }
-        val localCleanup = cleanupOn &&
-            cleanupEntries.any { it.kind == ProviderKind.LOCAL } &&
-            ModelDownloader.localCleanupModelFile(this, LocalCleanupProvider.selectedModel(this)) != null
-        return VocabularyTerms.localOnlyNote(
-            cloudTranscriptionActive = cloudTranscription,
-            cloudCleanupActive = cloudCleanup,
-            localCleanupActive = localCleanup,
-        )
-    }
-
-    private fun promptVocabulary() {
-        val input = EditText(this).apply {
-            hint = "One term per line, e.g. FastHTML"
-            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-            minLines = 3
-            gravity = Gravity.TOP or Gravity.START
-            setText(VocabularyTerms.serialize(vocabularyTerms()))
-        }
-        // #185/#182: the terms reach cloud transcription, cloud cleanup (prompt interpolation),
-        // and -- since #182's option-2 post-pass -- local cleanup, where they are applied as a
-        // deterministic correction over the model's output rather than in its prompt. Only
-        // local transcription ignores them (#131), so the inert-setting note now fires only
-        // when cleanup is off entirely on a local-transcription setup.
-        val message = buildString {
-            append(
-                "Project names or jargon that speech-to-text often mishears. One per line.\n\n" +
-                    "Applies to cloud transcription and to cleanup (cloud and local)."
-            )
-            vocabularyLocalOnlyNote()?.let { append("\n\n").append(it) }
-        }
-        android.app.AlertDialog.Builder(this)
-            .setTitle("Personal vocabulary")
-            .setMessage(message)
-            .setView(input.apply { setPadding(dp(24), dp(8), dp(24), dp(8)) })
-            .setPositiveButton("Save") { _, _ ->
-                val terms = VocabularyTerms.parse(input.text.toString())
-                prefs().edit().putString("custom_vocabulary_terms", VocabularyTerms.serialize(terms)).apply()
-                refresh()
-            }
-            .setNegativeButton("Cancel", null)
-            .show()
-    }
+    // Personal vocabulary (#26) editor + summaries moved to [VocabularyEditor] (#217), shared
+    // with MainActivity's top-level row.
 
     // --- Local transcription thread count (#107) ---
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -34,6 +34,7 @@ class MainActivity : BaseSettingsActivity() {
     private lateinit var cleanupRowSub: TextView
     private lateinit var livePreviewRowSub: TextView
     private lateinit var cloudRowSub: TextView
+    private lateinit var vocabularyRowSub: TextView
 
     // First-run wizard state (#6). Tracked in-memory so a dialog already on screen is never
     // duplicated by a stray onResume, and reset per Activity instance so a fresh launch always
@@ -112,6 +113,16 @@ class MainActivity : BaseSettingsActivity() {
         }
         cloudRowSub = cloudRow.findViewWithTag("subtitle")
         root.addView(cloudRow)
+
+        // Top-level Personal vocabulary entry (#217): the editor stayed reachable only via
+        // Advanced > Behavior for so long that #140's reporter asked for the feature without
+        // finding it. Same shared editor as the Behavior row ([VocabularyEditor]) -- this row
+        // just makes it discoverable, with a live term count as its subtitle.
+        val vocabularyRow = settingsRow("Personal vocabulary", "Checking...") {
+            VocabularyEditor.prompt(this) { refresh() }
+        }
+        vocabularyRowSub = vocabularyRow.findViewWithTag("subtitle")
+        root.addView(vocabularyRow)
 
         root.addView(settingsRow("Advanced", AdvancedActivity.subtitle(this)) {
             startActivity(Intent(this, AdvancedActivity::class.java))
@@ -238,6 +249,7 @@ class MainActivity : BaseSettingsActivity() {
         cleanupRowSub.text = CleanupActivity.subtitle(this)
         livePreviewRowSub.text = LivePreviewActivity.subtitle(this)
         cloudRowSub.text = CloudProviderActivity.subtitle(this)
+        vocabularyRowSub.text = vocabularyMainRowSubtitleText(VocabularyEditor.terms(this).size)
 
         // Ready logic -- see OnboardingWizard.isSetupComplete for what "ready" means (#52).
         val ready = OnboardingWizard.isSetupComplete(

--- a/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
@@ -45,3 +45,32 @@ fun advancedSubtitleText(hasSelfUpdate: Boolean): String {
     val updates = if (hasSelfUpdate) "updates, " else ""
     return "Redo setup, overlay appearance, behavior, ${updates}data & logs"
 }
+
+/**
+ * The main settings screen's "Personal vocabulary" row subtitle (#217): a live term count plus a
+ * one-line pitch, e.g. `"12 terms — names and jargon the models should get right"`. The count is
+ * the discoverability hook -- #140's reporter looked for exactly this feature and couldn't find
+ * it, so the row leads with evidence that it exists and is populated.
+ */
+fun vocabularyMainRowSubtitleText(termCount: Int): String {
+    val count = when (termCount) {
+        0 -> "No terms yet"
+        1 -> "1 term"
+        else -> "$termCount terms"
+    }
+    return "$count — names and jargon the models should get right"
+}
+
+/**
+ * The Behavior screen's "Personal vocabulary" row subtitle: the term list itself, prefixed with
+ * the #185 inert-setting warning when nothing in the current configuration applies the terms.
+ * Extracted from BehaviorActivity's private `vocabularySummary` (#217) so it's unit-testable and
+ * shared through [VocabularyEditor.rowSummary].
+ */
+fun vocabularyRowSummaryText(terms: List<String>, inert: Boolean): String {
+    val termsPart = if (terms.isEmpty()) "No custom terms" else terms.joinToString(", ")
+    // #185: the raw term list reads as confirmation the terms are in force -- when nothing
+    // in the current setup applies them (local ASR with cleanup fully off, since #182's
+    // post-pass made local cleanup vocabulary-capable) they aren't, so say so on the row.
+    return if (inert) "Not used while cleanup is off — $termsPart" else termsPart
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/VocabularyEditor.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/VocabularyEditor.kt
@@ -1,0 +1,100 @@
+package com.trevornk.ramblr
+
+import android.app.Activity
+import android.content.Context
+import android.text.InputType
+import android.view.Gravity
+import android.widget.EditText
+
+/**
+ * The Personal Vocabulary editor dialog and its row summary, shared by both Settings entry
+ * points (#217): the top-level "Personal vocabulary" row on [MainActivity] and the original
+ * Vocabulary section on [BehaviorActivity].
+ *
+ * Extracted verbatim from BehaviorActivity's private `promptVocabulary`/`vocabularySummary`/
+ * `vocabularyLocalOnlyNote` (#26/#185) when #140's discoverability complaint got the feature
+ * promoted to the main screen -- one implementation, two callers, so the two rows can never
+ * drift apart in behavior or copy. Same prefs key, same dialog, same inert-setting note.
+ */
+object VocabularyEditor {
+
+    fun terms(context: Context): List<String> = VocabularyTerms.parse(
+        prefs(context).getString(PREF_KEY, VocabularyTerms.DEFAULT_SERIALIZED)
+    )
+
+    /** The Behavior row's subtitle: the term list itself, prefixed with the #185 inert-setting
+     *  warning when nothing in the current configuration applies the terms. */
+    fun rowSummary(context: Context): String =
+        vocabularyRowSummaryText(terms(context), inert = localOnlyNote(context) != null)
+
+    /** Non-null when the user's current configuration ignores the vocabulary entirely (#185):
+     *  cloud transcription off AND no active cleanup path of any kind. Mirrors the real runtime
+     *  gates: transcription's `use_local` pref, cleanup's master toggle, [CloudFeatureToggle]'s
+     *  cloud gate, the chain's cleanup-capable entries, and -- for the local path, which applies
+     *  terms via [VocabularyPostCorrector]'s output post-pass since #182 -- an actually
+     *  installed local cleanup model ([ModelDownloader.localCleanupModelFile] non-null, the same
+     *  check the executor's LOCAL_LLM branch fails on). */
+    fun localOnlyNote(context: Context): String? {
+        val cloudTranscription = !prefs(context).getBoolean("use_local", true)
+        val cleanupOn = PostProcessingToggle.isEnabled(context)
+        val cleanupEntries = ProviderChainStore.load(context).capableEntriesFor(needsTranscription = false)
+        val cloudCleanup = cleanupOn &&
+            CloudFeatureToggle.cleanupEnabled(context) &&
+            cleanupEntries.any { it.kind != ProviderKind.LOCAL }
+        val localCleanup = cleanupOn &&
+            cleanupEntries.any { it.kind == ProviderKind.LOCAL } &&
+            ModelDownloader.localCleanupModelFile(context, LocalCleanupProvider.selectedModel(context)) != null
+        return VocabularyTerms.localOnlyNote(
+            cloudTranscriptionActive = cloudTranscription,
+            cloudCleanupActive = cloudCleanup,
+            localCleanupActive = localCleanup,
+        )
+    }
+
+    /** Shows the editor dialog. [onSaved] runs after a save so the caller can refresh its own
+     *  row subtitle -- each entry point words that subtitle differently (term count on the main
+     *  screen, term list on Behavior), which is why the dialog doesn't refresh anything itself. */
+    fun prompt(activity: Activity, onSaved: () -> Unit) {
+        val input = EditText(activity).apply {
+            hint = "One term per line, e.g. FastHTML"
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            minLines = 3
+            gravity = Gravity.TOP or Gravity.START
+            setText(VocabularyTerms.serialize(terms(activity)))
+        }
+        // #185/#182: the terms reach cloud transcription, cloud cleanup (prompt interpolation),
+        // and -- since #182's option-2 post-pass -- local cleanup, where they are applied as a
+        // deterministic correction over the model's output rather than in its prompt. Only
+        // local transcription ignores them (#131), so the inert-setting note now fires only
+        // when cleanup is off entirely on a local-transcription setup.
+        val message = buildString {
+            append(
+                "Project names or jargon that speech-to-text often mishears. One per line.\n\n" +
+                    "Applies to cloud transcription and to cleanup (cloud and local)."
+            )
+            localOnlyNote(activity)?.let { append("\n\n").append(it) }
+        }
+        android.app.AlertDialog.Builder(activity)
+            .setTitle("Personal vocabulary")
+            .setMessage(message)
+            .setView(input.apply { setPadding(dp(activity, 24), dp(activity, 8), dp(activity, 24), dp(activity, 8)) })
+            .setPositiveButton("Save") { _, _ ->
+                val terms = VocabularyTerms.parse(input.text.toString())
+                prefs(activity).edit()
+                    .putString(PREF_KEY, VocabularyTerms.serialize(terms))
+                    .apply()
+                onSaved()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    /** Same "custom_vocabulary_terms" key every reader uses ([WhisperAccessibilityService],
+     *  [ProcessTextActivity], [BackupManager]'s backup set) -- literal here because
+     *  ProcessTextActivity's mirror constant lives in its private companion. */
+    private const val PREF_KEY = "custom_vocabulary_terms"
+
+    private fun prefs(context: Context) = context.getSharedPreferences("ramblr", Context.MODE_PRIVATE)
+
+    private fun dp(context: Context, n: Int) = (n * context.resources.displayMetrics.density).toInt()
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/SettingsSubtitlesTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/SettingsSubtitlesTest.kt
@@ -128,4 +128,45 @@ class SettingsSubtitlesTest {
             assertFalse("dangling comma in: $subtitle", subtitle.trim().endsWith(","))
         }
     }
+
+    // --- main-screen vocabulary row subtitle (#217) -------------------------------------------
+
+    @Test fun `main vocabulary subtitle leads with the term count`() {
+        val subtitle = vocabularyMainRowSubtitleText(12)
+        assertTrue("expected '12 terms' prefix in: $subtitle", subtitle.startsWith("12 terms"))
+        assertTrue(subtitle.contains("names and jargon"))
+    }
+
+    @Test fun `main vocabulary subtitle singularizes one term`() {
+        assertTrue(vocabularyMainRowSubtitleText(1).startsWith("1 term —"))
+    }
+
+    @Test fun `main vocabulary subtitle does not claim zero terms exist`() {
+        val subtitle = vocabularyMainRowSubtitleText(0)
+        // "0 terms" reads like a bug; the empty state should still invite the user in.
+        assertTrue("expected 'No terms yet' in: $subtitle", subtitle.startsWith("No terms yet"))
+    }
+
+    @Test fun `default vocabulary seed count formats without surprises`() {
+        // The subtitle a fresh install actually shows: the #26 seed list, pluralized.
+        val subtitle = vocabularyMainRowSubtitleText(VocabularyTerms.DEFAULTS.size)
+        assertTrue(subtitle.startsWith("${VocabularyTerms.DEFAULTS.size} terms"))
+    }
+
+    // --- behavior-screen vocabulary row summary (#217 extraction of #185 logic) ---------------
+
+    @Test fun `behavior vocabulary summary lists the terms when active`() {
+        assertEquals("Pi, Codex", vocabularyRowSummaryText(listOf("Pi", "Codex"), inert = false))
+    }
+
+    @Test fun `behavior vocabulary summary shows the empty state`() {
+        assertEquals("No custom terms", vocabularyRowSummaryText(emptyList(), inert = false))
+    }
+
+    @Test fun `behavior vocabulary summary warns when the terms are inert`() {
+        // #185: the raw term list must not read as confirmation the terms are in force.
+        val subtitle = vocabularyRowSummaryText(listOf("Pi"), inert = true)
+        assertTrue("expected the inert warning in: $subtitle", subtitle.startsWith("Not used while cleanup is off"))
+        assertTrue("terms must still be listed in: $subtitle", subtitle.contains("Pi"))
+    }
 }


### PR DESCRIPTION
## Problem

Personal Vocabulary (#26) lives four levels deep: long-press icon → Open Ramblr settings → Advanced → Behavior → Personal Vocabulary. In #140 a user asked for the feature without finding it, and the reply there conceded it was "fairly hidden". Refs #217, see #140.

## Approach

- **New top-level "Personal vocabulary" row** on the main settings screen (MainActivity's category list), placed between Cloud and Advanced — visible without entering any subscreen. Subtitle is a live term count ("12 terms — names and jargon the models should get right"), refreshed in `refresh()`/`onResume` like the other dynamic subtitles.
- **Shared editor, not a duplicate:** BehaviorActivity's private `promptVocabulary()`/`vocabularySummary()`/`vocabularyLocalOnlyNote()` moved verbatim into a new `VocabularyEditor` object. Both entry points call it, so the two rows can never drift in behavior or copy. Same prefs key (`custom_vocabulary_terms`), same dialog, same #185 inert-setting note.
- **Behavior screen unchanged for users:** its Vocabulary section stays, now delegating to `VocabularyEditor`.
- Subtitle formatting is pure functions in `SettingsSubtitles.kt` (the #153 pattern: testable without constructing Activities).

## Tests

`./gradlew testGithubDebugUnitTest`: 146 suites, 1464 tests, 0 failures, 0 errors. 7 new tests in `SettingsSubtitlesTest` covering the count subtitle (0/1/n/seed-default) and the extracted Behavior-row summary (active/empty/inert).

## Not verified

No on-device UI pass — the row placement and dialog flow follow the existing `settingsRow` conventions exactly, but device verification is still pending.