### PR TITLE
Invocation-method chooser + service-killed guard rail + optional WRITE_SECURE_SETTINGS tier

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,19 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- #156 advanced tier: NEVER granted at install (signature|privileged|development), so this
+         declaration is inert for every normal user. It exists so a power user can opt in once via
+         `adb shell pm grant com.trevornk.ramblr android.permission.WRITE_SECURE_SETTINGS` (the
+         Tasker pattern), which lets Ramblr manage its own OS accessibility-shortcut bindings
+         (accessibility_button_targets / accessibility_shortcut_target_service) and re-enable its
+         service in-app: raw Secure writes bypass the invisible-toggle "last shortcut off kills
+         the service" sync that #156 is about. Feature-detected at every use
+         (InvocationSecureSettings.canWrite); everything falls back to system-Settings deep links
+         without it. tools:ignore because lint flags any non-app-grantable permission, which is
+         exactly the point here. -->
+    <uses-permission
+        android:name="android.permission.WRITE_SECURE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:allowBackup="true"
@@ -64,6 +77,10 @@
         <activity android:name=".CloudProviderActivity" android:exported="false"
             android:configChanges="screenLayout|smallestScreenSize|screenSize|orientation|keyboardHidden|uiMode" />
         <activity android:name=".AdvancedActivity" android:exported="false"
+            android:configChanges="screenLayout|smallestScreenSize|screenSize|orientation|keyboardHidden|uiMode" />
+        <!-- Invocation-method chooser (#156): same internal-only + fold/unfold handling as the
+             other per-category Settings screens above. -->
+        <activity android:name=".InvocationActivity" android:exported="false"
             android:configChanges="screenLayout|smallestScreenSize|screenSize|orientation|keyboardHidden|uiMode" />
         <!-- Advanced's four sub-Activities (#104 restructure): mirror AdvancedActivity's own
              configChanges declaration above for the same Pixel Fold fold/unfold reasoning. -->

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
@@ -1,0 +1,265 @@
+package com.trevornk.ramblr
+
+import android.app.StatusBarManager
+import android.content.ComponentName
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.ScrollView
+import android.widget.TextView
+import com.google.android.material.materialswitch.MaterialSwitch
+
+/**
+ * "Invocation" settings screen (#156): one place to see and choose every way of starting a
+ * dictation -- the app-owned floating ring and QS tile, and the OS-owned accessibility
+ * button/gesture and volume-keys hold.
+ *
+ * The OS-owned rows exist because of the invisible-toggle trap this screen is really about
+ * (#156 memo): Ramblr is an INVISIBLE_TOGGLE-class service, so system Settings couples the
+ * service's on/off state to its shortcut bindings -- turning off the LAST "Ramblr shortcut"
+ * switch there also turns off Ramblr itself. The app cannot manage those bindings through any
+ * supported API (enableShortcutsForTargets is @hide + MANAGE_ACCESSIBILITY), so the base tier
+ * deep-links to the service's own system page (ACTION_ACCESSIBILITY_DETAILS_SETTINGS, API 30+ =
+ * minSdk) BEHIND an explainer dialog that names the trap before the user meets it.
+ *
+ * The optional advanced tier (WRITE_SECURE_SETTINGS via a one-time adb grant, feature-detected
+ * per tap) upgrades the OS-owned rows to real in-app toggles: raw Settings.Secure writes bypass
+ * the invisible-toggle sync entirely (device-verified), so bindings change without the Settings
+ * round-trip and without ever tripping the service kill. See [InvocationSecureSettings].
+ */
+class InvocationActivity : BaseSettingsActivity() {
+
+    private lateinit var ringSwitch: MaterialSwitch
+    private lateinit var ringRowSub: TextView
+    private lateinit var systemButtonRowSub: TextView
+    private lateinit var volumeKeysRowSub: TextView
+    private lateinit var advancedTierRowSub: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val root = vertical(0, 0)
+
+        root.addView(TextView(this).apply {
+            text = "Invocation"
+            textSize = 32f
+            setPadding(dp(24), dp(64), dp(24), dp(24))
+        })
+
+        root.addView(sectionHeader("How to start dictation"))
+
+        // --- Floating ring (app-owned): a direct toggle over IconHiddenState, the same flag the
+        // long-press "Hide icon" menu and BehaviorActivity's restore row already share.
+        ringSwitch = MaterialSwitch(this).apply { isClickable = false }
+        val ringRow = settingsRow("Floating ring", "Checking...", ringSwitch) {
+            val nowHidden = !IconHiddenState.isHidden(this)
+            IconHiddenState.setHidden(this, nowHidden)
+            if (nowHidden) {
+                // Same affordance chain as the long-press hide (#135): once the ring is gone
+                // the notification is the way back that doesn't require finding this screen.
+                IconVisibilityNotifications.postHidden(this)
+            } else {
+                IconVisibilityNotifications.cancel(this)
+            }
+            WhisperAccessibilityService.instance?.applyOverlayVisibility()
+            refresh()
+        }
+        ringRowSub = ringRow.findViewWithTag("subtitle")
+        root.addView(ringRow)
+
+        // --- System accessibility button / gesture (OS-owned).
+        val systemButtonRow = settingsRow("System accessibility button / gesture", "Checking...") {
+            onOsShortcutRowTapped(
+                key = InvocationSecureSettings.KEY_BUTTON_TARGETS,
+                currentlyBound = InvocationSecureSettings.isButtonTargetBound(this),
+                methodName = "system accessibility button",
+                deepLinkHowTo = "On the next screen, tap the \u201cRamblr shortcut\u201d switch to " +
+                    "turn the button on or off.\n\n" +
+                    "Heads up: the system's floating button has its own long-press/drag menu and " +
+                    "a bright \u201cselected\u201d look \u2014 that brightness is a system affordance, " +
+                    "NOT Ramblr recording.",
+            )
+        }
+        systemButtonRowSub = systemButtonRow.findViewWithTag("subtitle")
+        root.addView(systemButtonRow)
+
+        // --- Volume-keys hold (OS-owned). Note (#156 memo, AMS 4295-4331): for a button-flag
+        // service this shortcut can only ever ENABLE the service or fire the dictation callback,
+        // never disable it -- it's the one OS entry point with no foot-gun of its own.
+        val volumeKeysRow = settingsRow("Volume-keys hold", "Checking...") {
+            onOsShortcutRowTapped(
+                key = InvocationSecureSettings.KEY_SHORTCUT_TARGET_SERVICE,
+                currentlyBound = InvocationSecureSettings.isVolumeKeysBound(this),
+                methodName = "volume-keys shortcut",
+                deepLinkHowTo = "On the next screen, tap \u201cRamblr shortcut\u201d, then tick " +
+                    "\u201cHold volume keys\u201d.\n\n" +
+                    "The first time you use the shortcut, Android shows a one-time confirmation " +
+                    "dialog \u2014 choose \u201cTurn on\u201d there. Holding both volume keys then " +
+                    "starts or stops dictation from anywhere.",
+            )
+        }
+        volumeKeysRowSub = volumeKeysRow.findViewWithTag("subtitle")
+        root.addView(volumeKeysRow)
+
+        // --- QS tile (app-owned, #127). The OS never tells an app whether its tile is currently
+        // placed in the panel, so this row is an add-affordance, not a status readout.
+        root.addView(settingsRow(
+            "Quick Settings tile",
+            invocationQsTileSubtitleText(canRequestAdd = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+        ) { onQsTileRowTapped() })
+
+        root.addView(sectionHeader("Advanced"))
+
+        val advancedTierRow = settingsRow("Direct shortcut control", "Checking...") {
+            showAdvancedTierDialog()
+        }
+        advancedTierRowSub = advancedTierRow.findViewWithTag("subtitle")
+        root.addView(advancedTierRow)
+
+        setContentView(ScrollView(this).apply {
+            setBackgroundColor(attrColor(android.R.attr.colorBackground))
+            addView(root)
+        })
+
+        refresh()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // The OS-owned states change out from under us exactly when this screen is most relevant
+        // (the user just came back from the system Settings round-trip) -- re-read everything.
+        refresh()
+    }
+
+    private fun refresh() {
+        val ringVisible = !IconHiddenState.isHidden(this)
+        val direct = InvocationSecureSettings.canWrite(this)
+        ringSwitch.isChecked = ringVisible
+        ringRowSub.text = invocationRingSubtitleText(ringVisible)
+        systemButtonRowSub.text = invocationSystemButtonSubtitleText(
+            bound = InvocationSecureSettings.isButtonTargetBound(this),
+            directControl = direct,
+        )
+        volumeKeysRowSub.text = invocationVolumeKeysSubtitleText(
+            bound = InvocationSecureSettings.isVolumeKeysBound(this),
+            directControl = direct,
+        )
+        advancedTierRowSub.text = invocationAdvancedTierSubtitleText(granted = direct)
+    }
+
+    /**
+     * OS-owned row tap: with the advanced tier granted, flip the binding in-app via a raw Secure
+     * write (which bypasses the invisible-toggle service kill entirely -- #156 memo §3); without
+     * it, explain the trap FIRST, then deep-link to the service's own system Settings page.
+     * The write path silently degrades to the deep-link path on failure ([setBinding] returns
+     * false rather than throwing).
+     */
+    private fun onOsShortcutRowTapped(key: String, currentlyBound: Boolean, methodName: String, deepLinkHowTo: String) {
+        if (InvocationSecureSettings.canWrite(this)) {
+            if (InvocationSecureSettings.setBinding(this, key, bound = !currentlyBound)) {
+                refresh()
+                return
+            }
+            toast("Direct write failed — opening system settings instead")
+        }
+        showOsShortcutExplainerThenDeepLink(methodName, deepLinkHowTo)
+    }
+
+    /**
+     * The #156 explainer, shown BEFORE navigating: the trap is that the system page's "Ramblr
+     * shortcut" switch doubles as a service kill-switch when it's the last shortcut left, and
+     * nothing on that page says so.
+     */
+    private fun showOsShortcutExplainerThenDeepLink(methodName: String, howTo: String) {
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Before you go: how this switch behaves")
+            .setMessage(
+                "The $methodName is managed on Ramblr's system Accessibility page.\n\n$howTo\n\n" +
+                    "\u26a0\ufe0f Important: the \u201cRamblr shortcut\u201d switch controls where the " +
+                    "shortcut appears \u2014 but turning off the LAST shortcut also turns off " +
+                    "Ramblr itself (system behavior for always-on accessibility tools). To hide " +
+                    "the system button without turning Ramblr off, enable the floating ring on " +
+                    "this screen first."
+            )
+            .setPositiveButton("Open system settings") { _, _ -> openServiceDetailsSettings() }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    /** Deep-link to Ramblr's own service page (action string public-in-behavior since API 30 =
+     *  minSdk; see [InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS] for why it's
+     *  a spelled-out string). Falls back to the top-level Accessibility list if an OEM skin
+     *  doesn't resolve the details action. */
+    private fun openServiceDetailsSettings() {
+        val component = ComponentName(this, WhisperAccessibilityService::class.java)
+        val details = Intent(InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS)
+            .putExtra(Intent.EXTRA_COMPONENT_NAME, component.flattenToString())
+        try {
+            startActivity(details)
+        } catch (_: android.content.ActivityNotFoundException) {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+    }
+
+    /** API 33+ gets the system's one-tap "add this tile?" sheet; below that, spell out the
+     *  manual panel-edit steps. */
+    private fun onQsTileRowTapped() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val statusBar = getSystemService(StatusBarManager::class.java)
+            if (statusBar != null) {
+                statusBar.requestAddTileService(
+                    ComponentName(this, RamblrQsTileService::class.java),
+                    getString(R.string.tile_label),
+                    Icon.createWithResource(this, R.drawable.ic_mic),
+                    mainExecutor,
+                ) { /* result codes don't distinguish states we can act on; refresh is moot since tile placement isn't readable */ }
+                return
+            }
+        }
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Add the Ramblr tile")
+            .setMessage(
+                "Swipe down twice to open Quick Settings, tap the edit (pencil) button, then " +
+                    "drag the Ramblr tile into your panel. Tapping the tile starts or stops dictation."
+            )
+            .setPositiveButton("OK", null)
+            .show()
+    }
+
+    /** The advanced tier's explainer: what it unlocks, the exact adb command (selectable for
+     *  copy), and the live granted/not-granted state. */
+    private fun showAdvancedTierDialog() {
+        val granted = InvocationSecureSettings.canWrite(this)
+        val command = wssAdbCommand(packageName)
+        val message = TextView(this).apply {
+            text = (if (granted) "\u2705 Active. Shortcut switches on this screen now apply " +
+                "instantly, in-app, and can never trip the system's \u201clast shortcut off turns " +
+                "the service off\u201d behavior.\n\n"
+            else "Android only lets apps change system shortcut bindings with a permission that " +
+                "must be granted once over adb (it survives reboots, but not reinstalls):\n\n") +
+                "$command\n\n" +
+                "With it granted, the rows above switch in-app with no system Settings round-trip, " +
+                "and if the service ever gets turned off by the system switch, Ramblr can turn " +
+                "itself back on with one tap."
+            setTextIsSelectable(true)
+            textSize = 14f
+            setPadding(dp(24), dp(16), dp(24), 0)
+        }
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Direct shortcut control")
+            .setView(message)
+            .setPositiveButton("OK") { _, _ -> refresh() }
+            .show()
+    }
+
+    companion object {
+        /** MainActivity category-row subtitle (SettingsSubtitles pattern: shared with refresh). */
+        fun subtitle(context: android.content.Context): String = invocationMainRowSubtitleText(
+            ringVisible = !IconHiddenState.isHidden(context),
+            systemButtonBound = InvocationSecureSettings.isButtonTargetBound(context),
+            volumeKeysBound = InvocationSecureSettings.isVolumeKeysBound(context),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
@@ -1,0 +1,57 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Persistence for the #156 "service killed by the OS shortcut toggle" guard rail. Two flags in
+ * the shared "ramblr" prefs file (same pattern as [IconHiddenState]/[HideIconToggle]):
+ *
+ *  - [KEY_SERVICE_WAS_ENABLED]: set true the first time the service connects, never cleared by
+ *    the service's own lifecycle (onDestroy also fires for reboots and app updates, which say
+ *    nothing about the user's intent). It means "this install has had a working service at least
+ *    once", which is what separates the invisible-toggle kill from a fresh install that never
+ *    finished setup.
+ *  - [KEY_BANNER_DISMISSED]: the non-nagging bit. Set when the user dismisses the recovery
+ *    banner; cleared when the service next connects, so the banner can fire again on the NEXT
+ *    fresh kill but never re-nags about the one already dismissed.
+ *
+ * The decision itself ([shouldShowServiceKilledBanner]) is pure and unit-tested; this object is
+ * only the prefs plumbing plus the live-state assembly ([shouldShowBanner]).
+ */
+object InvocationGuardRail {
+    private const val PREFS_NAME = "ramblr"
+    const val KEY_SERVICE_WAS_ENABLED = "service_was_enabled"
+    const val KEY_BANNER_DISMISSED = "service_killed_banner_dismissed"
+
+    /** Called from [WhisperAccessibilityService.onServiceConnected]: records that this install
+     *  has a working service and re-arms the banner for the next fresh detection. */
+    fun recordServiceConnected(context: Context) {
+        prefs(context).edit()
+            .putBoolean(KEY_SERVICE_WAS_ENABLED, true)
+            .putBoolean(KEY_BANNER_DISMISSED, false)
+            .apply()
+    }
+
+    /** The user tapped the banner's dismiss affordance: stay quiet until a fresh detection. */
+    fun dismissBanner(context: Context) {
+        prefs(context).edit().putBoolean(KEY_BANNER_DISMISSED, true).apply()
+    }
+
+    /** Assembles the live inputs for the pure [shouldShowServiceKilledBanner] decision. Uses
+     *  `enabled_accessibility_services` (not [WhisperAccessibilityService.instance]) for the
+     *  "enabled now" input: the enabled set is what the invisible-toggle sync edits, and a
+     *  connected-but-crashed service would otherwise false-positive the banner. */
+    fun shouldShowBanner(context: Context): Boolean {
+        val p = prefs(context)
+        return shouldShowServiceKilledBanner(
+            serviceWasEnabled = p.getBoolean(KEY_SERVICE_WAS_ENABLED, false),
+            serviceEnabledNow = InvocationSecureSettings.isServiceEnabled(context),
+            anyShortcutBound = InvocationSecureSettings.anyShortcutBound(context),
+            bannerDismissed = p.getBoolean(KEY_BANNER_DISMISSED, false),
+        )
+    }
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -1,0 +1,168 @@
+package com.trevornk.ramblr
+
+/**
+ * Pure logic for the invocation-method chooser and the #156 "service killed by the OS shortcut
+ * toggle" guard rail. No Android dependencies, so every rule here is unit-tested
+ * ([InvocationMethodsTest]) -- the same reason [SettingsSubtitles]' formatters are free
+ * functions.
+ *
+ * Background (#156 root-cause memo): Ramblr's service is classified INVISIBLE_TOGGLE by the OS
+ * (targetSdk > Q + FLAG_REQUEST_ACCESSIBILITY_BUTTON), so AccessibilityManagerService couples the
+ * service's enabled state to its OS shortcut bindings: removing the LAST shortcut (nav-bar/
+ * floating button, gesture, volume-keys, QS a11y tile) disables the whole service, and adding one
+ * re-enables it. That sync runs only through the framework's enableShortcutsForTargets() path --
+ * raw Settings.Secure writes bypass it (device-verified), which is what the optional
+ * WRITE_SECURE_SETTINGS tier exploits ([InvocationSecureSettings]).
+ *
+ * The OS stores shortcut bindings as colon-separated flattened-ComponentName lists in
+ * Settings.Secure (`accessibility_button_targets`, `accessibility_shortcut_target_service`,
+ * `enabled_accessibility_services`). The helpers below implement the read-modify-write editing of
+ * those lists. Two invariants matter enough to pin in tests:
+ *
+ *  - OTHER apps' entries are preserved byte-for-byte. Clobbering another accessibility tool's
+ *    binding (e.g. Tasker's) while toggling ours would be a serious, hard-to-diagnose bug on the
+ *    user's device.
+ *  - Component names come in two flatten forms -- full (`pkg/pkg.Cls`) and short (`pkg/.Cls`) --
+ *    and the OS mixes them freely. Matching is normalized so `com.trevornk.ramblr/
+ *    .WhisperAccessibilityService` and `com.trevornk.ramblr/com.trevornk.ramblr
+ *    .WhisperAccessibilityService` are the same entry.
+ */
+
+/** Separator the OS uses between entries in the accessibility component-list settings. */
+const val COMPONENT_LIST_SEPARATOR = ":"
+
+/**
+ * Expands the short flatten form (`pkg/.Cls` -> `pkg/pkg.Cls`) so the two spellings of the same
+ * component compare equal. Entries that aren't `pkg/cls`-shaped are returned unchanged -- the
+ * list helpers must tolerate junk without corrupting it.
+ */
+fun normalizeComponent(component: String): String {
+    val slash = component.indexOf('/')
+    if (slash <= 0 || slash == component.length - 1) return component
+    val pkg = component.substring(0, slash)
+    val cls = component.substring(slash + 1)
+    return if (cls.startsWith(".")) "$pkg/$pkg$cls" else component
+}
+
+/** Whether two flattened component names refer to the same component, in either flatten form. */
+fun componentEquals(a: String, b: String): Boolean = normalizeComponent(a) == normalizeComponent(b)
+
+/**
+ * Splits a colon-separated component list into its entries, verbatim (no normalization), dropping
+ * empty segments (a null/blank setting, doubled or stray separators).
+ */
+fun componentListEntries(list: String?): List<String> =
+    list.orEmpty().split(COMPONENT_LIST_SEPARATOR).map { it.trim() }.filter { it.isNotEmpty() }
+
+/** Whether [component] (in either flatten form) is present in the colon-separated [list]. */
+fun componentListContains(list: String?, component: String): Boolean =
+    componentListEntries(list).any { componentEquals(it, component) }
+
+/**
+ * Returns [list] with [component] added (no-op when already present in either flatten form).
+ * Every other entry is preserved verbatim, in order; the new entry is appended last, which is
+ * where the OS's own ShortcutUtils appends too.
+ */
+fun componentListAdd(list: String?, component: String): String {
+    val entries = componentListEntries(list)
+    if (entries.any { componentEquals(it, component) }) {
+        return entries.joinToString(COMPONENT_LIST_SEPARATOR)
+    }
+    return (entries + component).joinToString(COMPONENT_LIST_SEPARATOR)
+}
+
+/**
+ * Returns [list] with every occurrence of [component] (in either flatten form) removed. Every
+ * other entry is preserved verbatim, in order. Removing the last entry yields `""` -- the OS
+ * writes the empty string (not null) for an emptied target list, so that's what callers persist.
+ */
+fun componentListRemove(list: String?, component: String): String =
+    componentListEntries(list)
+        .filterNot { componentEquals(it, component) }
+        .joinToString(COMPONENT_LIST_SEPARATOR)
+
+/**
+ * The #156 guard-rail decision: should the "Ramblr was turned off by the system shortcut switch"
+ * recovery banner be showing right now?
+ *
+ * The state it detects is specific: the service used to be connected ([serviceWasEnabled], a pref
+ * the service itself writes in onServiceConnected), it is no longer in the OS's
+ * `enabled_accessibility_services` ([serviceEnabledNow]), and no OS shortcut binding remains
+ * ([anyShortcutBound] -- button/gesture targets and the volume-keys target both empty of Ramblr).
+ * That combination is exactly what the invisible-toggle sync leaves behind when the user turns
+ * off the last "Ramblr shortcut" switch in system Settings. A plain "user never enabled the
+ * service" fresh install has [serviceWasEnabled] false and shows nothing.
+ *
+ * [bannerDismissed] keeps it non-nagging: dismissing persists until the service next connects
+ * (the service clears the dismissal in onServiceConnected via
+ * [InvocationGuardRail.recordServiceConnected]), so the banner reappears only on a fresh
+ * detection, never as a repeat nag for the same one.
+ */
+fun shouldShowServiceKilledBanner(
+    serviceWasEnabled: Boolean,
+    serviceEnabledNow: Boolean,
+    anyShortcutBound: Boolean,
+    bannerDismissed: Boolean,
+): Boolean = serviceWasEnabled && !serviceEnabledNow && !anyShortcutBound && !bannerDismissed
+
+// --- Subtitle / status formatters (SettingsSubtitles pattern: pure, shared by build + refresh) ---
+
+/**
+ * The main settings screen's "Invocation" category-row subtitle: leads with the methods that are
+ * ON so the row doubles as a status line, falling back to the pitch line when only the default
+ * ring is active.
+ */
+fun invocationMainRowSubtitleText(
+    ringVisible: Boolean,
+    systemButtonBound: Boolean,
+    volumeKeysBound: Boolean,
+): String {
+    val active = buildList {
+        if (ringVisible) add("Floating ring")
+        if (systemButtonBound) add("System button")
+        if (volumeKeysBound) add("Volume keys")
+    }
+    return if (active.isEmpty()) "How to start dictation — no method currently active"
+    else "How to start dictation — ${active.joinToString(", ")} on"
+}
+
+/** The chooser's "Floating ring" row subtitle. */
+fun invocationRingSubtitleText(visible: Boolean): String =
+    if (visible) "On — tap the ring to start and stop dictation"
+    else "Off — the ring is hidden"
+
+/**
+ * The chooser's "System accessibility button / gesture" row subtitle. [bound] is whether Ramblr
+ * is in `accessibility_button_targets`; [directControl] is whether the WRITE_SECURE_SETTINGS
+ * tier is active (toggle applies in-app) as opposed to the deep-link path (toggle opens system
+ * Settings).
+ */
+fun invocationSystemButtonSubtitleText(bound: Boolean, directControl: Boolean): String {
+    val state = if (bound) "On — the system button/gesture starts dictation" else "Off"
+    val how = if (directControl) "tap to switch in-app" else "tap to open system settings"
+    return "$state · $how"
+}
+
+/** The chooser's "Volume-keys hold" row subtitle. [bound] is whether Ramblr is
+ *  `accessibility_shortcut_target_service`'s target. */
+fun invocationVolumeKeysSubtitleText(bound: Boolean, directControl: Boolean): String {
+    val state = if (bound) "On — hold both volume keys to start dictation" else "Off"
+    val how = if (directControl) "tap to switch in-app" else "tap to open system settings"
+    return "$state · $how"
+}
+
+/** The chooser's "Quick Settings tile" row subtitle. The OS gives an app no way to read whether
+ *  its tile has been added to the panel, so this is a how-to, not a status. [canRequestAdd] is
+ *  API 33+, where the one-tap system "add this tile?" prompt exists. */
+fun invocationQsTileSubtitleText(canRequestAdd: Boolean): String =
+    if (canRequestAdd) "Dictate from the Quick Settings panel — tap to add the tile"
+    else "Dictate from the Quick Settings panel — tap for setup steps"
+
+/** The advanced tier's row subtitle: granted state is feature-detected, never assumed. */
+fun invocationAdvancedTierSubtitleText(granted: Boolean): String =
+    if (granted) "Active — shortcut changes apply in-app, without the system Settings round-trip"
+    else "Lets Ramblr manage system shortcuts directly — requires a one-time adb grant, tap for the command"
+
+/** The exact adb command the advanced tier needs, shown in its dialog for copy/paste. */
+fun wssAdbCommand(packageName: String): String =
+    "adb shell pm grant $packageName android.permission.WRITE_SECURE_SETTINGS"

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
@@ -1,0 +1,108 @@
+package com.trevornk.ramblr
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.Settings
+import android.util.Log
+
+/**
+ * The Android side of the invocation chooser's OS-shortcut state: reads the three
+ * `Settings.Secure` accessibility component lists (readable by any app, no permission) and --
+ * only when the optional WRITE_SECURE_SETTINGS tier is granted via adb (#156) -- writes them.
+ *
+ * All list editing is delegated to the pure helpers in [InvocationMethods] so the
+ * preserve-other-apps'-entries invariant is unit-tested; this object only does the
+ * ContentResolver I/O. Every write path is wrapped so a SecurityException (grant revoked between
+ * the feature-detect and the write -- e.g. by an app update reinstall) degrades to `false` and
+ * the caller falls back to the deep-link flow instead of crashing.
+ *
+ * Why raw Secure writes work at all: the invisible-toggle "last shortcut off kills the service"
+ * sync runs only inside AccessibilityManagerService.enableShortcutsForTargets(); AMS's
+ * ContentObserver on these keys just re-reads the values. Raw writes therefore change shortcut
+ * bindings WITHOUT touching the service's enabled state (device-verified in the #156 memo, §3),
+ * which is exactly the decoupling the OS UI can't offer.
+ */
+object InvocationSecureSettings {
+
+    private const val TAG = "PhoneWhisper"
+
+    /** `Settings.Secure` key: nav-bar/floating a11y button (and, in button-mode 2, gesture) targets. */
+    const val KEY_BUTTON_TARGETS = "accessibility_button_targets"
+
+    /** `Settings.Secure` key: volume-keys-hold (hardware) shortcut target list. Named "_service"
+     *  (singular) for legacy reasons but colon-separated like the others on current Android. */
+    const val KEY_SHORTCUT_TARGET_SERVICE = "accessibility_shortcut_target_service"
+
+    /** `Settings.Secure` key: the master enabled-services list -- the one the invisible-toggle
+     *  sync empties of Ramblr when the last shortcut is removed. */
+    const val KEY_ENABLED_SERVICES = "enabled_accessibility_services"
+
+    /**
+     * The system Settings deep-link action for one service's own Accessibility page. This is
+     * `Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS`, spelled out because the SDK constant is
+     * `@hide` (not in the public android.jar, so it doesn't compile) even though the ACTION
+     * STRING has resolved via the Settings app's exported intent-filter since API 30 (= minSdk).
+     * Callers pair it with the public [android.content.Intent.EXTRA_COMPONENT_NAME] (the extra
+     * AOSP's AccessibilityDetailsSettingsActivity reads) and keep an
+     * ActivityNotFoundException fallback to ACTION_ACCESSIBILITY_SETTINGS for OEM skins that
+     * don't export it.
+     */
+    const val ACTION_ACCESSIBILITY_DETAILS_SETTINGS = "android.settings.ACCESSIBILITY_DETAILS_SETTINGS"
+
+    /** Ramblr's service component in the full flatten form the OS itself writes. */
+    fun serviceComponent(context: Context): String =
+        ComponentName(context, WhisperAccessibilityService::class.java).flattenToString()
+
+    /** Whether the optional advanced tier is active: `pm grant`-ed WRITE_SECURE_SETTINGS. */
+    fun canWrite(context: Context): Boolean =
+        context.checkSelfPermission(android.Manifest.permission.WRITE_SECURE_SETTINGS) ==
+            PackageManager.PERMISSION_GRANTED
+
+    // --- Reads (no permission needed) ---
+
+    fun isButtonTargetBound(context: Context): Boolean =
+        componentListContains(read(context, KEY_BUTTON_TARGETS), serviceComponent(context))
+
+    fun isVolumeKeysBound(context: Context): Boolean =
+        componentListContains(read(context, KEY_SHORTCUT_TARGET_SERVICE), serviceComponent(context))
+
+    fun isServiceEnabled(context: Context): Boolean =
+        componentListContains(read(context, KEY_ENABLED_SERVICES), serviceComponent(context))
+
+    /** Whether ANY OS shortcut still binds Ramblr -- the guard rail's "targets empty" input. */
+    fun anyShortcutBound(context: Context): Boolean =
+        isButtonTargetBound(context) || isVolumeKeysBound(context)
+
+    private fun read(context: Context, key: String): String? =
+        Settings.Secure.getString(context.contentResolver, key)
+
+    // --- Writes (advanced tier only; all return success and never throw) ---
+
+    /** Adds/removes Ramblr in [key]'s component list, preserving every other app's entries
+     *  verbatim (read-modify-write through the tested pure helpers). Returns false -- caller
+     *  falls back to the deep-link flow -- if the permission is missing or the write throws. */
+    fun setBinding(context: Context, key: String, bound: Boolean): Boolean {
+        if (!canWrite(context)) return false
+        val component = serviceComponent(context)
+        val current = read(context, key)
+        val updated = if (bound) componentListAdd(current, component) else componentListRemove(current, component)
+        return try {
+            Settings.Secure.putString(context.contentResolver, key, updated)
+        } catch (e: SecurityException) {
+            // Feature-detect said granted but the write still failed (revoked mid-flight, OEM
+            // quirk): degrade to the deep-link path, never crash a Settings tap.
+            Log.e(TAG, "WRITE_SECURE_SETTINGS write to $key failed despite grant", e)
+            false
+        }
+    }
+
+    /**
+     * The advanced tier's true one-tap re-enable (#156 guard rail): put Ramblr back into
+     * `enabled_accessibility_services`, preserving other services' entries (e.g. Tasker's)
+     * verbatim. Base tier can't do this -- its banner deep-links to the service's Settings page
+     * instead.
+     */
+    fun reEnableService(context: Context): Boolean =
+        setBinding(context, KEY_ENABLED_SERVICES, bound = true)
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -35,6 +35,8 @@ class MainActivity : BaseSettingsActivity() {
     private lateinit var livePreviewRowSub: TextView
     private lateinit var cloudRowSub: TextView
     private lateinit var vocabularyRowSub: TextView
+    private lateinit var invocationRowSub: TextView
+    private lateinit var serviceKilledBanner: View
 
     // First-run wizard state (#6). Tracked in-memory so a dialog already on screen is never
     // duplicated by a stray onResume, and reset per Activity instance so a fresh launch always
@@ -75,6 +77,13 @@ class MainActivity : BaseSettingsActivity() {
             setPadding(dp(24), dp(64), dp(24), dp(24))
         }
         root.addView(header)
+
+        // #156 guard rail: the invisible-toggle recovery banner. Built unconditionally and
+        // shown/hidden in refresh() (the #L16 lesson from BehaviorActivity's iconHiddenRow --
+        // the triggering state changes precisely while this Activity is paused, in system
+        // Settings), so onResume picks up a fresh kill immediately.
+        serviceKilledBanner = buildServiceKilledBanner()
+        root.addView(serviceKilledBanner)
 
         // Status row -- tapping it (re-)launches the setup walkthrough when setup isn't done yet
         // (#52); once ready it's just informational, same as before.
@@ -123,6 +132,17 @@ class MainActivity : BaseSettingsActivity() {
         }
         vocabularyRowSub = vocabularyRow.findViewWithTag("subtitle")
         root.addView(vocabularyRow)
+
+        // Invocation-method chooser (#156): one screen for every way to start dictation --
+        // app-owned (ring, QS tile) and OS-owned (a11y button/gesture, volume keys) -- with the
+        // invisible-toggle education the OS's own UI lacks. Top-level rather than under
+        // Advanced/Behavior: the OS-owned methods are how #156's service-kill trap gets sprung,
+        // so the safe path to them should be as discoverable as the trap is.
+        val invocationRow = settingsRow("Invocation", "Checking...") {
+            startActivity(Intent(this, InvocationActivity::class.java))
+        }
+        invocationRowSub = invocationRow.findViewWithTag("subtitle")
+        root.addView(invocationRow)
 
         root.addView(settingsRow("Advanced", AdvancedActivity.subtitle(this)) {
             startActivity(Intent(this, AdvancedActivity::class.java))
@@ -250,6 +270,9 @@ class MainActivity : BaseSettingsActivity() {
         livePreviewRowSub.text = LivePreviewActivity.subtitle(this)
         cloudRowSub.text = CloudProviderActivity.subtitle(this)
         vocabularyRowSub.text = vocabularyMainRowSubtitleText(VocabularyEditor.terms(this).size)
+        invocationRowSub.text = InvocationActivity.subtitle(this)
+        serviceKilledBanner.visibility =
+            if (InvocationGuardRail.shouldShowBanner(this)) View.VISIBLE else View.GONE
 
         // Ready logic -- see OnboardingWizard.isSetupComplete for what "ready" means (#52).
         val ready = OnboardingWizard.isSetupComplete(
@@ -265,6 +288,87 @@ class MainActivity : BaseSettingsActivity() {
     }
 
     private fun hasPerm(p: String) = ContextCompat.checkSelfPermission(this, p) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+    // --- #156 guard rail: "Ramblr was turned off by the system shortcut switch" banner ---
+
+    /**
+     * The recovery banner for the invisible-toggle kill (#156): the OS disables the whole
+     * service when its last shortcut is removed in system Settings, silently and with the app
+     * closed. Detection is [InvocationGuardRail.shouldShowBanner] (pure decision:
+     * [shouldShowServiceKilledBanner], unit-tested); this just builds the card once -- visibility
+     * is owned by [refresh], mirroring how the other rows update.
+     *
+     * Tap = the best available recovery per tier: with WRITE_SECURE_SETTINGS granted, a true
+     * one-tap re-enable (raw write to enabled_accessibility_services, preserving other services'
+     * entries); base tier deep-links straight to Ramblr's own Accessibility page where the
+     * enable switch lives. Dismiss = quiet until a FRESH kill (the dismissal is cleared when the
+     * service next connects), so the banner never turns into a nag.
+     */
+    private fun buildServiceKilledBanner(): View {
+        val banner = vertical(dp(16), dp(12)).apply {
+            background = android.graphics.drawable.GradientDrawable().apply {
+                cornerRadius = dp(12).toFloat()
+                setColor(withAlpha(attrColor(com.google.android.material.R.attr.colorPrimary), 0x22))
+            }
+            layoutParams = android.widget.LinearLayout.LayoutParams(LP_MATCH, LP_WRAP).apply {
+                setMargins(dp(16), 0, dp(16), dp(8))
+            }
+            visibility = View.GONE
+        }
+        banner.addView(TextView(this).apply {
+            text = "Ramblr was turned off by the system shortcut switch"
+            textSize = 16f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTextColor(attrColor(android.R.attr.textColorPrimary))
+        })
+        banner.addView(TextView(this).apply {
+            text = if (InvocationSecureSettings.canWrite(this@MainActivity))
+                "Tap to turn it back on."
+            else
+                "Tap to open its Accessibility page and turn it back on."
+            textSize = 14f
+            setTextColor(attrColor(android.R.attr.textColorSecondary))
+            setPadding(0, dp(4), 0, 0)
+        })
+        val dismiss = TextView(this).apply {
+            text = "Dismiss"
+            textSize = 14f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTextColor(attrColor(com.google.android.material.R.attr.colorPrimary))
+            setPadding(dp(8), dp(8), dp(8), dp(4))
+            setOnClickListener {
+                InvocationGuardRail.dismissBanner(this@MainActivity)
+                refresh()
+            }
+        }
+        banner.addView(dismiss)
+        banner.setOnClickListener { onServiceKilledBannerTapped() }
+        return banner
+    }
+
+    private fun onServiceKilledBannerTapped() {
+        // Advanced tier: true one-tap re-enable via a raw Secure write (#156 memo §3 -- raw
+        // writes bypass the invisible-toggle sync, and here that's exactly what we want: restore
+        // enabled_accessibility_services without the OS "helpfully" re-syncing shortcuts).
+        if (InvocationSecureSettings.reEnableService(this)) {
+            toast("Ramblr re-enabled")
+            refresh()
+            return
+        }
+        // Base tier: the OS offers no app-side re-enable, so the best path IS the service's own
+        // Settings page (resolvable since API 30 = minSdk; the action is a string constant --
+        // see InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS -- because the SDK
+        // symbol is @hide), where the enable switch is one tap away.
+        val details = Intent(InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS).putExtra(
+            Intent.EXTRA_COMPONENT_NAME,
+            android.content.ComponentName(this, WhisperAccessibilityService::class.java).flattenToString(),
+        )
+        try {
+            startActivity(details)
+        } catch (_: android.content.ActivityNotFoundException) {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+    }
 
     // --- Onboarding wizard (#6/#52/#80/#98) -- kept on MainActivity, see class kdoc ---
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -538,6 +538,10 @@ class WhisperAccessibilityService : AccessibilityService() {
 
     override fun onServiceConnected() {
         instance = this
+        // #156 guard rail: record that this install has a working service (the signal that
+        // separates "killed by the OS shortcut switch" from "never enabled") and re-arm the
+        // recovery banner's dismissal for the next fresh detection.
+        InvocationGuardRail.recordServiceConnected(this)
         CustomPersonaStore.ensureLegacySeeded(this)
         ProviderChainMigration.runIfNeeded(this)
         showOverlay()

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -1,0 +1,232 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The #156 invocation-chooser + guard-rail logic, pinned at the pure layer
+ * ([InvocationMethods.kt]) because none of it can be exercised on the JVM through the Activity /
+ * ContentResolver code that calls it -- the same reasoning as [SettingsSubtitlesTest].
+ *
+ * The component-list helpers get the heaviest coverage: with WRITE_SECURE_SETTINGS granted they
+ * read-modify-write the OS's real `Settings.Secure` accessibility lists, where corrupting
+ * ANOTHER app's entry (e.g. Tasker's) would break that app's accessibility setup with nothing
+ * pointing back at Ramblr as the cause.
+ */
+class InvocationMethodsTest {
+
+    private val ramblr = "com.trevornk.ramblr/com.trevornk.ramblr.WhisperAccessibilityService"
+    private val ramblrShort = "com.trevornk.ramblr/.WhisperAccessibilityService"
+    private val tasker = "net.dinglisch.android.taskerm/net.dinglisch.android.taskerm.MyAccessibilityService"
+    private val other = "com.example.other/.OtherService"
+
+    // --- normalizeComponent / componentEquals -----------------------------------------------
+
+    @Test fun `short flatten form expands to full form`() {
+        assertEquals(ramblr, normalizeComponent(ramblrShort))
+    }
+
+    @Test fun `full flatten form is unchanged`() {
+        assertEquals(ramblr, normalizeComponent(ramblr))
+    }
+
+    @Test fun `non component-shaped strings pass through unchanged`() {
+        // The helpers must tolerate junk in the settings value without corrupting it.
+        assertEquals("garbage", normalizeComponent("garbage"))
+        assertEquals("/leading", normalizeComponent("/leading"))
+        assertEquals("trailing/", normalizeComponent("trailing/"))
+        assertEquals("", normalizeComponent(""))
+    }
+
+    @Test fun `componentEquals matches across flatten forms in both directions`() {
+        assertTrue(componentEquals(ramblr, ramblrShort))
+        assertTrue(componentEquals(ramblrShort, ramblr))
+        assertFalse(componentEquals(ramblr, tasker))
+    }
+
+    // --- componentListEntries / componentListContains ---------------------------------------
+
+    @Test fun `null and empty lists have no entries`() {
+        assertEquals(emptyList<String>(), componentListEntries(null))
+        assertEquals(emptyList<String>(), componentListEntries(""))
+        assertFalse(componentListContains(null, ramblr))
+        assertFalse(componentListContains("", ramblr))
+    }
+
+    @Test fun `doubled and stray separators are dropped, not turned into empty entries`() {
+        assertEquals(listOf(tasker, ramblr), componentListEntries("$tasker::$ramblr:"))
+    }
+
+    @Test fun `contains matches the short form against a full-form list and vice versa`() {
+        assertTrue(componentListContains(ramblr, ramblrShort))
+        assertTrue(componentListContains(ramblrShort, ramblr))
+        assertTrue(componentListContains("$tasker:$ramblrShort", ramblr))
+        assertFalse(componentListContains(tasker, ramblr))
+    }
+
+    // --- componentListAdd -------------------------------------------------------------------
+
+    @Test fun `add to empty or null list yields just the component`() {
+        assertEquals(ramblr, componentListAdd(null, ramblr))
+        assertEquals(ramblr, componentListAdd("", ramblr))
+    }
+
+    @Test fun `add preserves other apps' entries verbatim and appends last`() {
+        assertEquals("$tasker:$other:$ramblr", componentListAdd("$tasker:$other", ramblr))
+    }
+
+    @Test fun `add is a no-op when already present`() {
+        assertEquals("$tasker:$ramblr", componentListAdd("$tasker:$ramblr", ramblr))
+    }
+
+    @Test fun `add is a no-op when present in the other flatten form`() {
+        // The OS may have written the short form; adding the full form must not duplicate it.
+        assertEquals("$tasker:$ramblrShort", componentListAdd("$tasker:$ramblrShort", ramblr))
+    }
+
+    // --- componentListRemove ----------------------------------------------------------------
+
+    @Test fun `remove from null or empty list yields empty string`() {
+        assertEquals("", componentListRemove(null, ramblr))
+        assertEquals("", componentListRemove("", ramblr))
+    }
+
+    @Test fun `removing the only entry yields empty string`() {
+        // The OS persists "" (not null) for an emptied target list; "" is what gets written back.
+        assertEquals("", componentListRemove(ramblr, ramblr))
+    }
+
+    @Test fun `remove preserves other apps' entries verbatim, in order`() {
+        assertEquals("$tasker:$other", componentListRemove("$tasker:$ramblr:$other", ramblr))
+    }
+
+    @Test fun `remove matches the other flatten form`() {
+        assertEquals(tasker, componentListRemove("$tasker:$ramblrShort", ramblr))
+        assertEquals(tasker, componentListRemove("$tasker:$ramblr", ramblrShort))
+    }
+
+    @Test fun `remove drops duplicates of the same component in mixed forms`() {
+        assertEquals(tasker, componentListRemove("$ramblr:$tasker:$ramblrShort", ramblr))
+    }
+
+    @Test fun `remove of an absent component leaves the list unchanged`() {
+        assertEquals("$tasker:$other", componentListRemove("$tasker:$other", ramblr))
+    }
+
+    @Test fun `add then remove round-trips back to the original entries`() {
+        val original = "$tasker:$other"
+        assertEquals(original, componentListRemove(componentListAdd(original, ramblr), ramblr))
+    }
+
+    // --- shouldShowServiceKilledBanner ------------------------------------------------------
+
+    @Test fun `banner fires on the exact invisible-toggle kill state`() {
+        assertTrue(shouldShowServiceKilledBanner(
+            serviceWasEnabled = true,
+            serviceEnabledNow = false,
+            anyShortcutBound = false,
+            bannerDismissed = false,
+        ))
+    }
+
+    @Test fun `fresh install that never enabled the service shows nothing`() {
+        assertFalse(shouldShowServiceKilledBanner(
+            serviceWasEnabled = false,
+            serviceEnabledNow = false,
+            anyShortcutBound = false,
+            bannerDismissed = false,
+        ))
+    }
+
+    @Test fun `service currently enabled shows nothing`() {
+        assertFalse(shouldShowServiceKilledBanner(
+            serviceWasEnabled = true,
+            serviceEnabledNow = true,
+            anyShortcutBound = false,
+            bannerDismissed = false,
+        ))
+    }
+
+    @Test fun `service off but a shortcut still bound is not the invisible-toggle kill`() {
+        // A remaining binding means the OS did NOT run the "last shortcut removed" sync -- the
+        // service is off for some other reason (and the bound shortcut can self-heal it: the
+        // volume-keys path re-enables a button-flag service on use). Don't misdiagnose.
+        assertFalse(shouldShowServiceKilledBanner(
+            serviceWasEnabled = true,
+            serviceEnabledNow = false,
+            anyShortcutBound = true,
+            bannerDismissed = false,
+        ))
+    }
+
+    @Test fun `dismissed banner stays quiet until re-armed`() {
+        assertFalse(shouldShowServiceKilledBanner(
+            serviceWasEnabled = true,
+            serviceEnabledNow = false,
+            anyShortcutBound = false,
+            bannerDismissed = true,
+        ))
+    }
+
+    // --- subtitle formatters ----------------------------------------------------------------
+
+    @Test fun `main row subtitle lists active methods`() {
+        assertEquals(
+            "How to start dictation — Floating ring, Volume keys on",
+            invocationMainRowSubtitleText(ringVisible = true, systemButtonBound = false, volumeKeysBound = true),
+        )
+    }
+
+    @Test fun `main row subtitle with nothing active says so`() {
+        assertEquals(
+            "How to start dictation — no method currently active",
+            invocationMainRowSubtitleText(ringVisible = false, systemButtonBound = false, volumeKeysBound = false),
+        )
+    }
+
+    @Test fun `ring subtitle reflects visibility`() {
+        assertEquals("On — tap the ring to start and stop dictation", invocationRingSubtitleText(visible = true))
+        assertEquals("Off — the ring is hidden", invocationRingSubtitleText(visible = false))
+    }
+
+    @Test fun `system button subtitle distinguishes deep-link and direct-control tiers`() {
+        assertEquals(
+            "On — the system button/gesture starts dictation · tap to open system settings",
+            invocationSystemButtonSubtitleText(bound = true, directControl = false),
+        )
+        assertEquals(
+            "Off · tap to switch in-app",
+            invocationSystemButtonSubtitleText(bound = false, directControl = true),
+        )
+    }
+
+    @Test fun `volume keys subtitle distinguishes deep-link and direct-control tiers`() {
+        assertEquals(
+            "On — hold both volume keys to start dictation · tap to switch in-app",
+            invocationVolumeKeysSubtitleText(bound = true, directControl = true),
+        )
+        assertEquals(
+            "Off · tap to open system settings",
+            invocationVolumeKeysSubtitleText(bound = false, directControl = false),
+        )
+    }
+
+    @Test fun `qs tile subtitle offers one-tap add only where the API exists`() {
+        assertTrue(invocationQsTileSubtitleText(canRequestAdd = true).contains("tap to add the tile"))
+        assertTrue(invocationQsTileSubtitleText(canRequestAdd = false).contains("tap for setup steps"))
+    }
+
+    @Test fun `advanced tier subtitle reflects the feature-detected grant`() {
+        assertTrue(invocationAdvancedTierSubtitleText(granted = true).startsWith("Active"))
+        assertTrue(invocationAdvancedTierSubtitleText(granted = false).contains("adb"))
+    }
+
+    @Test fun `adb command names the exact package and permission`() {
+        assertEquals(
+            "adb shell pm grant com.trevornk.ramblr android.permission.WRITE_SECURE_SETTINGS",
+            wssAdbCommand("com.trevornk.ramblr"),
+        )
+    }
+}


### PR DESCRIPTION
Refs #156 (do not auto-close — needs on-device verification first).

Implements option 1 from the #156 root-cause memo: Ramblr is an INVISIBLE_TOGGLE-class accessibility service (targetSdk > Q + `flagRequestAccessibilityButton` from #211), so AccessibilityManagerService couples the service's enabled state to its OS shortcut bindings — turning off the **last** "Ramblr shortcut" switch in system Settings silently turns off Ramblr itself. That coupling runs only through the framework's `enableShortcutsForTargets()` path; raw `Settings.Secure` writes bypass it (device-verified in the memo, §3).

## What's here

**1. Invocation chooser (`InvocationActivity`, new top-level "Invocation" row on the main screen)**
- **Floating ring** (app-owned): direct toggle over `IconHiddenState`, wired to the existing #135 hide/restore notification chain.
- **System accessibility button / gesture** (OS-owned): live bound-state read from `accessibility_button_targets` (readable with no permission); tap shows an explainer naming the invisible-toggle trap *before* deep-linking to the service's own Accessibility page (`android.settings.ACCESSIBILITY_DETAILS_SETTINGS` + `EXTRA_COMPONENT_NAME`, fallback to the top-level list). Includes the system floating-button quirk note (bright long-press state ≠ recording).
- **Volume-keys hold** (OS-owned): same pattern against `accessibility_shortcut_target_service`, with the one-time system-dialog warning. Per the memo (AMS 4295–4331), for button-flag services this shortcut can only enable/invoke, never disable.
- **Quick Settings tile** (app-owned, #127): API 33+ uses `StatusBarManager.requestAddTileService` for the one-tap add sheet; below that, manual panel-edit steps. Tile placement isn't readable by apps, so this row is an affordance, not a status.

**2. Guard rail — the actual #156 mitigation**
- `WhisperAccessibilityService.onServiceConnected` records `service_was_enabled` and re-arms the banner.
- `MainActivity.refresh()` (onCreate + onResume) shows a prominent dismissible card when: was-enabled ∧ absent from `enabled_accessibility_services` ∧ zero shortcut bindings left — the exact post-state of the invisible-toggle kill. A remaining binding suppresses it (that's not the kill state, and volume-keys self-heals).
- Tap = best recovery per tier: WSS tier does a true one-tap re-enable (raw write to `enabled_accessibility_services`, other services' entries preserved verbatim); base tier deep-links to the service's Settings page — the best the OS allows. Dismiss stays quiet until the *next* fresh kill (cleared on service connect), so it never nags.

**3. Optional advanced tier (feature-detected per tap, never assumed)**
- `adb shell pm grant com.trevornk.ramblr android.permission.WRITE_SECURE_SETTINGS` (command shown, selectable, in the chooser's "Direct shortcut control" dialog).
- When granted, the OS-owned rows become real in-app toggles: read-modify-write of the colon-separated component lists, preserving other apps' entries (e.g. Tasker's) byte-for-byte, matching both `ComponentName` flatten forms (`pkg/pkg.Cls` and `pkg/.Cls`). Writes bypass the invisible-toggle sync, so bindings change without ever killing the service.
- Every write path catches `SecurityException` and falls back to the deep-link flow.
- Manifest declares `WRITE_SECURE_SETTINGS` with `tools:ignore="ProtectedPermissions"` — inert unless adb-granted.

## Tests

All decision logic and list editing is pure (`InvocationMethods.kt`), pinned by `InvocationMethodsTest` — 31 tests covering: normalize/equals across flatten forms; entries/contains on null/empty/junk/doubled-separator lists; add (empty, append-last, no-op duplicate incl. cross-form); remove (null/empty, only-entry→`""` as the OS persists, preserve-others order, cross-form, mixed-form duplicates, absent no-op, add/remove round-trip); the banner decision's five states; and every subtitle formatter + the adb command string.

- `testGithubDebugUnitTest`: **1495 passed, 0 failed, 0 skipped** (baseline on main: 1464/0/0 → +31)
- `testStorefrontDebugUnitTest`: green (exit 0)

## Needs on-device verification before merge (device was offline for this work)

- [ ] Chooser renders correctly (rows, subtitles, switch states) on the Pixel 10 Pro Fold
- [ ] `ACCESSIBILITY_DETAILS_SETTINGS` deep-link resolves with `EXTRA_COMPONENT_NAME` as a flattened **string** extra (AOSP reads a String; if the OS build expects a Parcelable `ComponentName`, flip that one line) and lands on Ramblr's page
- [ ] Guard-rail banner fires after killing the service via the OS shortcut switch, tap recovers, dismiss re-arms only on next connect
- [ ] After `pm grant`: rows toggle bindings in-app, other services' entries (Tasker) untouched, service never disabled; banner does true one-tap re-enable
- [ ] Volume-keys bind via chooser → hold invokes dictation (and re-enables when off)
- [ ] QS tile add sheet appears (API 33+ path)
- [ ] Lint on release build accepts the `ProtectedPermissions` ignore

## Deviation from the memo

`Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS` is `@hide` in the public SDK (compile error against android.jar 36), despite being listed in some docs as API 30+. Used the literal action string `"android.settings.ACCESSIBILITY_DETAILS_SETTINGS"` (stable since R, resolved via the Settings app's exported intent-filter) with an `ActivityNotFoundException` fallback to `ACTION_ACCESSIBILITY_SETTINGS`. Everything else follows the memo as written.