### PR TITLE
Fix seamless mode-switch race: bind shortcut before enabling system component

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -279,3 +279,28 @@ fun invocationAdvancedTierSubtitleText(granted: Boolean): String =
 /** The exact adb command the advanced tier needs, shown in its dialog for copy/paste. */
 fun wssAdbCommand(packageName: String): String =
     "adb shell pm grant $packageName android.permission.WRITE_SECURE_SETTINGS"
+
+/**
+ * The seamless (WRITE_SECURE_SETTINGS) tier's Secure-settings writes for a mode switch, in
+ * mandatory order. Pure so the ordering invariant is unit-testable; executed by
+ * [InvocationServiceMode.switchMode].
+ *
+ * ENTERING system mode the button target must be bound BEFORE the enabled-services swap: the
+ * swap makes the OS re-run its INVISIBLE_TOGGLE shortcut<->service sync, which strips an
+ * enabled entry that has no shortcut bound (the #156 trap in reverse). LEAVING system mode the
+ * swap must come FIRST (the floating component is TOGGLE-classified and immune), then the
+ * shortcut keys are swept clean -- removing them first would fire the forward trap while the
+ * system component was still the enabled one.
+ */
+enum class SeamlessWrite { BIND_BUTTON_TARGET, SWAP_ENABLED_SERVICES, UNBIND_ALL_SHORTCUTS }
+
+fun seamlessSwitchWrites(target: InvocationMode): List<SeamlessWrite> = when (target) {
+    InvocationMode.SYSTEM_CONTROLS -> listOf(
+        SeamlessWrite.BIND_BUTTON_TARGET,
+        SeamlessWrite.SWAP_ENABLED_SERVICES,
+    )
+    InvocationMode.FLOATING_ICON -> listOf(
+        SeamlessWrite.SWAP_ENABLED_SERVICES,
+        SeamlessWrite.UNBIND_ALL_SHORTCUTS,
+    )
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
@@ -135,8 +135,39 @@ object InvocationServiceMode {
             PackageManager.DONT_KILL_APP,
         )
 
-        // Step 2 (seamless tier): swap our entry in enabled_accessibility_services.
-        val seamless = swapEnabledServicesEntry(context, oldComponent, newComponent)
+        // Step 2 (seamless tier): the Secure-settings writes, in the ORDER the invisible-toggle
+        // sync demands (device-verified 2026-08-26 on Pixel 10a; ordering invariant encoded and
+        // unit-tested as [seamlessSwitchWrites]):
+        //  - ENTERING system mode: bind the a11y-button target BEFORE the enabled-services swap.
+        //    The moment the swap write lands, the OS re-evaluates the INVISIBLE_TOGGLE coupling;
+        //    if no shortcut is bound yet it strips our freshly-added entry right back out (the
+        //    kill trap running in reverse) and the switch silently fails. Pre-binding the target
+        //    makes the enable stick. A stale binding left by a failed later step is harmless.
+        //  - LEAVING system mode: swap FIRST (the floating component is TOGGLE-classified, so
+        //    the sync ignores it), THEN sweep Ramblr out of both shortcut keys. Removing the
+        //    bindings while the system component was still the enabled one would trip the
+        //    forward trap (last shortcut removed -> service stripped) before our swap landed.
+        val seamless = seamlessSwitchWrites(target).all { step ->
+            when (step) {
+                SeamlessWrite.BIND_BUTTON_TARGET ->
+                    InvocationSecureSettings.setBinding(
+                        context, InvocationSecureSettings.KEY_BUTTON_TARGETS, bound = true,
+                    )
+                SeamlessWrite.SWAP_ENABLED_SERVICES ->
+                    swapEnabledServicesEntry(context, oldComponent, newComponent)
+                SeamlessWrite.UNBIND_ALL_SHORTCUTS -> {
+                    // Best-effort cleanup; failure here must not report the whole switch as
+                    // needing a Settings tap (the service is already correctly enabled).
+                    InvocationSecureSettings.setBinding(
+                        context, InvocationSecureSettings.KEY_BUTTON_TARGETS, bound = false,
+                    )
+                    InvocationSecureSettings.setBinding(
+                        context, InvocationSecureSettings.KEY_SHORTCUT_TARGET_SERVICE, bound = false,
+                    )
+                    true
+                }
+            }
+        }
 
         // Step 3: retire the old component (kills it if it was the live service -- inherent).
         pm.setComponentEnabledSetting(

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -392,4 +392,40 @@ class InvocationMethodsTest {
             wssAdbCommand("com.trevornk.ramblr"),
         )
     }
+
+    // --- seamlessSwitchWrites ordering invariant (#156 race fix, device-verified) ---
+
+    @Test
+    fun seamlessWrites_enteringSystemMode_bindsButtonTargetBeforeSwap() {
+        val writes = seamlessSwitchWrites(InvocationMode.SYSTEM_CONTROLS)
+        assertEquals(
+            listOf(SeamlessWrite.BIND_BUTTON_TARGET, SeamlessWrite.SWAP_ENABLED_SERVICES),
+            writes,
+        )
+    }
+
+    @Test
+    fun seamlessWrites_leavingSystemMode_swapsBeforeUnbindingShortcuts() {
+        val writes = seamlessSwitchWrites(InvocationMode.FLOATING_ICON)
+        assertEquals(
+            listOf(SeamlessWrite.SWAP_ENABLED_SERVICES, SeamlessWrite.UNBIND_ALL_SHORTCUTS),
+            writes,
+        )
+    }
+
+    @Test
+    fun seamlessWrites_enteringSystemMode_neverUnbindsShortcuts() {
+        assertFalse(
+            seamlessSwitchWrites(InvocationMode.SYSTEM_CONTROLS)
+                .contains(SeamlessWrite.UNBIND_ALL_SHORTCUTS),
+        )
+    }
+
+    @Test
+    fun seamlessWrites_leavingSystemMode_neverBindsButtonTarget() {
+        assertFalse(
+            seamlessSwitchWrites(InvocationMode.FLOATING_ICON)
+                .contains(SeamlessWrite.BIND_BUTTON_TARGET),
+        )
+    }
 }


### PR DESCRIPTION
Refs #156. The dual-component rework's seamless (WSS) switch into System controls mode raced the OS invisible-toggle sync: writing our component into `enabled_accessibility_services` with no shortcut bound triggers the same coupling that causes the #156 trap — the OS strips the entry back out immediately. Found during on-device verification (Pixel 10a): the UI reported system mode active while `enabled_accessibility_services` no longer contained Ramblr and the service never bound.

Fix: the seamless tier's Secure writes now follow a mandatory, unit-tested order (`seamlessSwitchWrites`): entering system mode binds `accessibility_button_targets` **before** the enabled-services swap (a bound shortcut makes the enable stick — device-verified); leaving system mode swaps first (floating component is TOGGLE-classified, immune to the sync) and then sweeps Ramblr from both shortcut keys, so no stale system button lingers in ring mode.

Bonus: entering system mode now lands with the a11y button already bound — the user gets a working system button immediately instead of an enabled-but-unbound service.

Tests: 1,517 (baseline 1,513 + 4 ordering-invariant), 0 failures.