### PR TITLE
Settle-verify-repair loop: make seamless mode switches survive the AMS re-persist race

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationServiceMode.kt
@@ -176,7 +176,69 @@ object InvocationServiceMode {
             PackageManager.DONT_KILL_APP,
         )
 
-        return if (seamless) SwitchResult.SEAMLESS else SwitchResult.NEEDS_SETTINGS_TAP
+        return if (seamless && verifySettled(context, target, oldComponent, newComponent)) {
+            SwitchResult.SEAMLESS
+        } else if (seamless) {
+            // Writes landed but the settle-verify loop couldn't hold them (unexpected OEM
+            // behavior): be honest with the caller -- the user gets the guided-tap flow.
+            SwitchResult.NEEDS_SETTINGS_TAP
+        } else {
+            SwitchResult.NEEDS_SETTINGS_TAP
+        }
+    }
+
+    /**
+     * Post-switch settle-verify-repair loop, and the reason the seamless tier actually works:
+     * the PM component flips make AccessibilityManagerService re-persist its IN-MEMORY user
+     * state asynchronously, and that re-persist can land AFTER our Secure writes, clobbering
+     * them (observed on Pixel 10a 2026-08-26: correct write order, entry gone ~1s later; a
+     * manual `settings put` with no concurrent PM change persists fine -- the clobber is
+     * specifically the async AMS re-persist racing our writes).
+     *
+     * So: poll the authoritative settings and REWRITE what the re-persist undid, until the
+     * state holds for one full interval or the budget (~2.4s) runs out. Runs on the calling
+     * (UI) thread by design -- a mode switch is rare, user-initiated, and the worst case is
+     * well under the ANR threshold; blocking keeps the SwitchResult contract synchronous and
+     * truthful.
+     */
+    private fun verifySettled(
+        context: Context,
+        target: InvocationMode,
+        old: ComponentName,
+        new: ComponentName,
+    ): Boolean {
+        var stableReads = 0
+        repeat(12) {
+            android.os.SystemClock.sleep(200)
+            val services = Settings.Secure.getString(
+                context.contentResolver, InvocationSecureSettings.KEY_ENABLED_SERVICES,
+            )
+            val serviceOk = componentListContains(services, new.flattenToString())
+            val bindingOk = when (target) {
+                // Entering system mode the button target must also have survived the re-persist.
+                InvocationMode.SYSTEM_CONTROLS -> InvocationSecureSettings.isButtonTargetBound(context)
+                InvocationMode.FLOATING_ICON -> true
+            }
+            if (serviceOk && bindingOk) {
+                // Require two consecutive good reads so we don't declare victory in the gap
+                // before a late re-persist lands.
+                stableReads++
+                if (stableReads >= 2) return true
+            } else {
+                stableReads = 0
+                Log.w(TAG, "AMS re-persist clobbered switch writes (serviceOk=$serviceOk bindingOk=$bindingOk); repairing")
+                if (!bindingOk) {
+                    InvocationSecureSettings.setBinding(
+                        context, InvocationSecureSettings.KEY_BUTTON_TARGETS, bound = true,
+                    )
+                }
+                if (!serviceOk) swapEnabledServicesEntry(context, old, new)
+            }
+        }
+        val services = Settings.Secure.getString(
+            context.contentResolver, InvocationSecureSettings.KEY_ENABLED_SERVICES,
+        )
+        return componentListContains(services, new.flattenToString())
     }
 
     /**


### PR DESCRIPTION
Refs #156. Second half of the mode-switch race fix (first half: #223).

**Why #223 alone wasn't enough:** the PM `setComponentEnabledSetting` calls make AccessibilityManagerService re-persist its **in-memory** user state asynchronously. That re-persist can land after our correctly-ordered Secure writes and clobber them — observed on the Pixel 10a as the enabled-services entry vanishing ~1s after a successful write. A bare `settings put` with no concurrent PM flip persists fine, which is why the pre-rework #220 binding writes never hit this.

**Fix:** `verifySettled()` — after the switch writes, poll `enabled_accessibility_services` (and the button target when entering system mode) every 200ms for up to 2.4s, rewriting anything the re-persist undid, requiring two consecutive stable reads before returning SEAMLESS. If the state won't hold, the caller gets NEEDS_SETTINGS_TAP and the existing guided-tap flow — honest degradation, never a silent failure. Runs on the calling thread by design: rare user-initiated action, bounded well under ANR, keeps the SwitchResult contract synchronous.

**On-device evidence (Pixel 10a, driven through the real UI):**
- floating→system: system component in enabled-services, `accessibility_button_targets` bound, service bound with `requestA11yBtn=true`
- system→floating: floating component restored (`requestA11yBtn=false`), both shortcut keys swept, ring back on
- Tasker's accessibility entry preserved verbatim through every write

Tests: 1,517, 0 failures (suite green in this worktree; no new pure-logic surface — the loop is deliberately thin plumbing around the already-tested helpers).