### PR TITLE
Dual service components: ring-only default restored, system controls opt-in (#156 rework)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -153,6 +153,17 @@
             </intent-filter>
         </activity>
 
+        <!-- #156 dual-component design: the same service class ships as TWO components because
+             flagRequestAccessibilityButton is static-XML-only (targetSdk > 29) yet decides the
+             OS-side classification (TOGGLE vs INVISIBLE_TOGGLE) — so each "world" needs its own
+             component, and exactly one is PM-enabled at a time (InvocationServiceMode).
+
+             Component 1 (DEFAULT, enabled): WhisperAccessibilityService = "Floating icon" mode.
+             Its config XML declares NO button flag -> ordinary TOGGLE service: independent
+             Settings switch, floating ring only, no system button/gesture, no invisible-toggle
+             trap. The name is deliberately unchanged from every prior release so existing
+             installs' enabled_accessibility_services entries keep pointing at it — an update
+             restores pre-#211 ring-only behavior with zero migration. -->
         <service
             android:name=".WhisperAccessibilityService"
             android:exported="false"
@@ -163,6 +174,31 @@
             <meta-data
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
+        </service>
+
+        <!-- Component 2 (OPT-IN, android:enabled="false"): SystemControlsAccessibilityService =
+             "System controls" mode. A trivial subclass (same behavior, same process-local
+             statics) whose config XML DOES declare flagRequestAccessibilityButton, enabling the
+             nav-bar/floating a11y button, the a11y gesture, and volume-keys-hold invocation —
+             at the cost of the INVISIBLE_TOGGLE coupling (#156), which the guard-rail banner
+             covers. Disabled by default so fresh installs and updates show exactly ONE "Ramblr"
+             entry in system Settings; the Invocation screen's mode switch flips the two
+             components via PackageManager.setComponentEnabledSetting (InvocationServiceMode).
+             android:label stays the plain app name: only one component is ever PM-enabled at a
+             time, so Settings never lists both, and the plain name reads cleanest in the
+             shortcut UIs (a11y button chooser, volume-keys first-use dialog). -->
+        <service
+            android:name=".SystemControlsAccessibilityService"
+            android:enabled="false"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config_system" />
         </service>
 
         <!-- Quick Settings tile (#127): alternative dictation trigger for users who hide the

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
@@ -12,25 +12,38 @@ import android.widget.TextView
 import com.google.android.material.materialswitch.MaterialSwitch
 
 /**
- * "Invocation" settings screen (#156): one place to see and choose every way of starting a
- * dictation -- the app-owned floating ring and QS tile, and the OS-owned accessibility
- * button/gesture and volume-keys hold.
+ * "Invocation" settings screen (#156, dual-component rework): the mode chooser at the top picks
+ * which of Ramblr's two service components is active, and the rows below configure the
+ * individual invocation surfaces.
  *
- * The OS-owned rows exist because of the invisible-toggle trap this screen is really about
- * (#156 memo): Ramblr is an INVISIBLE_TOGGLE-class service, so system Settings couples the
- * service's on/off state to its shortcut bindings -- turning off the LAST "Ramblr shortcut"
- * switch there also turns off Ramblr itself. The app cannot manage those bindings through any
- * supported API (enableShortcutsForTargets is @hide + MANAGE_ACCESSIBILITY), so the base tier
- * deep-links to the service's own system page (ACTION_ACCESSIBILITY_DETAILS_SETTINGS, API 30+ =
- * minSdk) BEHIND an explainer dialog that names the trap before the user meets it.
+ * The two modes exist because `flagRequestAccessibilityButton` is static-XML-only (targetSdk >
+ * 29) yet decides the OS classification of the whole service:
  *
- * The optional advanced tier (WRITE_SECURE_SETTINGS via a one-time adb grant, feature-detected
- * per tap) upgrades the OS-owned rows to real in-app toggles: raw Settings.Secure writes bypass
- * the invisible-toggle sync entirely (device-verified), so bindings change without the Settings
- * round-trip and without ever tripping the service kill. See [InvocationSecureSettings].
+ *  - FLOATING ICON (default, [WhisperAccessibilityService], no flag): ordinary TOGGLE service.
+ *    Ramblr's own ring starts dictation; the system Settings switch is independent and there is
+ *    no invisible-toggle trap. This is the pre-#211 world, restored for everyone by default.
+ *  - SYSTEM CONTROLS (opt-in, [SystemControlsAccessibilityService], flag declared): the OS
+ *    a11y button/gesture and the volume-keys hold invoke dictation -- at the price of the
+ *    INVISIBLE_TOGGLE coupling (last shortcut off kills the service), which the #220 guard-rail
+ *    banner watches for while this mode is active.
+ *
+ * Mode switching ([InvocationServiceMode.switchMode]) flips which component is PM-enabled. With
+ * the optional WRITE_SECURE_SETTINGS tier (adb grant, feature-detected) the switch is seamless:
+ * `enabled_accessibility_services` is rewritten in the same motion, so the service hops
+ * components without a Settings visit. Without it, the switch PM-flips the components (killing
+ * the running service -- the confirmation dialog warns about exactly this) and then deep-links
+ * to system Settings, where the single visible Ramblr entry needs one enable tap.
+ *
+ * The floating ring stays available in BOTH modes (someone on system controls may still want
+ * it) but is defaulted OFF on the switch into system mode so there aren't two floating buttons;
+ * the volume-keys and button rows are inert in floating-icon mode -- for a TOGGLE-class service
+ * the volume-keys shortcut would toggle the SERVICE on/off (AMS semantics), not dictation, so
+ * offering it there would be a trap of its own.
  */
 class InvocationActivity : BaseSettingsActivity() {
 
+    private lateinit var floatingModeCardSub: TextView
+    private lateinit var systemModeCardSub: TextView
     private lateinit var ringSwitch: MaterialSwitch
     private lateinit var ringRowSub: TextView
     private lateinit var systemButtonRowSub: TextView
@@ -48,10 +61,26 @@ class InvocationActivity : BaseSettingsActivity() {
             setPadding(dp(24), dp(64), dp(24), dp(24))
         })
 
+        // --- Mode chooser: two exclusive cards, one per service component. ---
+        root.addView(sectionHeader("Mode"))
+
+        val floatingCard = settingsRow("Floating icon (default)", "Checking...") {
+            onModeCardTapped(InvocationMode.FLOATING_ICON)
+        }
+        floatingModeCardSub = floatingCard.findViewWithTag("subtitle")
+        root.addView(floatingCard)
+
+        val systemCard = settingsRow("System controls", "Checking...") {
+            onModeCardTapped(InvocationMode.SYSTEM_CONTROLS)
+        }
+        systemModeCardSub = systemCard.findViewWithTag("subtitle")
+        root.addView(systemCard)
+
         root.addView(sectionHeader("How to start dictation"))
 
-        // --- Floating ring (app-owned): a direct toggle over IconHiddenState, the same flag the
-        // long-press "Hide icon" menu and BehaviorActivity's restore row already share.
+        // --- Floating ring (app-owned, works in BOTH modes): a direct toggle over
+        // IconHiddenState, the same flag the long-press "Hide icon" menu and BehaviorActivity's
+        // restore row already share.
         ringSwitch = MaterialSwitch(this).apply { isClickable = false }
         val ringRow = settingsRow("Floating ring", "Checking...", ringSwitch) {
             val nowHidden = !IconHiddenState.isHidden(this)
@@ -69,8 +98,12 @@ class InvocationActivity : BaseSettingsActivity() {
         ringRowSub = ringRow.findViewWithTag("subtitle")
         root.addView(ringRow)
 
-        // --- System accessibility button / gesture (OS-owned).
+        // --- System accessibility button / gesture (OS-owned; system mode only).
         val systemButtonRow = settingsRow("System accessibility button / gesture", "Checking...") {
+            if (InvocationServiceMode.currentMode(this) != InvocationMode.SYSTEM_CONTROLS) {
+                toast("Switch to System controls mode first")
+                return@settingsRow
+            }
             onOsShortcutRowTapped(
                 key = InvocationSecureSettings.KEY_BUTTON_TARGETS,
                 currentlyBound = InvocationSecureSettings.isButtonTargetBound(this),
@@ -85,10 +118,17 @@ class InvocationActivity : BaseSettingsActivity() {
         systemButtonRowSub = systemButtonRow.findViewWithTag("subtitle")
         root.addView(systemButtonRow)
 
-        // --- Volume-keys hold (OS-owned). Note (#156 memo, AMS 4295-4331): for a button-flag
-        // service this shortcut can only ever ENABLE the service or fire the dictation callback,
-        // never disable it -- it's the one OS entry point with no foot-gun of its own.
+        // --- Volume-keys hold (OS-owned; system mode only -- and hard-gated, not just greyed:
+        // for the floating component (TOGGLE class, no button flag) the OS's volume-keys
+        // shortcut TOGGLES THE SERVICE on/off (AMS.java 4296-4306) instead of invoking
+        // dictation, so binding it in that mode would be a foot-gun. On the system component
+        // (INVISIBLE_TOGGLE) the same shortcut fires the a11y-button callback -> dictation, and
+        // can only ever enable the service, never disable it (#156 memo, AMS 4295-4331).
         val volumeKeysRow = settingsRow("Volume-keys hold", "Checking...") {
+            if (InvocationServiceMode.currentMode(this) != InvocationMode.SYSTEM_CONTROLS) {
+                toast("Switch to System controls mode first")
+                return@settingsRow
+            }
             onOsShortcutRowTapped(
                 key = InvocationSecureSettings.KEY_SHORTCUT_TARGET_SERVICE,
                 currentlyBound = InvocationSecureSettings.isVolumeKeysBound(this),
@@ -103,8 +143,9 @@ class InvocationActivity : BaseSettingsActivity() {
         volumeKeysRowSub = volumeKeysRow.findViewWithTag("subtitle")
         root.addView(volumeKeysRow)
 
-        // --- QS tile (app-owned, #127). The OS never tells an app whether its tile is currently
-        // placed in the panel, so this row is an add-affordance, not a status readout.
+        // --- QS tile (app-owned, #127, unchanged by the mode). The OS never tells an app
+        // whether its tile is currently placed in the panel, so this row is an add-affordance,
+        // not a status readout.
         root.addView(settingsRow(
             "Quick Settings tile",
             invocationQsTileSubtitleText(canRequestAdd = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
@@ -134,20 +175,105 @@ class InvocationActivity : BaseSettingsActivity() {
     }
 
     private fun refresh() {
+        val mode = InvocationServiceMode.currentMode(this)
+        val systemMode = mode == InvocationMode.SYSTEM_CONTROLS
         val ringVisible = !IconHiddenState.isHidden(this)
         val direct = InvocationSecureSettings.canWrite(this)
+        floatingModeCardSub.text = invocationFloatingModeSubtitleText(active = !systemMode)
+        systemModeCardSub.text = invocationSystemModeSubtitleText(active = systemMode, directControl = direct)
         ringSwitch.isChecked = ringVisible
         ringRowSub.text = invocationRingSubtitleText(ringVisible)
         systemButtonRowSub.text = invocationSystemButtonSubtitleText(
+            modeActive = systemMode,
             bound = InvocationSecureSettings.isButtonTargetBound(this),
             directControl = direct,
         )
         volumeKeysRowSub.text = invocationVolumeKeysSubtitleText(
+            modeActive = systemMode,
             bound = InvocationSecureSettings.isVolumeKeysBound(this),
             directControl = direct,
         )
         advancedTierRowSub.text = invocationAdvancedTierSubtitleText(granted = direct)
     }
+
+    // --- Mode switching -------------------------------------------------------------------
+
+    /**
+     * A mode card tap: no-op when already active; otherwise confirm with tier-appropriate copy
+     * (the base tier's dialog must set the expectation that dictation stops until the one
+     * enable tap in system Settings), then run [InvocationServiceMode.switchMode] and follow up
+     * per its result.
+     */
+    private fun onModeCardTapped(target: InvocationMode) {
+        if (InvocationServiceMode.currentMode(this) == target) return
+        val direct = InvocationSecureSettings.canWrite(this)
+        val (title, message) = when (target) {
+            InvocationMode.SYSTEM_CONTROLS ->
+                "Switch to System controls?" to (
+                    "Ramblr will switch to a service variant that supports the system " +
+                        "accessibility button, gesture, and volume-keys hold.\n\n" +
+                        (if (direct)
+                            "The switch is automatic \u2014 dictation keeps working throughout."
+                        else
+                            "Dictation will STOP for a moment: Android needs you to re-enable " +
+                            "Ramblr with one tap on the next screen (there will be exactly one " +
+                            "Ramblr entry \u2014 just turn it on).") +
+                        "\n\nThe floating ring will be hidden to avoid two on-screen buttons; " +
+                        "you can turn it back on below.\n\n" +
+                        "\u26a0\ufe0f In this mode, the system couples Ramblr to its shortcuts: " +
+                        "turning off the LAST \u201cRamblr shortcut\u201d in system Settings also " +
+                        "turns Ramblr off. If that happens, Ramblr shows a recovery banner."
+                )
+            InvocationMode.FLOATING_ICON ->
+                "Switch to Floating icon?" to (
+                    "Ramblr will switch back to the default service variant: the floating ring " +
+                        "starts dictation, the system button/gesture and volume-keys shortcuts " +
+                        "go away, and the system Settings switch becomes a simple independent " +
+                        "on/off again.\n\n" +
+                        (if (direct)
+                            "The switch is automatic \u2014 dictation keeps working throughout."
+                        else
+                            "Dictation will STOP for a moment: Android needs you to re-enable " +
+                            "Ramblr with one tap on the next screen (there will be exactly one " +
+                            "Ramblr entry \u2014 just turn it on).")
+                )
+        }
+        android.app.AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton("Switch") { _, _ -> performModeSwitch(target) }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun performModeSwitch(target: InvocationMode) {
+        // No-double-icon default: entering system mode hides the ring (it stays available via
+        // the toggle below -- deliberate default, not a removal). Leaving system mode restores
+        // it, since the ring is the only invocation surface floating-icon mode has.
+        if (target == InvocationMode.SYSTEM_CONTROLS) {
+            IconHiddenState.setHidden(this, true)
+            WhisperAccessibilityService.instance?.applyOverlayVisibility()
+        } else {
+            IconHiddenState.setHidden(this, false)
+            IconVisibilityNotifications.cancel(this)
+            WhisperAccessibilityService.instance?.applyOverlayVisibility()
+        }
+        when (InvocationServiceMode.switchMode(this, target)) {
+            InvocationServiceMode.SwitchResult.SEAMLESS -> {
+                toast("Mode switched")
+                refresh()
+            }
+            InvocationServiceMode.SwitchResult.NEEDS_SETTINGS_TAP -> {
+                // The one guided tap: the old component is already PM-disabled, so system
+                // Settings shows exactly one Ramblr entry -- the target component -- and its
+                // details page has the enable switch front and center.
+                openServiceDetailsSettings()
+            }
+            InvocationServiceMode.SwitchResult.NO_OP -> refresh()
+        }
+    }
+
+    // --- OS shortcut rows (system mode only) ----------------------------------------------
 
     /**
      * OS-owned row tap: with the advanced tier granted, flip the binding in-app via a raw Secure
@@ -170,7 +296,8 @@ class InvocationActivity : BaseSettingsActivity() {
     /**
      * The #156 explainer, shown BEFORE navigating: the trap is that the system page's "Ramblr
      * shortcut" switch doubles as a service kill-switch when it's the last shortcut left, and
-     * nothing on that page says so.
+     * nothing on that page says so. (Only reachable in system-controls mode -- the floating
+     * component isn't subject to the trap, but its rows never lead here.)
      */
     private fun showOsShortcutExplainerThenDeepLink(methodName: String, howTo: String) {
         android.app.AlertDialog.Builder(this)
@@ -179,21 +306,22 @@ class InvocationActivity : BaseSettingsActivity() {
                 "The $methodName is managed on Ramblr's system Accessibility page.\n\n$howTo\n\n" +
                     "\u26a0\ufe0f Important: the \u201cRamblr shortcut\u201d switch controls where the " +
                     "shortcut appears \u2014 but turning off the LAST shortcut also turns off " +
-                    "Ramblr itself (system behavior for always-on accessibility tools). To hide " +
-                    "the system button without turning Ramblr off, enable the floating ring on " +
-                    "this screen first."
+                    "Ramblr itself (system behavior for always-on accessibility tools). To keep " +
+                    "dictation available without any system shortcut, switch back to Floating " +
+                    "icon mode on this screen instead."
             )
             .setPositiveButton("Open system settings") { _, _ -> openServiceDetailsSettings() }
             .setNegativeButton("Cancel", null)
             .show()
     }
 
-    /** Deep-link to Ramblr's own service page (action string public-in-behavior since API 30 =
-     *  minSdk; see [InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS] for why it's
-     *  a spelled-out string). Falls back to the top-level Accessibility list if an OEM skin
-     *  doesn't resolve the details action. */
+    /** Deep-link to the ACTIVE component's own service page (action string public-in-behavior
+     *  since API 30 = minSdk; see [InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS]
+     *  for why it's a spelled-out string). Falls back to the top-level Accessibility list if an
+     *  OEM skin doesn't resolve the details action -- which is also fine for the mode-switch
+     *  flow, since only one Ramblr entry is visible there. */
     private fun openServiceDetailsSettings() {
-        val component = ComponentName(this, WhisperAccessibilityService::class.java)
+        val component = InvocationServiceMode.activeComponent(this)
         val details = Intent(InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS)
             .putExtra(Intent.EXTRA_COMPONENT_NAME, component.flattenToString())
         try {
@@ -234,15 +362,16 @@ class InvocationActivity : BaseSettingsActivity() {
         val granted = InvocationSecureSettings.canWrite(this)
         val command = wssAdbCommand(packageName)
         val message = TextView(this).apply {
-            text = (if (granted) "\u2705 Active. Shortcut switches on this screen now apply " +
-                "instantly, in-app, and can never trip the system's \u201clast shortcut off turns " +
+            text = (if (granted) "\u2705 Active. Mode switches happen seamlessly (no system " +
+                "Settings visit, dictation keeps working), shortcut switches apply instantly " +
+                "in-app, and none of it can trip the system's \u201clast shortcut off turns " +
                 "the service off\u201d behavior.\n\n"
             else "Android only lets apps change system shortcut bindings with a permission that " +
                 "must be granted once over adb (it survives reboots, but not reinstalls):\n\n") +
                 "$command\n\n" +
-                "With it granted, the rows above switch in-app with no system Settings round-trip, " +
-                "and if the service ever gets turned off by the system switch, Ramblr can turn " +
-                "itself back on with one tap."
+                "With it granted, mode switches complete in-app without the system Settings " +
+                "round-trip, the shortcut rows switch instantly, and if the service ever gets " +
+                "turned off by the system switch, Ramblr can turn itself back on with one tap."
             setTextIsSelectable(true)
             textSize = 14f
             setPadding(dp(24), dp(16), dp(24), 0)
@@ -257,6 +386,7 @@ class InvocationActivity : BaseSettingsActivity() {
     companion object {
         /** MainActivity category-row subtitle (SettingsSubtitles pattern: shared with refresh). */
         fun subtitle(context: android.content.Context): String = invocationMainRowSubtitleText(
+            mode = InvocationServiceMode.currentMode(context),
             ringVisible = !IconHiddenState.isHidden(context),
             systemButtonBound = InvocationSecureSettings.isButtonTargetBound(context),
             volumeKeysBound = InvocationSecureSettings.isVolumeKeysBound(context),

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
@@ -38,13 +38,22 @@ object InvocationGuardRail {
         prefs(context).edit().putBoolean(KEY_BANNER_DISMISSED, true).apply()
     }
 
-    /** Assembles the live inputs for the pure [shouldShowServiceKilledBanner] decision. Uses
-     *  `enabled_accessibility_services` (not [WhisperAccessibilityService.instance]) for the
-     *  "enabled now" input: the enabled set is what the invisible-toggle sync edits, and a
-     *  connected-but-crashed service would otherwise false-positive the banner. */
+    /** Assembles the live inputs for the pure [shouldShowServiceKilledBanner] decision.
+     *
+     *  Dual-component rework: the banner is gated on SYSTEM_CONTROLS mode being active
+     *  ([InvocationServiceMode.currentMode]) -- only that component is INVISIBLE_TOGGLE-
+     *  classified, so only it can be killed by the shortcut sync; in floating-icon mode a
+     *  disabled service is an ordinary user choice and never the trap.
+     *
+     *  Uses `enabled_accessibility_services` (not [WhisperAccessibilityService.instance]) for
+     *  the "enabled now" input: the enabled set is what the invisible-toggle sync edits, and a
+     *  connected-but-crashed service would otherwise false-positive the banner. The read
+     *  matches EITHER Ramblr component, which converges correctly mid-mode-switch too. */
     fun shouldShowBanner(context: Context): Boolean {
         val p = prefs(context)
         return shouldShowServiceKilledBanner(
+            systemControlsModeActive =
+                InvocationServiceMode.currentMode(context) == InvocationMode.SYSTEM_CONTROLS,
             serviceWasEnabled = p.getBoolean(KEY_SERVICE_WAS_ENABLED, false),
             serviceEnabledNow = InvocationSecureSettings.isServiceEnabled(context),
             anyShortcutBound = InvocationSecureSettings.anyShortcutBound(context),

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -6,13 +6,17 @@ package com.trevornk.ramblr
  * ([InvocationMethodsTest]) -- the same reason [SettingsSubtitles]' formatters are free
  * functions.
  *
- * Background (#156 root-cause memo): Ramblr's service is classified INVISIBLE_TOGGLE by the OS
- * (targetSdk > Q + FLAG_REQUEST_ACCESSIBILITY_BUTTON), so AccessibilityManagerService couples the
- * service's enabled state to its OS shortcut bindings: removing the LAST shortcut (nav-bar/
- * floating button, gesture, volume-keys, QS a11y tile) disables the whole service, and adding one
- * re-enables it. That sync runs only through the framework's enableShortcutsForTargets() path --
- * raw Settings.Secure writes bypass it (device-verified), which is what the optional
- * WRITE_SECURE_SETTINGS tier exploits ([InvocationSecureSettings]).
+ * Background (#156 root-cause memo + dual-component rework): a service with targetSdk > Q and
+ * FLAG_REQUEST_ACCESSIBILITY_BUTTON is classified INVISIBLE_TOGGLE by the OS, which makes
+ * AccessibilityManagerService couple the service's enabled state to its OS shortcut bindings:
+ * removing the LAST shortcut (nav-bar/floating button, gesture, volume-keys, QS a11y tile)
+ * disables the whole service, and adding one re-enables it. The flag is static-XML-only, so
+ * Ramblr ships TWO service components -- [WhisperAccessibilityService] without the flag (plain
+ * TOGGLE class, ring-only, the default) and [SystemControlsAccessibilityService] with it -- and
+ * PM-enables exactly one ([InvocationServiceMode]). The kill sync runs only through the
+ * framework's enableShortcutsForTargets() path -- raw Settings.Secure writes bypass it
+ * (device-verified), which is what the optional WRITE_SECURE_SETTINGS tier exploits
+ * ([InvocationSecureSettings]).
  *
  * The OS stores shortcut bindings as colon-separated flattened-ComponentName lists in
  * Settings.Secure (`accessibility_button_targets`, `accessibility_shortcut_target_service`,
@@ -82,16 +86,90 @@ fun componentListRemove(list: String?, component: String): String =
         .joinToString(COMPONENT_LIST_SEPARATOR)
 
 /**
- * The #156 guard-rail decision: should the "Ramblr was turned off by the system shortcut switch"
- * recovery banner be showing right now?
+ * Returns [list] with [oldComponent] replaced by [newComponent] -- the #156 dual-component mode
+ * switch's read-modify-write on `enabled_accessibility_services`. Rules, each pinned in tests:
+ *
+ *  - [oldComponent] is replaced IN PLACE (first occurrence's position), so other apps' entries
+ *    (e.g. Tasker's) keep their exact positions and spellings.
+ *  - Both flatten forms of [oldComponent] match; any further duplicates of it are dropped.
+ *  - If [newComponent] is already present (either form), the result is deduped -- the swap never
+ *    yields both of our components enabled at once.
+ *  - If [oldComponent] is absent, [newComponent] is appended last (the position the OS's own
+ *    ShortcutUtils uses when it adds entries) -- the mode switch still lands the user in a
+ *    working state even when the old component had already been disabled out from under us.
+ */
+fun componentListReplace(list: String?, oldComponent: String, newComponent: String): String {
+    val entries = componentListEntries(list)
+    val result = mutableListOf<String>()
+    var replaced = false
+    for (entry in entries) {
+        when {
+            componentEquals(entry, oldComponent) -> {
+                // First occurrence becomes the new component (unless it's already in the
+                // result); later duplicates are dropped entirely.
+                if (!replaced && result.none { componentEquals(it, newComponent) }) {
+                    result += newComponent
+                }
+                replaced = true
+            }
+            componentEquals(entry, newComponent) -> {
+                // Already-present new component: keep one occurrence, verbatim.
+                if (result.none { componentEquals(it, newComponent) }) result += entry
+            }
+            else -> result += entry
+        }
+    }
+    if (result.none { componentEquals(it, newComponent) }) result += newComponent
+    return result.joinToString(COMPONENT_LIST_SEPARATOR)
+}
+
+// --- #156 dual-component mode resolution ----------------------------------------------------
+
+/**
+ * The two invocation "worlds" of the #156 dual-component design, each a separate manifest
+ * `<service>` because `flagRequestAccessibilityButton` is static-XML-only yet decides the OS
+ * classification (TOGGLE vs INVISIBLE_TOGGLE). Exactly one component is PM-enabled at a time.
+ */
+enum class InvocationMode {
+    /** [WhisperAccessibilityService], no button flag: ring-only, independent Settings switch,
+     *  no invisible-toggle trap. The default -- and what every pre-dual install already has in
+     *  `enabled_accessibility_services`. */
+    FLOATING_ICON,
+
+    /** [SystemControlsAccessibilityService], button flag declared: system a11y button/gesture/
+     *  volume-keys invoke dictation, at the cost of the INVISIBLE_TOGGLE shortcut-service
+     *  coupling (which the guard rail watches). Opt-in, PM-disabled by default. */
+    SYSTEM_CONTROLS,
+}
+
+/**
+ * Which mode the install is in, from the one bit that decides it: whether the system-controls
+ * component is PM-enabled. The floating component's own PM state is deliberately NOT an input --
+ * the switch sequence enables the target before disabling the old component, so a crash between
+ * those steps can briefly leave both enabled, and "system component on" must win during that
+ * window for the retry/recovery paths to converge.
+ */
+fun resolveInvocationMode(systemComponentPmEnabled: Boolean): InvocationMode =
+    if (systemComponentPmEnabled) InvocationMode.SYSTEM_CONTROLS else InvocationMode.FLOATING_ICON
+
+/**
+ * The #156 guard-rail decision: should the "Ramblr was turned off by the system shortcut
+ * switch" recovery banner be showing right now?
+ *
+ * [systemControlsModeActive] gates the whole thing (dual-component rework): only the
+ * system-controls component is INVISIBLE_TOGGLE-classified, so only it is subject to the
+ * "last shortcut off kills the service" sync. In floating-icon mode the service is an ordinary
+ * TOGGLE service with an independent Settings switch -- a disabled service there is a user
+ * choice, not the trap, and the banner must stay quiet.
  *
  * The state it detects is specific: the service used to be connected ([serviceWasEnabled], a pref
  * the service itself writes in onServiceConnected), it is no longer in the OS's
- * `enabled_accessibility_services` ([serviceEnabledNow]), and no OS shortcut binding remains
- * ([anyShortcutBound] -- button/gesture targets and the volume-keys target both empty of Ramblr).
- * That combination is exactly what the invisible-toggle sync leaves behind when the user turns
- * off the last "Ramblr shortcut" switch in system Settings. A plain "user never enabled the
- * service" fresh install has [serviceWasEnabled] false and shows nothing.
+ * `enabled_accessibility_services` ([serviceEnabledNow], checked for the ACTIVE component), and
+ * no OS shortcut binding remains ([anyShortcutBound] -- button/gesture targets and the
+ * volume-keys target both empty of Ramblr). That combination is exactly what the
+ * invisible-toggle sync leaves behind when the user turns off the last "Ramblr shortcut" switch
+ * in system Settings. A plain "user never enabled the service" fresh install has
+ * [serviceWasEnabled] false and shows nothing.
  *
  * [bannerDismissed] keeps it non-nagging: dismissing persists until the service next connects
  * (the service clears the dismissal in onServiceConnected via
@@ -99,53 +177,88 @@ fun componentListRemove(list: String?, component: String): String =
  * detection, never as a repeat nag for the same one.
  */
 fun shouldShowServiceKilledBanner(
+    systemControlsModeActive: Boolean,
     serviceWasEnabled: Boolean,
     serviceEnabledNow: Boolean,
     anyShortcutBound: Boolean,
     bannerDismissed: Boolean,
-): Boolean = serviceWasEnabled && !serviceEnabledNow && !anyShortcutBound && !bannerDismissed
+): Boolean = systemControlsModeActive && serviceWasEnabled && !serviceEnabledNow &&
+    !anyShortcutBound && !bannerDismissed
 
 // --- Subtitle / status formatters (SettingsSubtitles pattern: pure, shared by build + refresh) ---
 
 /**
- * The main settings screen's "Invocation" category-row subtitle: leads with the methods that are
- * ON so the row doubles as a status line, falling back to the pitch line when only the default
- * ring is active.
+ * The main settings screen's "Invocation" category-row subtitle: leads with the active mode,
+ * then the methods that are ON so the row doubles as a status line.
  */
 fun invocationMainRowSubtitleText(
+    mode: InvocationMode,
     ringVisible: Boolean,
     systemButtonBound: Boolean,
     volumeKeysBound: Boolean,
 ): String {
-    val active = buildList {
-        if (ringVisible) add("Floating ring")
-        if (systemButtonBound) add("System button")
-        if (volumeKeysBound) add("Volume keys")
+    val modeName = when (mode) {
+        InvocationMode.FLOATING_ICON -> "Floating icon mode"
+        InvocationMode.SYSTEM_CONTROLS -> "System controls mode"
     }
-    return if (active.isEmpty()) "How to start dictation — no method currently active"
-    else "How to start dictation — ${active.joinToString(", ")} on"
+    val active = buildList {
+        if (ringVisible) add("ring on")
+        if (mode == InvocationMode.SYSTEM_CONTROLS && systemButtonBound) add("system button on")
+        if (mode == InvocationMode.SYSTEM_CONTROLS && volumeKeysBound) add("volume keys on")
+    }
+    return if (active.isEmpty()) "$modeName — no method currently active"
+    else "$modeName — ${active.joinToString(", ")}"
 }
 
-/** The chooser's "Floating ring" row subtitle. */
+/** The mode chooser's "Floating icon" card subtitle. */
+fun invocationFloatingModeSubtitleText(active: Boolean): String =
+    if (active) "Active — Ramblr's own floating ring starts dictation; the service has a " +
+        "simple independent on/off switch in system Settings"
+    else "Ramblr's floating ring only — no system button, and the system Settings switch " +
+        "can't be tripped by shortcut changes"
+
+/**
+ * The mode chooser's "System controls" card subtitle. [directControl] is whether the
+ * WRITE_SECURE_SETTINGS tier is active (switching modes is seamless) as opposed to the guided
+ * path (one enable tap in system Settings after switching).
+ */
+fun invocationSystemModeSubtitleText(active: Boolean, directControl: Boolean): String =
+    if (active) "Active — the system accessibility button, gesture, or volume-keys hold starts dictation"
+    else "Nav-bar/floating button, accessibility gesture, and volume-keys hold" +
+        if (directControl) " — switches instantly" else " — needs one enable tap in system Settings"
+
+/** The chooser's "Floating ring" toggle subtitle -- available in BOTH modes (someone in system
+ *  mode may still want the ring), but defaulted off on the switch INTO system mode to avoid the
+ *  double-icon problem. */
 fun invocationRingSubtitleText(visible: Boolean): String =
     if (visible) "On — tap the ring to start and stop dictation"
     else "Off — the ring is hidden"
 
 /**
- * The chooser's "System accessibility button / gesture" row subtitle. [bound] is whether Ramblr
- * is in `accessibility_button_targets`; [directControl] is whether the WRITE_SECURE_SETTINGS
- * tier is active (toggle applies in-app) as opposed to the deep-link path (toggle opens system
- * Settings).
+ * The system-mode "System accessibility button / gesture" row subtitle. Only meaningful while
+ * [modeActive]; in floating-icon mode the row is inert and says why. [bound] is whether the
+ * system component is in `accessibility_button_targets`; [directControl] is whether the
+ * WRITE_SECURE_SETTINGS tier is active (toggle applies in-app) as opposed to the deep-link path
+ * (toggle opens system Settings).
  */
-fun invocationSystemButtonSubtitleText(bound: Boolean, directControl: Boolean): String {
+fun invocationSystemButtonSubtitleText(modeActive: Boolean, bound: Boolean, directControl: Boolean): String {
+    if (!modeActive) return "Requires System controls mode"
     val state = if (bound) "On — the system button/gesture starts dictation" else "Off"
     val how = if (directControl) "tap to switch in-app" else "tap to open system settings"
     return "$state · $how"
 }
 
-/** The chooser's "Volume-keys hold" row subtitle. [bound] is whether Ramblr is
- *  `accessibility_shortcut_target_service`'s target. */
-fun invocationVolumeKeysSubtitleText(bound: Boolean, directControl: Boolean): String {
+/**
+ * The system-mode "Volume-keys hold" row subtitle. Only offered in system-controls mode, and
+ * not just for tidiness: for the floating-icon component (an ordinary TOGGLE-class service,
+ * no button flag) the OS's volume-keys shortcut semantics are "toggle the service on/off"
+ * (AMS.java 4296-4306) -- binding it there would make the volume keys silently kill and revive
+ * Ramblr instead of starting dictation. Only the button-flag (INVISIBLE_TOGGLE) component gets
+ * the "fire the a11y-button callback" semantics that make this shortcut an invoker.
+ */
+fun invocationVolumeKeysSubtitleText(modeActive: Boolean, bound: Boolean, directControl: Boolean): String {
+    if (!modeActive) return "Requires System controls mode — in Floating icon mode this " +
+        "shortcut would turn Ramblr itself off and on"
     val state = if (bound) "On — hold both volume keys to start dictation" else "Off"
     val how = if (directControl) "tap to switch in-app" else "tap to open system settings"
     return "$state · $how"

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
@@ -1,15 +1,21 @@
 package com.trevornk.ramblr
 
-import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
 import android.provider.Settings
 import android.util.Log
 
 /**
- * The Android side of the invocation chooser's OS-shortcut state: reads the three
+ * The Android side of the invocation screen's OS-shortcut state: reads the three
  * `Settings.Secure` accessibility component lists (readable by any app, no permission) and --
  * only when the optional WRITE_SECURE_SETTINGS tier is granted via adb (#156) -- writes them.
+ *
+ * Dual-component aware (#156 rework): Ramblr ships two service components
+ * ([WhisperAccessibilityService] / [SystemControlsAccessibilityService], see
+ * [InvocationServiceMode]), and the OS lists may name either -- e.g. an install that predates
+ * the rework still has the old component bound in `accessibility_button_targets`. All READS
+ * therefore match EITHER component ("is any Ramblr service/binding present"), while WRITES that
+ * add an entry always use the currently-active component, and writes that remove clean up both.
  *
  * All list editing is delegated to the pure helpers in [InvocationMethods] so the
  * preserve-other-apps'-entries invariant is unit-tested; this object only does the
@@ -50,25 +56,33 @@ object InvocationSecureSettings {
      */
     const val ACTION_ACCESSIBILITY_DETAILS_SETTINGS = "android.settings.ACCESSIBILITY_DETAILS_SETTINGS"
 
-    /** Ramblr's service component in the full flatten form the OS itself writes. */
+    /** The ACTIVE service component (per the current #156 mode) in the full flatten form the OS
+     *  itself writes -- what new bindings and deep links must target. */
     fun serviceComponent(context: Context): String =
-        ComponentName(context, WhisperAccessibilityService::class.java).flattenToString()
+        InvocationServiceMode.activeComponent(context).flattenToString()
 
     /** Whether the optional advanced tier is active: `pm grant`-ed WRITE_SECURE_SETTINGS. */
     fun canWrite(context: Context): Boolean =
         context.checkSelfPermission(android.Manifest.permission.WRITE_SECURE_SETTINGS) ==
             PackageManager.PERMISSION_GRANTED
 
-    // --- Reads (no permission needed) ---
+    // --- Reads (no permission needed; match EITHER Ramblr component -- see class kdoc) ---
+
+    /** Whether [list] contains ANY Ramblr service component, in either flatten form. */
+    private fun anyRamblrIn(context: Context, list: String?): Boolean =
+        InvocationServiceMode.allComponents(context).any { componentListContains(list, it) }
 
     fun isButtonTargetBound(context: Context): Boolean =
-        componentListContains(read(context, KEY_BUTTON_TARGETS), serviceComponent(context))
+        anyRamblrIn(context, read(context, KEY_BUTTON_TARGETS))
 
     fun isVolumeKeysBound(context: Context): Boolean =
-        componentListContains(read(context, KEY_SHORTCUT_TARGET_SERVICE), serviceComponent(context))
+        anyRamblrIn(context, read(context, KEY_SHORTCUT_TARGET_SERVICE))
 
+    /** Whether ANY Ramblr component is in `enabled_accessibility_services` -- the health check
+     *  used app-wide (setup rows, onboarding, guard rail) since either component counts as
+     *  "the service is enabled". */
     fun isServiceEnabled(context: Context): Boolean =
-        componentListContains(read(context, KEY_ENABLED_SERVICES), serviceComponent(context))
+        anyRamblrIn(context, read(context, KEY_ENABLED_SERVICES))
 
     /** Whether ANY OS shortcut still binds Ramblr -- the guard rail's "targets empty" input. */
     fun anyShortcutBound(context: Context): Boolean =
@@ -79,14 +93,23 @@ object InvocationSecureSettings {
 
     // --- Writes (advanced tier only; all return success and never throw) ---
 
-    /** Adds/removes Ramblr in [key]'s component list, preserving every other app's entries
-     *  verbatim (read-modify-write through the tested pure helpers). Returns false -- caller
-     *  falls back to the deep-link flow -- if the permission is missing or the write throws. */
+    /**
+     * Adds/removes Ramblr in [key]'s component list, preserving every other app's entries
+     * verbatim (read-modify-write through the tested pure helpers). Adding uses the ACTIVE
+     * component; removing sweeps BOTH components so stale pre-rework bindings (which name the
+     * old component) get cleaned up by the same tap. Returns false -- caller falls back to the
+     * deep-link flow -- if the permission is missing or the write throws.
+     */
     fun setBinding(context: Context, key: String, bound: Boolean): Boolean {
         if (!canWrite(context)) return false
-        val component = serviceComponent(context)
         val current = read(context, key)
-        val updated = if (bound) componentListAdd(current, component) else componentListRemove(current, component)
+        val updated = if (bound) {
+            componentListAdd(current, serviceComponent(context))
+        } else {
+            InvocationServiceMode.allComponents(context)
+                .fold(current as String?) { list, component -> componentListRemove(list, component) }
+                .orEmpty()
+        }
         return try {
             Settings.Secure.putString(context.contentResolver, key, updated)
         } catch (e: SecurityException) {
@@ -98,10 +121,10 @@ object InvocationSecureSettings {
     }
 
     /**
-     * The advanced tier's true one-tap re-enable (#156 guard rail): put Ramblr back into
-     * `enabled_accessibility_services`, preserving other services' entries (e.g. Tasker's)
-     * verbatim. Base tier can't do this -- its banner deep-links to the service's Settings page
-     * instead.
+     * The advanced tier's true one-tap re-enable (#156 guard rail): put the ACTIVE component
+     * back into `enabled_accessibility_services`, preserving other services' entries (e.g.
+     * Tasker's) verbatim. Base tier can't do this -- its banner deep-links to the service's
+     * Settings page instead.
      */
     fun reEnableService(context: Context): Boolean =
         setBinding(context, KEY_ENABLED_SERVICES, bound = true)

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
@@ -1,0 +1,169 @@
+package com.trevornk.ramblr
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.provider.Settings
+import android.util.Log
+
+/**
+ * The Android side of the #156 dual-component design: which of the two service components is
+ * the active one, and the mode switch that flips them.
+ *
+ * Both components run the identical service code ([SystemControlsAccessibilityService] is an
+ * empty subclass of [WhisperAccessibilityService]); they differ only in their static meta-data
+ * XML -- the system component declares `flagRequestAccessibilityButton`, the floating one
+ * doesn't. The flag can't be toggled at runtime (ignored for targetSdk > 29) and it decides the
+ * OS classification (INVISIBLE_TOGGLE vs TOGGLE), so "which world are we in" is exactly "which
+ * component is PM-enabled", flipped via [PackageManager.setComponentEnabledSetting].
+ *
+ * The mode decision itself ([resolveInvocationMode]) is pure and unit-tested; this object is
+ * the PM/ContentResolver plumbing plus the two switching flows:
+ *
+ *  - [switchMode] with WRITE_SECURE_SETTINGS granted: fully seamless. Enable target component,
+ *    rewrite `enabled_accessibility_services` (swap our old component string for the new one,
+ *    preserving every other app's entries -- Tasker!), disable old component. The service
+ *    reconnects as the other component within a beat, no Settings visit.
+ *  - [switchMode] without it: enable target, disable old (the running service dies here -- the
+ *    UI warns first), then the caller deep-links to system Settings where the ONE visible
+ *    Ramblr entry needs a single enable tap. One guided tap, by design: because the old
+ *    component is already PM-disabled, Settings lists only the target component, so there is
+ *    nothing to pick wrong.
+ */
+object InvocationServiceMode {
+
+    private const val TAG = "PhoneWhisper"
+
+    /** The default "Floating icon" component -- the pre-#211-behaving, no-button-flag service
+     *  every existing install's `enabled_accessibility_services` entry already points at. */
+    fun floatingComponent(context: Context): ComponentName =
+        ComponentName(context, WhisperAccessibilityService::class.java)
+
+    /** The opt-in "System controls" component (button flag declared, ships PM-disabled). */
+    fun systemComponent(context: Context): ComponentName =
+        ComponentName(context, SystemControlsAccessibilityService::class.java)
+
+    /** Both Ramblr service components, full flatten form -- for "is EITHER of ours in this
+     *  Settings.Secure list" checks ([InvocationSecureSettings]). */
+    fun allComponents(context: Context): List<String> = listOf(
+        floatingComponent(context).flattenToString(),
+        systemComponent(context).flattenToString(),
+    )
+
+    /**
+     * Whether [component] is PM-enabled, resolving DEFAULT against the manifest: the floating
+     * component declares no android:enabled (default true), the system one ships
+     * android:enabled="false".
+     */
+    private fun isComponentPmEnabled(context: Context, component: ComponentName, manifestDefault: Boolean): Boolean =
+        when (context.packageManager.getComponentEnabledSetting(component)) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> true
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED -> false
+            else -> manifestDefault // COMPONENT_ENABLED_STATE_DEFAULT
+        }
+
+    /** The current mode, from the one deciding bit (see [resolveInvocationMode]'s kdoc for why
+     *  only the system component's PM state is consulted). */
+    fun currentMode(context: Context): InvocationMode = resolveInvocationMode(
+        systemComponentPmEnabled = isComponentPmEnabled(context, systemComponent(context), manifestDefault = false),
+    )
+
+    /** The component that is (or should be) the live service under the current mode -- what
+     *  deep links, Settings.Secure writes, and the guard rail must all target. */
+    fun activeComponent(context: Context): ComponentName = when (currentMode(context)) {
+        InvocationMode.FLOATING_ICON -> floatingComponent(context)
+        InvocationMode.SYSTEM_CONTROLS -> systemComponent(context)
+    }
+
+    /** How a [switchMode] call completed, so the UI knows what happens next. */
+    enum class SwitchResult {
+        /** Already in the requested mode; nothing changed. */
+        NO_OP,
+
+        /** WRITE_SECURE_SETTINGS path: components flipped AND `enabled_accessibility_services`
+         *  rewritten -- the service reconnects as the new component on its own. */
+        SEAMLESS,
+
+        /** Base-tier path: components flipped, but the OS list still needs the user to flip the
+         *  single visible Ramblr entry on -- caller deep-links to system Settings now. */
+        NEEDS_SETTINGS_TAP,
+    }
+
+    /**
+     * Switches to [target] mode. Ordering is deliberate and identical in both tiers:
+     *
+     *  1. PM-ENABLE the target component first. From this moment the target is resolvable, so
+     *     an `enabled_accessibility_services` entry naming it (step 2, or the user's Settings
+     *     tap) can actually bind. Enabling before touching anything else also means a crash
+     *     mid-switch leaves the app in the both-enabled state, which [resolveInvocationMode]
+     *     deliberately reads as the TARGET mode (system wins) so a retry converges.
+     *  2. Seamless tier only: read-modify-write `enabled_accessibility_services`, swapping our
+     *     old component string for the new one via [componentListReplace] -- other apps'
+     *     entries (Tasker's!) preserved verbatim, both flatten forms matched, deduped if the
+     *     new component was somehow already listed. Raw Secure writes bypass the
+     *     invisible-toggle sync (device-verified, #156 memo §3), so nothing here can trip the
+     *     OS's kill logic. Doing the write BEFORE step 3 means the binding for the new
+     *     component exists by the time the old one disappears -- AMS re-evaluates on both
+     *     changes, so the service hop is one unbind/bind, not an unbound gap.
+     *  3. PM-DISABLE the old component. If it was the live service, the OS unbinds/kills it
+     *     here -- inherent to disabling a running service's component. On the seamless tier the
+     *     new component is already enabled+listed, so AMS immediately binds the replacement; on
+     *     the base tier the service STAYS DOWN until the user's one enable tap in Settings
+     *     (the pre-switch dialog sets exactly this expectation). DONT_KILL_APP so the rest of
+     *     the app process (this Activity!) survives the flip; it does not keep the old service
+     *     component alive, which is fine -- it's the component being retired.
+     *
+     * The seamless write is wrapped so a SecurityException (grant revoked between the
+     * feature-detect and the write) degrades to the base-tier result instead of crashing.
+     */
+    fun switchMode(context: Context, target: InvocationMode): SwitchResult {
+        val current = currentMode(context)
+        if (current == target) return SwitchResult.NO_OP
+
+        val pm = context.packageManager
+        val (oldComponent, newComponent) = when (target) {
+            InvocationMode.SYSTEM_CONTROLS -> floatingComponent(context) to systemComponent(context)
+            InvocationMode.FLOATING_ICON -> systemComponent(context) to floatingComponent(context)
+        }
+
+        // Step 1: target becomes resolvable.
+        pm.setComponentEnabledSetting(
+            newComponent,
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            PackageManager.DONT_KILL_APP,
+        )
+
+        // Step 2 (seamless tier): swap our entry in enabled_accessibility_services.
+        val seamless = swapEnabledServicesEntry(context, oldComponent, newComponent)
+
+        // Step 3: retire the old component (kills it if it was the live service -- inherent).
+        pm.setComponentEnabledSetting(
+            oldComponent,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP,
+        )
+
+        return if (seamless) SwitchResult.SEAMLESS else SwitchResult.NEEDS_SETTINGS_TAP
+    }
+
+    /**
+     * The seamless tier's `enabled_accessibility_services` rewrite. Returns false (base-tier
+     * fallback) when WRITE_SECURE_SETTINGS isn't granted or the write throws.
+     */
+    private fun swapEnabledServicesEntry(context: Context, old: ComponentName, new: ComponentName): Boolean {
+        if (!InvocationSecureSettings.canWrite(context)) return false
+        val key = InvocationSecureSettings.KEY_ENABLED_SERVICES
+        val current = Settings.Secure.getString(context.contentResolver, key)
+        val updated = componentListReplace(current, old.flattenToString(), new.flattenToString())
+        return try {
+            Settings.Secure.putString(context.contentResolver, key, updated)
+        } catch (e: SecurityException) {
+            // Feature-detect said granted but the write still failed (revoked mid-flight, OEM
+            // quirk): the component flip still happens; the caller falls back to the guided tap.
+            Log.e(TAG, "WRITE_SECURE_SETTINGS swap of $key failed despite grant", e)
+            false
+        }
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -358,10 +358,12 @@ class MainActivity : BaseSettingsActivity() {
         // Base tier: the OS offers no app-side re-enable, so the best path IS the service's own
         // Settings page (resolvable since API 30 = minSdk; the action is a string constant --
         // see InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS -- because the SDK
-        // symbol is @hide), where the enable switch is one tap away.
+        // symbol is @hide), where the enable switch is one tap away. Targets whichever component
+        // the current #156 mode says should be active (the banner only fires in system-controls
+        // mode, so in practice this is SystemControlsAccessibilityService).
         val details = Intent(InvocationSecureSettings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS).putExtra(
             Intent.EXTRA_COMPONENT_NAME,
-            android.content.ComponentName(this, WhisperAccessibilityService::class.java).flattenToString(),
+            InvocationServiceMode.activeComponent(this).flattenToString(),
         )
         try {
             startActivity(details)

--- a/app/src/main/kotlin/com/trevornk/ramblr/SystemControlsAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/SystemControlsAccessibilityService.kt
@@ -1,0 +1,25 @@
+package com.trevornk.ramblr
+
+/**
+ * The "System controls" mode component of the #156 dual-component design: byte-for-byte the
+ * same service as [WhisperAccessibilityService] (an empty subclass -- every override, pref,
+ * overlay, and the [WhisperAccessibilityService.instance] static all come from the base class,
+ * which never assumes its own concrete component name), declared as a SECOND `<service>` in the
+ * manifest whose meta-data XML (`accessibility_service_config_system.xml`) adds
+ * `flagRequestAccessibilityButton`.
+ *
+ * Why a whole separate component for one XML flag: the flag is static-only (runtime writes are
+ * ignored for targetSdk > 29) and it is what classifies a service INVISIBLE_TOGGLE vs TOGGLE in
+ * the OS -- i.e. it simultaneously (a) enables the system a11y button / gesture / volume-keys
+ * invocation surfaces and (b) welds the service's enabled state to its shortcut bindings, so
+ * removing the last shortcut in system Settings kills the service (#156). Since one class can't
+ * be both classifications, Ramblr ships both components and PM-enables exactly one
+ * ([InvocationServiceMode]): this one only when the user explicitly opts into system controls
+ * on the Invocation screen, accepting the coupling that the guard-rail banner then watches for.
+ *
+ * The [WhisperAccessibilityService.accessibilityButtonCallback] registration in the base class
+ * is what receives the button/gesture/volume-keys events here; on the base component the same
+ * registration is a harmless no-op because without the flag the OS never routes a button event
+ * to the service.
+ */
+class SystemControlsAccessibilityService : WhisperAccessibilityService()

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -145,9 +145,16 @@ private data class PendingInjection(
     val historyTimestamp: Long,
 )
 
-class WhisperAccessibilityService : AccessibilityService() {
+open class WhisperAccessibilityService : AccessibilityService() {
 
     companion object {
+        /** The connected service instance, whichever of the two #156 components it is: this
+         *  companion is shared by [WhisperAccessibilityService] and its empty subclass
+         *  [SystemControlsAccessibilityService] (JVM statics live on the base class), and
+         *  onServiceConnected/onDestroy assign/clear it for both. Every `instance != null`
+         *  service-health check in the app therefore accepts EITHER component for free -- and
+         *  nothing in this class may compare against its own concrete component name; use
+         *  [InvocationServiceMode.activeComponent] for that. */
         var instance: WhisperAccessibilityService? = null
 
         /** SharedPreferences keys for the persisted overlay drag position (#101). */
@@ -560,11 +567,14 @@ class WhisperAccessibilityService : AccessibilityService() {
     }
 
     /**
-     * OS accessibility-shortcut trigger (#156, plan §2.5): with `flagRequestAccessibilityButton`
-     * declared in the service XML (static-only for targetSdk > 29), the user can enable a
-     * nav-bar button, floating shortcut, or volume-key hold for Ramblr in the system's
-     * Settings > Accessibility > Ramblr shortcut UI -- an invocation surface that keeps working
-     * with the floating ring hidden and adds no new permission.
+     * OS accessibility-shortcut trigger (#156 dual-component design): with
+     * `flagRequestAccessibilityButton` declared in [SystemControlsAccessibilityService]'s config
+     * XML (static-only for targetSdk > 29), the user can enable a nav-bar button, floating
+     * shortcut, or volume-key hold for Ramblr -- an invocation surface that keeps working with
+     * the floating ring hidden and adds no new permission. The registration lives here in the
+     * base class and runs for BOTH components; on the default floating-icon component (no flag
+     * in its XML) it's a harmless no-op -- the OS never routes a button event to a service
+     * without the flag, so the callback simply never fires.
      *
      * Routes through [requestToggleRecording] rather than [onTap] directly so it shares the QS
      * tile's #136 guard: never start a recording while the icon is hidden and invisible -- a

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- accessibilityFlags (H3 audit, declared 2026-08-26): flagRetrieveInteractiveWindows is what
+<!-- Config for WhisperAccessibilityService = the "Floating icon" mode component (#156 dual-
+     component design). Its twin, accessibility_service_config_system.xml, backs
+     SystemControlsAccessibilityService and differs in exactly one way: it adds
+     flagRequestAccessibilityButton. Keep everything else in the two files identical.
+
+     accessibilityFlags (H3 audit, declared 2026-08-26): flagRetrieveInteractiveWindows is what
      makes AccessibilityService.getWindows() return anything at all; without it the framework
      always hands back an empty list, and WhisperAccessibilityService.findInjectionCandidates()'s
      multi-window scan (dialogs, popups, split-screen) was dead code, silently degrading those
@@ -7,17 +12,21 @@
      (effective flags = 0), and flagDefault would newly make Ramblr the default handler for its
      feedbackGeneric type, a behavior change unrelated to the window scan.
 
-     flagRequestAccessibilityButton (#156, plan §2.5): opts Ramblr into the OS-rendered
-     accessibility shortcut (nav-bar button, floating shortcut, or volume-key hold; the user
-     picks in Settings > Accessibility > Ramblr > shortcut). MUST be static XML: with
-     targetSdk > 29 the framework ignores runtime attempts to set this flag
-     (AccessibilityServiceInfo.java:508-511, AOSP). Declaring it only makes the OS offer the
-     shortcut UI; whether the button appears is entirely the user's system-level choice, so this
-     changes nothing for users who never enable it. -->
+     flagRequestAccessibilityButton is deliberately ABSENT here (#156 rework of #211/#220): the
+     flag is not just "offer the a11y button" — it also reclassifies the service as
+     INVISIBLE_TOGGLE (AccessibilityUtil.getAccessibilityServiceFragmentType reads ONLY
+     targetSdk + this flag), which makes the OS weld the service's enabled state to its shortcut
+     bindings: turning off the last "Ramblr shortcut" switch in system Settings silently turns
+     off the whole service. Without the flag this component is an ordinary TOGGLE service —
+     independent on/off switch in Settings, no system button/gesture, no trap — i.e. the exact
+     pre-#211 behavior. Existing installs' enabled_accessibility_services entries already point
+     at this component, so on update they get ring-only behavior back with zero migration.
+     Users who want the system button/gesture/volume-keys opt into the
+     SystemControlsAccessibilityService component via the in-app Invocation screen instead. -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeViewFocused"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagRetrieveInteractiveWindows|flagRequestAccessibilityButton"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"
     android:notificationTimeout="100"
     android:description="@string/accessibility_description" />

--- a/app/src/main/res/xml/accessibility_service_config_system.xml
+++ b/app/src/main/res/xml/accessibility_service_config_system.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Config for SystemControlsAccessibilityService = the "System controls" mode component (#156
+     dual-component design). Identical to accessibility_service_config.xml (which backs the
+     default "Floating icon" component) EXCEPT for flagRequestAccessibilityButton — keep the
+     rest of the two files in lockstep.
+
+     flagRequestAccessibilityButton (#156, originally added by #211): opts this component into
+     the OS-rendered accessibility shortcut surfaces (nav-bar button / floating button, the
+     2-finger a11y gesture, and the hold-both-volume-keys shortcut — all of which funnel into
+     the same AccessibilityButtonController callback the base class registers). MUST be static
+     XML: with targetSdk > 29 the framework ignores runtime attempts to set this flag
+     (AccessibilityServiceInfo.java:508-511, AOSP).
+
+     The flag also reclassifies this component as INVISIBLE_TOGGLE (targetSdk > Q + this flag is
+     the whole classification), which is why it lives in its own component: the OS couples an
+     INVISIBLE_TOGGLE service's enabled state to its shortcut bindings (last shortcut off = whole
+     service off). That trade-off is opt-in — the component ships android:enabled="false" in the
+     manifest and is only enabled when the user picks "System controls" on the Invocation screen.
+     The #220 guard-rail banner covers the kill-by-shortcut-switch trap while this component is
+     the active one. -->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeViewFocused"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows|flagRequestAccessibilityButton"
+    android:canRetrieveWindowContent="true"
+    android:notificationTimeout="100"
+    android:description="@string/accessibility_description" />

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -19,6 +19,8 @@ class InvocationMethodsTest {
 
     private val ramblr = "com.trevornk.ramblr/com.trevornk.ramblr.WhisperAccessibilityService"
     private val ramblrShort = "com.trevornk.ramblr/.WhisperAccessibilityService"
+    private val ramblrSystem = "com.trevornk.ramblr/com.trevornk.ramblr.SystemControlsAccessibilityService"
+    private val ramblrSystemShort = "com.trevornk.ramblr/.SystemControlsAccessibilityService"
     private val tasker = "net.dinglisch.android.taskerm/net.dinglisch.android.taskerm.MyAccessibilityService"
     private val other = "com.example.other/.OtherService"
 
@@ -120,10 +122,117 @@ class InvocationMethodsTest {
         assertEquals(original, componentListRemove(componentListAdd(original, ramblr), ramblr))
     }
 
+    // --- componentListReplace (#156 dual-component mode switch) -----------------------------
+
+    @Test fun `replace swaps old for new in place, preserving other apps' entries verbatim`() {
+        // The exact seamless-switch scenario from the memo baseline: Tasker + Ramblr enabled.
+        assertEquals(
+            "$tasker:$ramblrSystem",
+            componentListReplace("$tasker:$ramblr", ramblr, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace works in the other direction too`() {
+        assertEquals(
+            "$tasker:$ramblr",
+            componentListReplace("$tasker:$ramblrSystem", ramblrSystem, ramblr),
+        )
+    }
+
+    @Test fun `replace keeps position - old entry mid-list stays mid-list`() {
+        assertEquals(
+            "$tasker:$ramblrSystem:$other",
+            componentListReplace("$tasker:$ramblr:$other", ramblr, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace matches the old component in short flatten form`() {
+        assertEquals(
+            "$tasker:$ramblrSystem",
+            componentListReplace("$tasker:$ramblrShort", ramblr, ramblrSystem),
+        )
+        assertEquals(
+            "$tasker:$ramblrSystem",
+            componentListReplace("$tasker:$ramblr", ramblrShort, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace with old absent appends new last and keeps everything else`() {
+        // The old component had already been disabled out from under us -- the switch must
+        // still land the user in a working state.
+        assertEquals(
+            "$tasker:$other:$ramblrSystem",
+            componentListReplace("$tasker:$other", ramblr, ramblrSystem),
+        )
+        assertEquals(ramblrSystem, componentListReplace(null, ramblr, ramblrSystem))
+        assertEquals(ramblrSystem, componentListReplace("", ramblr, ramblrSystem))
+    }
+
+    @Test fun `replace with both present dedupes to a single new entry`() {
+        // A crashed previous switch can leave both components listed; the retry must converge
+        // to exactly one.
+        assertEquals(
+            "$tasker:$ramblrSystem",
+            componentListReplace("$tasker:$ramblr:$ramblrSystem", ramblr, ramblrSystem),
+        )
+        // ...matching the new component's short form too.
+        assertEquals(
+            "$tasker:$ramblrSystemShort",
+            componentListReplace("$tasker:$ramblrSystemShort:$ramblr", ramblr, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace drops duplicate old entries in mixed flatten forms`() {
+        assertEquals(
+            "$ramblrSystem:$tasker",
+            componentListReplace("$ramblr:$tasker:$ramblrShort", ramblr, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace when already switched is idempotent`() {
+        assertEquals(
+            "$tasker:$ramblrSystem",
+            componentListReplace("$tasker:$ramblrSystem", ramblr, ramblrSystem),
+        )
+    }
+
+    @Test fun `replace round-trips back to the original list`() {
+        val original = "$tasker:$ramblr:$other"
+        assertEquals(
+            original,
+            componentListReplace(componentListReplace(original, ramblr, ramblrSystem), ramblrSystem, ramblr),
+        )
+    }
+
+    // --- resolveInvocationMode --------------------------------------------------------------
+
+    @Test fun `system component PM-enabled resolves to system controls mode`() {
+        assertEquals(InvocationMode.SYSTEM_CONTROLS, resolveInvocationMode(systemComponentPmEnabled = true))
+    }
+
+    @Test fun `system component PM-disabled resolves to floating icon mode`() {
+        // The floating component's own PM state is deliberately not an input: mid-switch both
+        // components can briefly be enabled, and "system on" must win for retries to converge.
+        assertEquals(InvocationMode.FLOATING_ICON, resolveInvocationMode(systemComponentPmEnabled = false))
+    }
+
     // --- shouldShowServiceKilledBanner ------------------------------------------------------
 
-    @Test fun `banner fires on the exact invisible-toggle kill state`() {
+    @Test fun `banner fires on the exact invisible-toggle kill state in system controls mode`() {
         assertTrue(shouldShowServiceKilledBanner(
+            systemControlsModeActive = true,
+            serviceWasEnabled = true,
+            serviceEnabledNow = false,
+            anyShortcutBound = false,
+            bannerDismissed = false,
+        ))
+    }
+
+    @Test fun `banner never fires in floating icon mode - that component has no trap`() {
+        // The floating component is TOGGLE-classified: a disabled service there is a user
+        // choice made on an independent Settings switch, not the invisible-toggle kill.
+        assertFalse(shouldShowServiceKilledBanner(
+            systemControlsModeActive = false,
             serviceWasEnabled = true,
             serviceEnabledNow = false,
             anyShortcutBound = false,
@@ -133,6 +242,7 @@ class InvocationMethodsTest {
 
     @Test fun `fresh install that never enabled the service shows nothing`() {
         assertFalse(shouldShowServiceKilledBanner(
+            systemControlsModeActive = true,
             serviceWasEnabled = false,
             serviceEnabledNow = false,
             anyShortcutBound = false,
@@ -142,6 +252,7 @@ class InvocationMethodsTest {
 
     @Test fun `service currently enabled shows nothing`() {
         assertFalse(shouldShowServiceKilledBanner(
+            systemControlsModeActive = true,
             serviceWasEnabled = true,
             serviceEnabledNow = true,
             anyShortcutBound = false,
@@ -154,6 +265,7 @@ class InvocationMethodsTest {
         // service is off for some other reason (and the bound shortcut can self-heal it: the
         // volume-keys path re-enables a button-flag service on use). Don't misdiagnose.
         assertFalse(shouldShowServiceKilledBanner(
+            systemControlsModeActive = true,
             serviceWasEnabled = true,
             serviceEnabledNow = false,
             anyShortcutBound = true,
@@ -163,6 +275,7 @@ class InvocationMethodsTest {
 
     @Test fun `dismissed banner stays quiet until re-armed`() {
         assertFalse(shouldShowServiceKilledBanner(
+            systemControlsModeActive = true,
             serviceWasEnabled = true,
             serviceEnabledNow = false,
             anyShortcutBound = false,
@@ -172,17 +285,52 @@ class InvocationMethodsTest {
 
     // --- subtitle formatters ----------------------------------------------------------------
 
-    @Test fun `main row subtitle lists active methods`() {
+    @Test fun `main row subtitle leads with the mode and lists active methods`() {
         assertEquals(
-            "How to start dictation — Floating ring, Volume keys on",
-            invocationMainRowSubtitleText(ringVisible = true, systemButtonBound = false, volumeKeysBound = true),
+            "System controls mode — ring on, volume keys on",
+            invocationMainRowSubtitleText(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                ringVisible = true, systemButtonBound = false, volumeKeysBound = true,
+            ),
+        )
+    }
+
+    @Test fun `main row subtitle in floating mode ignores stale system bindings`() {
+        // Leftover accessibility_button_targets entries from a previous system-mode stint must
+        // not be reported as active methods while the floating component is the live one.
+        assertEquals(
+            "Floating icon mode — ring on",
+            invocationMainRowSubtitleText(
+                mode = InvocationMode.FLOATING_ICON,
+                ringVisible = true, systemButtonBound = true, volumeKeysBound = true,
+            ),
         )
     }
 
     @Test fun `main row subtitle with nothing active says so`() {
         assertEquals(
-            "How to start dictation — no method currently active",
-            invocationMainRowSubtitleText(ringVisible = false, systemButtonBound = false, volumeKeysBound = false),
+            "Floating icon mode — no method currently active",
+            invocationMainRowSubtitleText(
+                mode = InvocationMode.FLOATING_ICON,
+                ringVisible = false, systemButtonBound = false, volumeKeysBound = false,
+            ),
+        )
+    }
+
+    @Test fun `floating mode card subtitle reflects active state`() {
+        assertTrue(invocationFloatingModeSubtitleText(active = true).startsWith("Active"))
+        assertFalse(invocationFloatingModeSubtitleText(active = false).startsWith("Active"))
+    }
+
+    @Test fun `system mode card subtitle names the switch cost per tier when inactive`() {
+        assertTrue(invocationSystemModeSubtitleText(active = true, directControl = false).startsWith("Active"))
+        assertTrue(
+            invocationSystemModeSubtitleText(active = false, directControl = true)
+                .contains("switches instantly"),
+        )
+        assertTrue(
+            invocationSystemModeSubtitleText(active = false, directControl = false)
+                .contains("one enable tap in system Settings"),
         )
     }
 
@@ -194,23 +342,38 @@ class InvocationMethodsTest {
     @Test fun `system button subtitle distinguishes deep-link and direct-control tiers`() {
         assertEquals(
             "On — the system button/gesture starts dictation · tap to open system settings",
-            invocationSystemButtonSubtitleText(bound = true, directControl = false),
+            invocationSystemButtonSubtitleText(modeActive = true, bound = true, directControl = false),
         )
         assertEquals(
             "Off · tap to switch in-app",
-            invocationSystemButtonSubtitleText(bound = false, directControl = true),
+            invocationSystemButtonSubtitleText(modeActive = true, bound = false, directControl = true),
+        )
+    }
+
+    @Test fun `system button subtitle in floating mode says the mode is required`() {
+        assertEquals(
+            "Requires System controls mode",
+            invocationSystemButtonSubtitleText(modeActive = false, bound = true, directControl = true),
         )
     }
 
     @Test fun `volume keys subtitle distinguishes deep-link and direct-control tiers`() {
         assertEquals(
             "On — hold both volume keys to start dictation · tap to switch in-app",
-            invocationVolumeKeysSubtitleText(bound = true, directControl = true),
+            invocationVolumeKeysSubtitleText(modeActive = true, bound = true, directControl = true),
         )
         assertEquals(
             "Off · tap to open system settings",
-            invocationVolumeKeysSubtitleText(bound = false, directControl = false),
+            invocationVolumeKeysSubtitleText(modeActive = true, bound = false, directControl = false),
         )
+    }
+
+    @Test fun `volume keys subtitle in floating mode warns about the toggle semantics`() {
+        // In floating-icon (TOGGLE-class) mode the OS volume-keys shortcut toggles the SERVICE
+        // on/off rather than invoking dictation -- the copy must say so, not just grey out.
+        val text = invocationVolumeKeysSubtitleText(modeActive = false, bound = false, directControl = true)
+        assertTrue(text.contains("Requires System controls mode"))
+        assertTrue(text.contains("turn Ramblr itself off and on"))
     }
 
     @Test fun `qs tile subtitle offers one-tap add only where the API exists`() {


### PR DESCRIPTION
## Summary

Implements the approved **dual-service-component design** for #156 (rework of #211's flag and #220's chooser/guard-rail): ship the accessibility service as **two manifest components** — one without `flagRequestAccessibilityButton`, one with it — and PM-enable exactly one, because the flag is static-XML-only (ignored at runtime for targetSdk > 29) yet is the sole input (besides targetSdk) to the OS's TOGGLE vs INVISIBLE_TOGGLE classification. One class cannot be both, so each "world" gets its own component.

Refs #156

## The mechanism

| | Floating icon (default) | System controls (opt-in) |
|---|---|---|
| Component | `WhisperAccessibilityService` (name + declaration unchanged) | `SystemControlsAccessibilityService : WhisperAccessibilityService()` (empty subclass, own `<service>` + own meta-data XML, `android:enabled="false"`) |
| Button flag | **removed** | declared |
| OS class | TOGGLE | INVISIBLE_TOGGLE |
| Settings switch | independent on/off, no trap | welded to shortcut bindings ("last shortcut off kills the service") |
| Invocation | floating ring (+ QS tile) | system a11y button / gesture / volume-keys hold (+ optional ring, + QS tile) |
| Guard-rail banner | never fires | watches for the shortcut-sync kill |

Mode = "is the system component PM-enabled" (`InvocationServiceMode`), flipped with `PackageManager.setComponentEnabledSetting`. The switch sequence is enable-target → (WSS tier) swap our entry in `enabled_accessibility_services` → disable-old, so a crash mid-switch leaves both enabled, which mode resolution deliberately reads as the target mode so retries converge — and on the seamless tier the new binding exists before the old component disappears, making the hop one unbind/bind.

`android:label` decision: kept as plain "Ramblr" for both components. Only one is ever PM-enabled, so system Settings never lists both, and the plain name reads cleanest in the shortcut UIs (a11y-button chooser, volume-keys first-use dialog). Documented in the manifest comment.

## Existing-user impact (zero migration)

Existing installs' `enabled_accessibility_services` entries already point at `WhisperAccessibilityService`. On update, that component simply no longer declares the flag → **ring-only behavior is restored for everyone**: the system a11y button/floating button disappears, the Settings switch becomes an ordinary independent toggle, and the invisible-toggle trap is gone. Nothing to migrate, nothing to re-enable. Anyone who wants the system button/gesture/volume-keys opts in via Settings → Invocation → System controls.

Stale OS bindings from the pre-rework component (e.g. a leftover `accessibility_button_targets` entry) are matched by the either-component readers and swept by the WSS removal path; while in floating mode they are inert (no flag → OS never routes button events).

## Switching UX: WSS vs base tier

- **WRITE_SECURE_SETTINGS granted** (adb power-up, feature-detected per use): fully seamless. Components flip and `enabled_accessibility_services` is rewritten in the same motion via the tested `componentListReplace` (other apps' entries — Tasker! — preserved verbatim, both flatten forms matched, both-present deduped, old-absent appends). Raw Secure writes bypass the invisible-toggle sync (device-verified in the #156 memo §3), so nothing can trip the kill logic. Dictation keeps working through the hop.
- **Base tier**: components flip (the running service dies when its component is disabled — inherent; the confirmation dialog warns about exactly this), then the app deep-links to system Settings where **exactly one** Ramblr entry is visible (the old component is already PM-disabled) and one enable tap finishes the switch. A `SecurityException` on the WSS write degrades to this path instead of crashing.

## Invocation screen rework

- Top: two exclusive mode cards with tier-aware confirmation dialogs.
- Floating ring toggle works in **both** modes, but entering system mode defaults the ring to hidden (no-double-icon requirement); it stays one tap away. Leaving system mode restores it.
- System button/gesture and volume-keys rows are hard-gated to system mode. Volume keys especially: on the TOGGLE-class floating component the OS volume-keys shortcut **toggles the service on/off** (AMS.java 4296–4306) rather than invoking dictation, so offering it there would be a trap — the row copy says so. On the flag-carrying component it fires the a11y-button callback → dictation, and can only ever enable the service (AMS 4295–4331).
- QS tile row unchanged from #220.
- Guard-rail banner (#220) now fires **only in system-controls mode** and its deep-link targets the active component.

## Tests

`./gradlew testGithubDebugUnitTest`: **147 suites / 1,513 tests, 0 failures** (baseline on main 7830a13: 147 suites / 1,496 — +17 new cases). New coverage: `componentListReplace` invariants (in-place swap preserving Tasker entries, both flatten forms, old-absent, both-present dedupe, round-trip), `resolveInvocationMode`, mode-gated `shouldShowServiceKilledBanner` (including "never fires in floating mode"), and the new mode-chooser formatters. #220's existing cases were updated to the two-component model, not deleted.

## On-device verification checklist (post-merge)

- [ ] Update over a current install: system button gone, ring back, service still enabled, no Settings visit needed
- [ ] Mode switch floating → system and back, **with** WSS granted (seamless, dictation keeps working, `enabled_accessibility_services` swap correct)
- [ ] Mode switch both directions **without** WSS (service dies as warned; exactly one Ramblr entry in Settings; one tap re-enables)
- [ ] Volume-keys hold invokes dictation in system mode (first-use system dialog: "Turn on")
- [ ] No double icon: entering system mode hides the ring by default; ring re-enableable from the toggle
- [ ] Tasker's `enabled_accessibility_services` entry byte-identical across every switch
- [ ] Guard-rail banner: fires after killing the last shortcut in system mode; never fires in floating mode; deep-link lands on the right component's page
- [ ] Only one "Ramblr" entry visible in Settings → Accessibility in each mode
