### PR TITLE
Add package-visibility decoy filters so selection menus can see Ramblr

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,35 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <!-- Package-visibility decoys (Android 11+ declared package visibility,
+                 https://developer.android.com/training/package-visibility).
+
+                 Hosts building the text-selection toolbar call
+                 queryIntentActivities(ACTION_PROCESS_TEXT, "text/plain") from their own
+                 process, so the *host's* <queries> rules decide whether Ramblr's handler is
+                 returned at all. Gmail, Google Messages and Keep do NOT declare a
+                 PROCESS_TEXT <queries> entry — they only become able to see a handler app
+                 when one of their generic <queries> intents (ACTION_VIEW variants) matches
+                 some exported intent-filter in that app. ChatGPT/Kiwix appear in those
+                 toolbars because their deep-link/file VIEW filters happen to match; Ramblr
+                 (and Claude) had no matching filter, so the entry was silently filtered out
+                 (device-verified on a Pixel 10 Pro Fold, Android 16).
+
+                 The two filters below exist solely to match those generic VIEW queries.
+                 They deliberately omit android.intent.category.DEFAULT, so implicit
+                 intents can never resolve to this activity — Ramblr does not appear in any
+                 link-open chooser (adb-verified) and the activity remains reachable only
+                 explicitly. Hosts whose <queries> contain no VIEW intent at all (e.g.
+                 SchildiChat) still cannot see any third-party handler; that is
+                 host-app-side and unfixable from here. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
 
         <service


### PR DESCRIPTION
Refs #157

## Problem

Ramblr's PROCESS_TEXT entry is missing from the text-selection toolbar in Gmail, Google Messages, Google Keep and SchildiChat, while **Ask ChatGPT** and **Search Kiwix** appear in those same toolbars. Present in AFFiNE and Amazon.

## Root cause (device-proven, Pixel 10 Pro Fold / Android 16)

The selection toolbar item list is built by the **host app** calling `queryIntentActivities(ACTION_PROCESS_TEXT, "text/plain")` from its own process (classic `TextView` toolbar and Compose Foundation 1.9's `ProcessText.android.kt` both do exactly this). On Android 11+ **declared package visibility** filters that query by the *host's* `<queries>` rules — not by anything in the handler's PROCESS_TEXT filter.

Pulled manifests off the device:

| Host | `<queries>` PROCESS_TEXT entry? | Relevant generic queries |
|---|---|---|
| Gmail | ❌ none | several `ACTION_VIEW` intents (`BROWSABLE https`, bare `VIEW`, `VIEW+DEFAULT */*`) |
| Google Messages | ❌ none | bare `VIEW`, `VIEW BROWSABLE https`, `VIEW scheme=* host=*` |
| Google Keep | ❌ none | `VIEW scheme=https` |
| SchildiChat | ❌ none | **no VIEW query at all** (only CustomTabs/UnifiedPush) |
| Amazon | ✅ explicit `PROCESS_TEXT text/plain` query | — |

ChatGPT and Kiwix are visible to Gmail/Messages/Keep only because their **other** exported intent-filters (deep links `https://chatgpt.com`, Kiwix's `VIEW */*` file filters) happen to match the hosts' generic VIEW queries — package visibility is per-package, so once any filter matches, the PROCESS_TEXT activity resolves too. Ramblr (and Claude, also absent from those toolbars) exposes only `MAIN/LAUNCHER` + `PROCESS_TEXT`, matching nothing.

Causal proof: a scratch host app cloning each host's exact `<queries>` block, plus a scratch PROCESS_TEXT provider mutated filter-by-filter:

- Ramblr-shaped provider (PROCESS_TEXT only): invisible to Gmail/Keep/Messages-style hosts — reproduces the bug; ChatGPT/Kiwix visible in the same query — reproduces the asymmetry.
- Adding a bare `VIEW` filter → visible to Gmail/Messages-style hosts.
- Adding hostless `VIEW + BROWSABLE + https` → visible to Keep-style hosts.
- Both decoys, no `category.DEFAULT` → visible to all three, **and not resolvable by any implicit intent**: `cmd package query-activities -a android.intent.action.VIEW -d https://example.com/` does not list the app (no link-chooser pollution).

## Fix

Two decoy intent-filters on `ProcessTextActivity`, deliberately without `category.DEFAULT` (implicit resolution requires DEFAULT, so they can never be launched by a link/chooser — they exist purely to satisfy hosts' package-visibility queries). `ProcessTextActivity.onCreate` already finishes on any non-`PROCESS_TEXT` action as a second guard.

**SchildiChat remains unfixable from our side**: its `<queries>` contains no intent that any handler's filters could match; every third-party PROCESS_TEXT app (incl. ChatGPT) is invisible there. Host-side bug.

## Verification

- Scratch-app matrix above (exact decoy set from this PR verified against Gmail/Keep/Messages `<queries>` clones before the device left the network).
- `./gradlew testGithubDebugUnitTest`: **1457 tests, 0 failures, 0 errors, 0 skipped** (146 JUnit XML files).
- `assembleGithubDebug` builds; APK manifest dump confirms both decoys present with no DEFAULT category.

⚠️ Pending device return: final on-device check of the rebuilt Ramblr APK itself in the scratch host (the device dropped off the network mid-install). The causal chain is fully proven with the scratch provider carrying this exact filter set; the remaining step is confirmatory only. Also two scratch packages are still installed on the Fold and should be removed: `com.scratch.pthost`, `com.scratch.ptprov`.