### PR TITLE
#143 Phase 2: harden runtime session ownership

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
@@ -116,9 +116,10 @@ interface RuntimeListener {
  * [context] is whatever Context the host is (the service passes itself); the runtime only uses
  * Context-level APIs (prefs, cacheDir, system services, Toast), never service-only ones.
  */
-class DictationRuntime(
+class DictationRuntime internal constructor(
     private val context: Context,
     private val listener: RuntimeListener,
+    private val leaseRegistry: DictationSessionLeaseRegistry = ProcessDictationSessionLeaseRegistry,
     /** Test seam: lets host-side unit tests substitute a fake engine at the capture boundary.
      *  The default is exactly the pre-extraction construction. */
     private val engineFactory: (File, RecordingStateMachine) -> RecordingEngine =
@@ -136,6 +137,19 @@ class DictationRuntime(
     private val stateMachine = RecordingStateMachine()
 
     @Volatile private var recordingEngine: RecordingEngine? = null
+    @Volatile private var sessionLease: DictationSessionLease? = null
+    @Volatile private var shuttingDown = false
+    @Volatile private var shutdownLeaseAwaitingReader: DictationSessionLease? = null
+
+    /** Releases only the exact session captured by the caller; stale callbacks are harmless. */
+    private fun releaseSessionLease(lease: DictationSessionLease?) {
+        if (lease == null) return
+        synchronized(this) {
+            if (sessionLease !== lease) return
+            sessionLease = null
+        }
+        leaseRegistry.release(lease)
+    }
 
     /** Non-null only while a recording with silence-based auto-stop (#108, mode 1) active is in
      *  progress -- see [startRecording]/[onRecordingFinished]. Zero-cost when the feature is off
@@ -353,28 +367,36 @@ class DictationRuntime(
     }
 
     internal fun startRecording() {
-        if (context.checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
-            != android.content.pm.PackageManager.PERMISSION_GRANTED) {
-            toast("Grant audio permission in Ramblr app"); return
+        val lease = leaseRegistry.tryAcquire()
+        if (lease == null) {
+            toast("Ramblr is already dictating from another input surface")
+            return
         }
+        sessionLease = lease
+        var recordingStarted = false
+        try {
+            if (context.checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+                != android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                toast("Grant audio permission in Ramblr app"); return
+            }
 
-        warmUpLocalCleanupModelIfNeeded()
-        warmUpTranscribersIfTrimmed()
-        warmUpCloudConnectionsIfNeeded()
+            warmUpLocalCleanupModelIfNeeded()
+            warmUpTranscribersIfTrimmed()
+            warmUpCloudConnectionsIfNeeded()
 
         // Host-owned pre-recording teardown: resolve a still-pending preview (#40), end the
         // previous streaming session, flush the pending handoff, and reset the live-preview
         // bubble throttle -- verbatim the pre-extraction startRecording prologue, now behind the
         // listener seam because every one of those pieces is host delivery state.
-        listener.onRecordingStartRequested()
-        val streamingActive = streamingTranscriberSlot.get() != null
-        if (streamingActive) streamingTranscriberSlot.use { it.beginSession() }
+            listener.onRecordingStartRequested()
+            val streamingActive = streamingTranscriberSlot.get() != null
+            if (streamingActive) streamingTranscriberSlot.use { it.beginSession() }
 
         // Silence-based auto-stop (#108, mode 1): additive and opt-in -- a session (and the
         // native Vad it owns) is only ever created when the toggle is on AND the model is
         // actually installed. Either condition being false means zero VAD instantiation and
         // byte-for-byte identical recording behavior to before this feature existed.
-        val autoStopSession = if (SilenceAutoStopToggle.isEnabled(context)) {
+            val autoStopSession = if (SilenceAutoStopToggle.isEnabled(context)) {
             ModelDownloader.vadModelFile(context, SILERO_VAD_MODEL)?.let { modelFile ->
                 try {
                     SilenceAutoStopSession(
@@ -388,14 +410,14 @@ class DictationRuntime(
                 }
             }
         } else null
-        silenceAutoStopSession = autoStopSession
+            silenceAutoStopSession = autoStopSession
 
         // Compressed-upload AAC encoding (#109): additive and opt-in -- a session (and the
         // MediaCodec/MediaMuxer it owns) is only ever created when CompressedUploadToggle is on.
         // Unlike #108's VAD, no model download or extra precondition is needed: AAC-LC is a
         // built-in platform codec. Toggle off means zero AacEncoderSession instantiation and
         // byte-for-byte identical recording behavior to before this feature existed.
-        val aacSession = if (CompressedUploadToggle.isEnabled(context)) {
+            val aacSession = if (CompressedUploadToggle.isEnabled(context)) {
             try {
                 AacEncoderSession(context.cacheDir)
             } catch (e: Exception) {
@@ -403,9 +425,9 @@ class DictationRuntime(
                 null
             }
         } else null
-        aacEncoderSession = aacSession
+            aacEncoderSession = aacSession
 
-        val onChunk: (ByteArray, Int) -> Unit = when {
+            val onChunk: (ByteArray, Int) -> Unit = when {
             streamingActive && autoStopSession != null && aacSession != null -> { buf, len ->
                 handleStreamingChunk(buf, len)
                 autoStopSession.onChunk(buf, len)
@@ -429,8 +451,8 @@ class DictationRuntime(
             else -> { _, _ -> }
         }
 
-        val engine = engineFactory(context.cacheDir, stateMachine)
-        val started = engine.start(
+            val engine = engineFactory(context.cacheDir, stateMachine)
+            val started = engine.start(
             onFinished = { result ->
                 // H1 (#193): release the per-recording LOCALS captured by this closure, never the
                 // fields. A reader stalled in AudioRecord.read() can outlive a rapid
@@ -445,11 +467,11 @@ class DictationRuntime(
                 aacSession?.release()
                 if (aacEncoderSession === aacSession) aacEncoderSession = null
                 val finalResult = if (compressedFile != null) result.copy(compressedFile = compressedFile) else result
-                onRecordingFinished(engine, finalResult)
+                onRecordingFinished(engine, finalResult, lease)
             },
             onChunk = onChunk
         )
-        if (!started) {
+            if (!started) {
             // End the streaming session so a failed recorder start doesn't leak the OnlineStream
             // opened by beginSession() above until the next recording (L11).
             if (streamingActive) listener.onRecordingStartFailed()
@@ -458,23 +480,28 @@ class DictationRuntime(
             aacSession?.release()
             aacEncoderSession = null
             toast("Couldn't start recording — mic busy?")
-            return
-        }
+                return
+            }
 
-        recordingEngine = engine
+            recordingStarted = true
+            recordingEngine = engine
         // M6: recording is genuinely live -- open the bounded wakelock window that spans
-        // recording + transcription; resetToIdle() (the terminal-state funnel) closes it.
+        // recording + transcription; resetToIdle (the terminal-state funnel) closes it.
         // Placed after the `started` check so a failed recorder start never acquires.
-        acquireTranscriptionWakeLock()
-        listener.onRecordingStarted()
+            acquireTranscriptionWakeLock()
+            listener.onRecordingStarted()
+        } finally {
+            if (!recordingStarted) releaseSessionLease(lease)
+        }
     }
 
     /** Flips shared state; the reader thread notices, drains, tears down and hands off via [onRecordingFinished]. */
     internal fun stopAndTranscribe() {
+        val lease = sessionLease ?: return
         if (!stateMachine.tryStartTranscribing()) return
         activeToken = guard.start()
         pipelineTiming.start(PipelineTiming(stopTapAtMs = System.currentTimeMillis(), correlationId = correlationIdFor(activeToken)))
-        armWatchdog(activeToken)
+        armWatchdog(activeToken, lease)
         listener.onEnterTranscribingUi()
     }
 
@@ -539,16 +566,17 @@ class DictationRuntime(
     /** Long-press while TRANSCRIBING (see the host's overlay touch listener): abort the in-flight call and return to idle. */
     fun cancelTranscription() {
         if (stateMachine.current() != RecordingStateMachine.State.TRANSCRIBING) return
+        val lease = sessionLease ?: return
         inFlightCall.cancel()
         // H2 (#192): this dictation will never reach finishInjection, so drop its timeline now --
         // otherwise the next unrelated injection would consume it as its own.
         pipelineTiming.abandon()
-        resetToIdle()
+        resetToIdle(lease)
         toast("Transcription cancelled")
     }
 
     /** Backstop for a callback that never arrives (stalled socket, hung local model, etc). See #20. */
-    private fun armWatchdog(token: Int) {
+    private fun armWatchdog(token: Int, lease: DictationSessionLease) {
         // Remove any previously-armed watchdog so a fresh arm (e.g. the transcribe->cleanup handoff
         // arms a second one) doesn't leave the first runnable sitting in the handler queue for its
         // full 400s (L14). The runnable is held so resetToIdle/shutdown can remove it on normal
@@ -561,7 +589,7 @@ class DictationRuntime(
                 // H2 (#192): a timed-out dictation never reaches finishInjection; drop its
                 // timeline so a later unrelated injection can't consume it.
                 pipelineTiming.abandon()
-                resetToIdle()
+                resetToIdle(lease)
                 toast("Transcription timed out")
             }
         }
@@ -575,25 +603,34 @@ class DictationRuntime(
     }
 
     /** Common teardown for every path back to IDLE: normal completion, cancel, or watchdog. */
-    internal fun resetToIdle() {
-        cancelWatchdog()
-        guard.cancel()
-        activeToken = 0
-        // M6: the pipeline is terminal here -- injection finished, cancel, watchdog, or error
-        // (reset(msg) funnels here too) -- so the recording+transcription wakelock window ends.
-        // isHeld-guarded and non-reference-counted, so the paths where no dictation was running
-        // (e.g. preview-before-inject's early resetToIdle) are harmless no-ops or early releases
-        // that the next startRecording() re-acquires.
-        releaseTranscriptionWakeLock()
-        // #115: deliberately NOT abandoned here. resetToIdle() runs immediately after beginPreview()
-        // too (preview-before-inject, #40) -- well before the real injectText() call that resolves
-        // the preview, possibly seconds later on a timeout. Abandoning here would silently drop
-        // pipeline timing for every previewed dictation. Instead each non-happy-path exit
-        // (cancel, watchdog, no-speech, reset(msg)) calls pipelineTiming.abandon() itself (H2,
-        // #192), and the happy path consumes exactly once in the host's finishInjection().
-        stateMachine.reset()
-        listener.onIdleUi()
-        teardownStreamingPreview()
+    internal fun resetToIdle(expectedLease: DictationSessionLease) {
+        if (sessionLease !== expectedLease) return
+        try {
+            cancelWatchdog()
+            guard.cancel()
+            activeToken = 0
+            // M6: the pipeline is terminal here -- injection finished, cancel, watchdog, or error
+            // (reset(msg) funnels here too) -- so the recording+transcription wakelock window ends.
+            // isHeld-guarded and non-reference-counted, so the paths where no dictation was running
+            // (e.g. preview-before-inject's early resetToIdle) are harmless no-ops or early releases
+            // that the next startRecording() re-acquires.
+            releaseTranscriptionWakeLock()
+            // #115: deliberately NOT abandoned here. resetToIdle runs immediately after beginPreview()
+            // too (preview-before-inject, #40) -- well before the real injectText() call that resolves
+            // the preview, possibly seconds later on a timeout. Abandoning here would silently drop
+            // pipeline timing for every previewed dictation. Instead each non-happy-path exit
+            // (cancel, watchdog, no-speech, reset(msg)) calls pipelineTiming.abandon() itself (H2,
+            // #192), and the happy path consumes exactly once in the host's finishInjection().
+            stateMachine.reset()
+            listener.onIdleUi()
+            teardownStreamingPreview()
+        } finally {
+            // Cancellation can reach IDLE while AudioRecord's reader is still draining. Its exact
+            // lease stays held until onRecordingFinished confirms the microphone is released.
+            if (recordingEngine?.isReaderTeardownPending() != true) {
+                releaseSessionLease(expectedLease)
+            }
+        }
     }
 
     /** The runtime half of the pre-extraction `teardownStreamingPreview()`: the host moves its
@@ -607,12 +644,26 @@ class DictationRuntime(
     }
 
     /** Called on the reader thread once the AudioRecord has been drained and released. */
-    private fun onRecordingFinished(engine: RecordingEngine, result: RecordingEngine.Result) {
+    private fun onRecordingFinished(
+        engine: RecordingEngine,
+        result: RecordingEngine.Result,
+        lease: DictationSessionLease,
+    ) {
         // Clear the reference only if it still points at THIS engine (H2): a late old-session
         // handoff must not null out the *new* engine's reference, or shutdown would skip its
         // teardown and leave the new reader keeping the mic hot after the service appears off.
         if (recordingEngine === engine) recordingEngine = null
-        if (result.discarded) return // service destroyed / recording forced off — nothing to transcribe
+        if (result.discarded) {
+            // During shutdown the host deliberately keeps ownership until reader teardown AND
+            // cancellation finish below. Every other discarded handoff can release immediately.
+            if (!shuttingDown) {
+                releaseSessionLease(lease)
+            } else if (shutdownLeaseAwaitingReader === lease) {
+                shutdownLeaseAwaitingReader = null
+                releaseSessionLease(lease)
+            }
+            return // service destroyed / recording forced off — nothing to transcribe
+        }
 
         // #115: mark stop-tap -> reader-drain/PCM-handoff the instant it actually happens, on
         // this reader thread, rather than waiting for the main-thread token resolution below --
@@ -623,7 +674,7 @@ class DictationRuntime(
         val token = when {
             activeToken != 0 && guard.isCurrent(activeToken) -> activeToken
             result.stopReason == RecordingEngine.StopReason.MAX_DURATION -> {
-                startMaxDurationTranscription(result)
+                startMaxDurationTranscription(result, lease)
                 return
             }
             else -> {
@@ -632,22 +683,26 @@ class DictationRuntime(
                 // CAS this reader thread reacted to, so deciding to discard here could silently
                 // drop a real dictation. Resolve on the main thread instead, where token/state
                 // are authoritative — mirroring startMaxDurationTranscription's pattern.
-                handler.post { resolveLateRecordingOnMain(result) }
+                handler.post { resolveLateRecordingOnMain(result, lease) }
                 return
             }
         }
-        continueTranscription(result, token)
+        continueTranscription(result, token, lease)
     }
 
     /** Main-thread resolution for a recording that finished without a token (#66/#90) — see
      *  [resolveLateRecording] for the decision table. */
-    private fun resolveLateRecordingOnMain(result: RecordingEngine.Result) {
+    private fun resolveLateRecordingOnMain(
+        result: RecordingEngine.Result,
+        lease: DictationSessionLease,
+    ) {
         val token = activeToken
         when (resolveLateRecording(token, guard.isCurrent(token), stateMachine.current())) {
-            LateRecordingResolution.CONTINUE_TRANSCRIPTION -> thread { continueTranscription(result, token) }
+            LateRecordingResolution.CONTINUE_TRANSCRIPTION -> thread { continueTranscription(result, token, lease) }
             LateRecordingResolution.DISCARD -> {
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
+                releaseSessionLease(lease)
             }
             LateRecordingResolution.DISCARD_AND_RESET -> {
                 // Mic error mid-recording (#90): the reader thread self-claimed TRANSCRIBING but
@@ -655,7 +710,10 @@ class DictationRuntime(
                 // overlay stays stuck in TRANSCRIBING with taps as no-ops forever.
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
-                reset(result.errorMessage?.let { "Recording error: $it" } ?: "Recording stopped unexpectedly")
+                resetRecordingError(
+                    result.errorMessage?.let { "Recording error: $it" } ?: "Recording stopped unexpectedly",
+                    lease,
+                )
             }
         }
     }
@@ -665,11 +723,15 @@ class DictationRuntime(
      * that token on the main thread with a fresh state check; if the user/service already reset to
      * IDLE, discard the temp file instead of resurrecting a cancelled transcription.
      */
-    private fun startMaxDurationTranscription(result: RecordingEngine.Result) {
+    private fun startMaxDurationTranscription(
+        result: RecordingEngine.Result,
+        lease: DictationSessionLease,
+    ) {
         handler.post {
             if (stateMachine.current() != RecordingStateMachine.State.TRANSCRIBING || activeToken != 0) {
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
+                releaseSessionLease(lease)
                 return@post
             }
             val token = guard.start()
@@ -681,16 +743,20 @@ class DictationRuntime(
             // any pipelineTiming existed to record it against.
             val nowMs = System.currentTimeMillis()
             pipelineTiming.start(PipelineTiming(stopTapAtMs = nowMs, correlationId = correlationIdFor(token), drainAtMs = nowMs))
-            armWatchdog(token)
+            armWatchdog(token, lease)
             listener.onEnterTranscribingUi()
             toast("Recording limit reached (10 min) — transcribing…")
-            thread { continueTranscription(result, token) }
+            thread { continueTranscription(result, token, lease) }
         }
     }
 
-    private fun continueTranscription(result: RecordingEngine.Result, token: Int) {
+    private fun continueTranscription(
+        result: RecordingEngine.Result,
+        token: Int,
+        lease: DictationSessionLease,
+    ) {
         val file = result.pcmFile
-        if (file == null) { reset("No audio captured"); return }
+        if (file == null) { reset("No audio captured", token, lease); return }
         if (result.errorMessage != null) Log.e(TAG, "Recording ended with error: ${result.errorMessage}")
 
         // M3a (#192): a recording under the minimum duration floor (~300ms of PCM) cannot contain
@@ -700,7 +766,7 @@ class DictationRuntime(
             Log.i(TAG, "Recording below ${MIN_RECORDING_DURATION_MS}ms floor (${file.length()} bytes); discarding")
             file.delete()
             result.compressedFile?.delete()
-            reset("No speech detected")
+            reset("No speech detected", token, lease)
             return
         }
 
@@ -714,7 +780,7 @@ class DictationRuntime(
         when {
             useLocal && transcriberSlot.get() != null -> {
                 compressedFile?.delete()
-                transcribeLocal(file, token)
+                transcribeLocal(file, token, lease)
             }
             // #98 UX follow-up: previously this fell straight through to transcribeApi() whenever
             // the local model wasn't loaded yet, regardless of *why* -- including the real-world
@@ -727,13 +793,13 @@ class DictationRuntime(
             // configured -- unless #100's "fall back to cloud if on-device fails" toggle is on,
             // in which case a not-yet-downloaded local model is exactly the case that toggle
             // exists for.
-            useLocal && allowCloudFallback -> transcribeApi(file, token, compressedFile)
+            useLocal && allowCloudFallback -> transcribeApi(file, token, compressedFile, lease)
             useLocal -> {
                 compressedFile?.delete()
                 file.delete()
-                reset("Local model still downloading — try again once it finishes")
+                reset("Local model still downloading — try again once it finishes", token, lease)
             }
-            else -> transcribeApi(file, token, compressedFile)
+            else -> transcribeApi(file, token, compressedFile, lease)
         }
     }
 
@@ -781,7 +847,12 @@ class DictationRuntime(
      * still transcribe it, and [transcribeApi]'s `advanceOrGiveUp` deletes it once the chain is
      * exhausted -- the [TranscriptionChain.shouldDeletePcm] contract.
      */
-    private fun transcribeLocal(file: File, token: Int, onChainFailure: ((String) -> Unit)? = null) {
+    private fun transcribeLocal(
+        file: File,
+        token: Int,
+        lease: DictationSessionLease,
+        onChainFailure: ((String) -> Unit)? = null,
+    ) {
         thread {
             // Benchmark-log timing starts before the read/decode too, so a failure there (rare,
             // but possible on a corrupt/truncated PCM file) still gets an honest latency instead
@@ -847,7 +918,7 @@ class DictationRuntime(
                     rawText = text,
                 )
 
-                handleTranscriptionResult(text, token)
+                handleTranscriptionResult(text, token, lease)
             } catch (e: Exception) {
                 Log.e(TAG, "Local transcription failed", e)
                 BenchmarkLogger.log(
@@ -887,7 +958,7 @@ class DictationRuntime(
                     handler.post {
                         if (!guard.isCurrent(token)) return@post // cancelled or watchdog already reset the UI
                         toast("Local error: ${e.message}")
-                        resetToIdle()
+                        resetToIdle(lease)
                     }
                 }
             }
@@ -907,14 +978,19 @@ class DictationRuntime(
     private fun vocabularyTerms(): List<String> =
         VocabularyTerms.parse(prefs().getString("custom_vocabulary_terms", VocabularyTerms.DEFAULT_SERIALIZED))
 
-    private fun transcribeApi(file: File, token: Int, compressedFile: File? = null) {
+    private fun transcribeApi(
+        file: File,
+        token: Int,
+        compressedFile: File? = null,
+        lease: DictationSessionLease,
+    ) {
         val chain = ProviderChainStore.load(context)
         val allowLocalFallback = DictationModeToggle.allowLocalFallback(context)
         val candidates = ProviderChainRuntime.transcriptionCandidates(chain, allowLocalFallback)
         if (candidates.isEmpty()) {
             file.delete()
             compressedFile?.delete()
-            reset("No transcription provider configured")
+            reset("No transcription provider configured", token, lease)
             return
         }
 
@@ -930,7 +1006,7 @@ class DictationRuntime(
             if (index >= candidates.size) {
                 file.delete()
                 remainingCompressedFile?.delete()
-                reset("Set API key in Ramblr app")
+                reset("Set API key in Ramblr app", token, lease)
                 return
             }
             val entry = candidates[index]
@@ -967,7 +1043,7 @@ class DictationRuntime(
                     } else {
                         file.delete()
                         remainingCompressedFile?.delete()
-                        reset("Error: ${error ?: "transcription failed"}")
+                        reset("Error: ${error ?: "transcription failed"}", token, lease)
                     }
                 }
             }
@@ -1051,7 +1127,7 @@ class DictationRuntime(
                         if (success) {
                             file.delete()
                             uploadCompressedFile?.delete()
-                            handleTranscriptionResult(result.text, token)
+                            handleTranscriptionResult(result.text, token, lease)
                         } else {
                             advanceOrGiveUp(result.error ?: "empty transcript")
                         }
@@ -1069,7 +1145,7 @@ class DictationRuntime(
                     // deletes it at chain exhaustion) instead of transcribeLocal's direct-path
                     // delete-and-reset. See transcribeLocal's PCM-lifetime kdoc and
                     // TranscriptionChain.shouldDeletePcm.
-                    transcribeLocal(file, token, onChainFailure = { error -> advanceOrGiveUp(error) })
+                    transcribeLocal(file, token, lease, onChainFailure = { error -> advanceOrGiveUp(error) })
                 }
                 ProviderKind.GEMINI -> {
                     val apiKey = ProviderCredentialStore.get(context, ProviderKind.GEMINI)
@@ -1123,7 +1199,7 @@ class DictationRuntime(
                             if (success) {
                                 file.delete()
                                 uploadCompressedFile?.delete()
-                                handleTranscriptionResult(result.text, token)
+                                handleTranscriptionResult(result.text, token, lease)
                             } else {
                                 advanceOrGiveUp(result.error ?: "empty transcript")
                             }
@@ -1137,7 +1213,18 @@ class DictationRuntime(
         attempt(0)
     }
 
+    /** Test seam retaining the existing token-only API; stale tokens never borrow a newer lease. */
     internal fun handleTranscriptionResult(text: String?, token: Int) {
+        val lease = sessionLease ?: return
+        if (activeToken != token || !guard.isCurrent(token)) return
+        handleTranscriptionResult(text, token, lease)
+    }
+
+    private fun handleTranscriptionResult(
+        text: String?,
+        token: Int,
+        lease: DictationSessionLease,
+    ) {
         if (text.isNullOrBlank()) {
             // H2 (#192): a no-speech dictation never reaches finishInjection -- abandon its
             // timing so a later unrelated injection (e.g. feedback-bubble raw-text retry) can't
@@ -1146,7 +1233,7 @@ class DictationRuntime(
             handler.post {
                 if (!guard.isCurrent(token)) return@post
                 toast("No speech detected")
-                resetToIdle()
+                resetToIdle(lease)
             }
             return
         }
@@ -1159,7 +1246,7 @@ class DictationRuntime(
             handler.post {
                 if (!guard.isCurrent(token)) return@post
                 listener.deliverText(text, rawText = null, paidFallbackGroup = null, cleanupError = null, feedbackDurationMs = 2000)
-                resetToIdle()
+                resetToIdle(lease)
             }
             return
         }
@@ -1193,7 +1280,7 @@ class DictationRuntime(
                 handler.post {
                     if (!guard.isCurrent(token)) return@post
                     listener.deliverText(text, rawText = null, paidFallbackGroup = null, cleanupError = null, feedbackDurationMs = 2000)
-                    resetToIdle()
+                    resetToIdle(lease)
                 }
                 return
             }
@@ -1210,7 +1297,7 @@ class DictationRuntime(
                     if (!guard.isCurrent(token)) return@post
                     toast("Post-processing needs API key. Using raw text.")
                     listener.deliverText(text, rawText = null, paidFallbackGroup = null, cleanupError = null, feedbackDurationMs = 2000)
-                    resetToIdle()
+                    resetToIdle(lease)
                 }
                 return
             }
@@ -1266,14 +1353,14 @@ class DictationRuntime(
                         // overlay.
                         listener.deliverText(text, rawText = null, paidFallbackGroup = null, cleanupError = reason, feedbackDurationMs = 4000)
                     }
-                    resetToIdle()
+                    resetToIdle(lease)
                 }
             }
         } else {
             handler.post {
                 if (!guard.isCurrent(token)) return@post
                 listener.deliverText(text, rawText = null, paidFallbackGroup = null, cleanupError = null, feedbackDurationMs = 2000)
-                resetToIdle()
+                resetToIdle(lease)
             }
         }
     }
@@ -1295,17 +1382,29 @@ class DictationRuntime(
         return step.group
     }
 
-    /** Safe to call from any thread: [resetToIdle] mutates main-thread-only state
-     *  (the host's streamingSession/pendingStreamingHandoff, node recycling, the guard), and this
-     *  is the one entry point reachable from the RecordingEngine reader thread (fast tap-tap with
-     *  zero bytes captured, or missing API key) -- so it hops (#72). */
-    private fun reset(msg: String) {
+    /** Safe to call from any thread; both token and lease bind the reset to its originating session. */
+    private fun reset(msg: String, token: Int, expectedLease: DictationSessionLease) {
+        if (!guard.isCurrent(token) || sessionLease !== expectedLease) return
         toast(msg)
         // H2 (#192): every reset(msg) call site is a terminal error/give-up exit (no audio, chain
         // exhausted, recording error, ...) after which no finishInjection will run for this
         // dictation -- abandon its timing so it can't be misattributed to a later injection.
         pipelineTiming.abandon()
-        handler.post { resetToIdle() }
+        handler.post {
+            if (!guard.isCurrent(token) || sessionLease !== expectedLease) return@post
+            resetToIdle(expectedLease)
+        }
+    }
+
+    /** Tokenless recorder-error reset, still compare-bound to the exact recording lease. */
+    private fun resetRecordingError(msg: String, expectedLease: DictationSessionLease) {
+        if (sessionLease !== expectedLease) return
+        toast(msg)
+        pipelineTiming.abandon()
+        handler.post {
+            if (sessionLease !== expectedLease) return@post
+            resetToIdle(expectedLease)
+        }
     }
 
     // --- Streaming preview (#29) ---
@@ -1331,31 +1430,47 @@ class DictationRuntime(
      * host interleaves its own pieces around this call -- see the service's onDestroy).
      */
     fun shutdown() {
-        // If a recording is in progress, force the reader thread off RECORDING/TRANSCRIBING so
-        // it tears down the AudioRecord and discards buffered PCM instead of leaking the mic or
-        // silently continuing to record after the service appears off. reset() runs
-        // unconditionally (H2): even if recordingEngine reads null here, a late old-session
-        // handoff could have raced our read of it while a reader is still live, so we must always
-        // walk the shared state machine out of RECORDING/TRANSCRIBING.
-        stateMachine.reset()
-        recordingEngine?.awaitTeardown()
-        recordingEngine = null
-        // Belt-and-suspenders alongside the release already wired into startRecording's onFinished
-        // (#108): awaitTeardown above blocks until the reader thread's onFinished has run, so this
-        // is normally already null, but a stray VAD session must never survive service teardown.
-        silenceAutoStopSession?.release()
-        silenceAutoStopSession = null
-        // Belt-and-suspenders alongside the release already wired into startRecording's onFinished
-        // (#109): awaitTeardown above blocks until the reader thread's onFinished has run, so this
-        // is normally already null, but a stray encoder session must never survive service teardown
-        // and leave a partial .m4a temp file behind.
-        aacEncoderSession?.release()
-        aacEncoderSession = null
-        cancelWatchdog()
-        guard.cancel()
+        shuttingDown = true
+        val lease = sessionLease
+        val engine = recordingEngine
+        if (engine != null) shutdownLeaseAwaitingReader = lease
+        // Cancel transcription work before waiting for capture teardown. If the reader times out,
+        // its eventual callback can now release ownership knowing both terminal conditions hold.
         inFlightCall.cancel()
+        var readerTeardownCompleted = engine == null
+        try {
+            // If a recording is in progress, force the reader thread off RECORDING/TRANSCRIBING so
+            // it tears down the AudioRecord and discards buffered PCM instead of leaking the mic or
+            // silently continuing to record after the service appears off. reset() runs
+            // unconditionally (H2): even if recordingEngine reads null here, a late old-session
+            // handoff could have raced our read of it while a reader is still live, so we must always
+            // walk the shared state machine out of RECORDING/TRANSCRIBING.
+            stateMachine.reset()
+            readerTeardownCompleted = engine?.awaitTeardown() ?: true
+            recordingEngine = null
+            // Belt-and-suspenders alongside the release already wired into startRecording's onFinished
+            // (#108): awaitTeardown above blocks until the reader thread's onFinished has run, so this
+            // is normally already null, but a stray VAD session must never survive service teardown.
+            silenceAutoStopSession?.release()
+            silenceAutoStopSession = null
+            // Belt-and-suspenders alongside the release already wired into startRecording's onFinished
+            // (#109): awaitTeardown above blocks until the reader thread's onFinished has run, so this
+            // is normally already null, but a stray encoder session must never survive service teardown
+            // and leave a partial .m4a temp file behind.
+            aacEncoderSession?.release()
+            aacEncoderSession = null
+            cancelWatchdog()
+            guard.cancel()
+        } finally {
+            // A timed-out reader keeps the lease until its onFinished callback confirms AudioRecord
+            // teardown. Otherwise release now; active capture never migrates to another destination.
+            if (readerTeardownCompleted) {
+                if (shutdownLeaseAwaitingReader === lease) shutdownLeaseAwaitingReader = null
+                releaseSessionLease(lease)
+            }
+        }
         // M6 belt-and-suspenders: service teardown is terminal for any in-flight dictation, and
-        // resetToIdle() may never run for it. isHeld-guarded, so a no-dictation destroy is a no-op.
+        // resetToIdle may never run for it. isHeld-guarded, so a no-dictation destroy is a no-op.
         releaseTranscriptionWakeLock()
         // The cancel above makes any in-flight local completion abort at its next piece check
         // (#83), so the holder's daemon thread can close the cached ~1 GB cleanup model promptly

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationSessionLeaseRegistry.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationSessionLeaseRegistry.kt
@@ -1,0 +1,34 @@
+package com.trevornk.ramblr
+
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/** Opaque identity for one process-local dictation session. It never retains a host or Context. */
+internal class DictationSessionLease internal constructor(internal val generation: Long)
+
+/** Atomic process-local ownership seam; injectable so runtime tests never share global state. */
+internal interface DictationSessionLeaseRegistry {
+    fun tryAcquire(): DictationSessionLease?
+    fun release(lease: DictationSessionLease): Boolean
+}
+
+/**
+ * Lock-free lease registry. [release] is compare-and-release against the exact immutable lease,
+ * so a late callback carrying an older generation cannot clear a newer session's ownership.
+ */
+internal class InMemoryDictationSessionLeaseRegistry : DictationSessionLeaseRegistry {
+    private val nextGeneration = AtomicLong(0)
+    private val active = AtomicReference<DictationSessionLease?>(null)
+
+    override fun tryAcquire(): DictationSessionLease? {
+        val lease = DictationSessionLease(nextGeneration.incrementAndGet())
+        return if (active.compareAndSet(null, lease)) lease else null
+    }
+
+    override fun release(lease: DictationSessionLease): Boolean =
+        active.compareAndSet(lease, null)
+}
+
+/** The one registry shared by every production [DictationRuntime] in this app process. */
+internal object ProcessDictationSessionLeaseRegistry : DictationSessionLeaseRegistry by
+    InMemoryDictationSessionLeaseRegistry()

--- a/app/src/main/kotlin/com/trevornk/ramblr/RecordingEngine.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/RecordingEngine.kt
@@ -225,8 +225,16 @@ open class RecordingEngine(
         return true
     }
 
-    /** Blocks until the reader thread has stopped/released the recorder, or [timeoutMs] elapses. Safe to call from onDestroy. */
-    open fun awaitTeardown(timeoutMs: Long = 2000) {
+    /**
+     * Blocks until the reader thread has stopped/released the recorder, or [timeoutMs] elapses.
+     * Returns true only when teardown is confirmed, so lifecycle owners do not hand microphone
+     * ownership to a replacement host while a timed-out reader is still alive.
+     */
+    open fun awaitTeardown(timeoutMs: Long = 2000): Boolean {
         readerThread?.join(timeoutMs)
+        return readerThread?.isAlive != true
     }
+
+    /** Non-blocking teardown probe used by terminal reset paths before releasing a session lease. */
+    open fun isReaderTeardownPending(): Boolean = readerThread?.isAlive == true
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
@@ -7,6 +7,7 @@ import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -15,6 +16,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
 
 /**
  * Host-side state-transition tests for [DictationRuntime] (#143 Phase 1) -- the pipeline logic
@@ -39,6 +41,7 @@ class DictationRuntimeTest {
     private lateinit var app: Application
     private lateinit var listener: RecordingListener
     private lateinit var engines: MutableList<FakeRecordingEngine>
+    private lateinit var leaseRegistry: InMemoryDictationSessionLeaseRegistry
     private lateinit var runtime: DictationRuntime
 
     /** Records every listener callback in arrival order, so ordering assertions are direct. */
@@ -88,6 +91,7 @@ class DictationRuntimeTest {
         var onFinished: ((Result) -> Unit)? = null
         var onChunk: ((ByteArray, Int) -> Unit)? = null
         var startResult = true
+        var teardownCompleted = true
 
         override fun start(onFinished: (Result) -> Unit, onChunk: (ByteArray, Int) -> Unit): Boolean {
             if (!startResult) return false
@@ -97,7 +101,9 @@ class DictationRuntimeTest {
             return true
         }
 
-        override fun awaitTeardown(timeoutMs: Long) {}
+        override fun awaitTeardown(timeoutMs: Long): Boolean = teardownCompleted
+
+        override fun isReaderTeardownPending(): Boolean = !teardownCompleted
 
         /** Mirrors the real reader thread's end-of-loop handoff: claim TRANSCRIBING if nobody
          *  else has (max-duration/error paths), then report discarded from the current state. */
@@ -121,7 +127,8 @@ class DictationRuntimeTest {
         shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
         listener = RecordingListener()
         engines = mutableListOf()
-        runtime = DictationRuntime(app, listener) { cacheDir, stateMachine ->
+        leaseRegistry = InMemoryDictationSessionLeaseRegistry()
+        runtime = DictationRuntime(app, listener, leaseRegistry) { cacheDir, stateMachine ->
             FakeRecordingEngine(cacheDir, stateMachine).also { engines += it }
         }
     }
@@ -145,6 +152,45 @@ class DictationRuntimeTest {
         runtime.onTap()
         assertEquals(RecordingStateMachine.State.RECORDING, runtime.currentState())
         assertEquals(listOf("startRequested", "recordingStarted"), listener.events)
+    }
+
+    @Test
+    fun `second runtime is rejected before host or recorder setup while first owns dictation`() {
+        runtime.onTap()
+        val secondListener = RecordingListener()
+        val secondEngines = mutableListOf<FakeRecordingEngine>()
+        val secondRuntime = DictationRuntime(app, secondListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { secondEngines += it }
+        }
+
+        secondRuntime.onTap()
+        idleMainLooper()
+
+        assertEquals(RecordingStateMachine.State.IDLE, secondRuntime.currentState())
+        assertTrue(secondListener.events.isEmpty())
+        assertTrue(secondEngines.isEmpty())
+        assertEquals(
+            "Ramblr is already dictating from another input surface",
+            ShadowToast.getTextOfLatestToast(),
+        )
+    }
+
+    @Test
+    fun `normal completion releases lease for another runtime`() {
+        runtime.onTap()
+        runtime.onTap()
+        runtime.handleTranscriptionResult("first dictation", token = 1)
+        idleMainLooper()
+
+        val secondListener = RecordingListener()
+        val secondEngines = mutableListOf<FakeRecordingEngine>()
+        val secondRuntime = DictationRuntime(app, secondListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { secondEngines += it }
+        }
+        secondRuntime.onTap()
+
+        assertEquals(RecordingStateMachine.State.RECORDING, secondRuntime.currentState())
+        assertEquals(1, secondEngines.size)
     }
 
     @Test
@@ -276,6 +322,46 @@ class DictationRuntimeTest {
     }
 
     @Test
+    fun `cancel releases lease for another runtime`() {
+        runtime.onTap()
+        runtime.onTap()
+        runtime.cancelTranscription()
+        idleMainLooper()
+
+        val secondListener = RecordingListener()
+        val secondEngines = mutableListOf<FakeRecordingEngine>()
+        val secondRuntime = DictationRuntime(app, secondListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { secondEngines += it }
+        }
+        secondRuntime.onTap()
+
+        assertEquals(RecordingStateMachine.State.RECORDING, secondRuntime.currentState())
+        assertEquals(1, secondEngines.size)
+    }
+
+    @Test
+    fun `cancel with delayed reader teardown blocks another runtime until old reader finishes`() {
+        runtime.onTap()
+        val stalledEngine = engines.single().also { it.teardownCompleted = false }
+        runtime.onTap()
+        runtime.cancelTranscription()
+
+        val contenderListener = RecordingListener()
+        val contenderEngines = mutableListOf<FakeRecordingEngine>()
+        val contender = DictationRuntime(app, contenderListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { contenderEngines += it }
+        }
+        contender.onTap()
+        assertEquals(RecordingStateMachine.State.IDLE, contender.currentState())
+        assertTrue(contenderEngines.isEmpty())
+
+        stalledEngine.finishAs(null, RecordingEngine.StopReason.USER, superseded = true)
+        contender.onTap()
+        assertEquals(RecordingStateMachine.State.RECORDING, contender.currentState())
+        assertEquals(1, contenderEngines.size)
+    }
+
+    @Test
     fun `cancel while idle or recording is a no-op`() {
         runtime.cancelTranscription()
         assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
@@ -307,6 +393,29 @@ class DictationRuntimeTest {
     }
 
     @Test
+    fun `stale async callback after cancel and same-runtime restart cannot release new lease`() {
+        runtime.onTap()
+        runtime.onTap()
+        runtime.cancelTranscription()
+        runtime.onTap()
+
+        runtime.handleTranscriptionResult("stale old result", token = 1)
+        idleMainLooper()
+
+        val contenderListener = RecordingListener()
+        val contenderEngines = mutableListOf<FakeRecordingEngine>()
+        val contender = DictationRuntime(app, contenderListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { contenderEngines += it }
+        }
+        contender.onTap()
+
+        assertEquals(RecordingStateMachine.State.RECORDING, runtime.currentState())
+        assertEquals(RecordingStateMachine.State.IDLE, contender.currentState())
+        assertTrue(contenderEngines.isEmpty())
+        assertTrue(contenderListener.events.isEmpty())
+    }
+
+    @Test
     fun `late finish from a superseded recording is discarded and does not disturb the new session`() {
         runtime.onTap()
         val firstEngine = engines.single()
@@ -327,6 +436,36 @@ class DictationRuntimeTest {
         assertEquals(RecordingStateMachine.State.RECORDING, runtime.currentState())
         assertTrue("no listener transitions from the stale finish", listener.events.isEmpty())
         assertTrue(listener.delivered.isEmpty())
+    }
+
+    @Test
+    fun `late finish from old runtime cannot release newer runtime lease`() {
+        runtime.onTap()
+        val oldEngine = engines.single()
+        runtime.onTap()
+        runtime.cancelTranscription()
+        idleMainLooper()
+
+        val newerListener = RecordingListener()
+        val newerRuntime = DictationRuntime(app, newerListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine)
+        }
+        newerRuntime.onTap()
+
+        oldEngine.finishAs(realSizedPcm(), RecordingEngine.StopReason.USER, superseded = true)
+        idleMainLooper()
+
+        val contenderListener = RecordingListener()
+        val contenderEngines = mutableListOf<FakeRecordingEngine>()
+        val contender = DictationRuntime(app, contenderListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { contenderEngines += it }
+        }
+        contender.onTap()
+
+        assertEquals(RecordingStateMachine.State.RECORDING, newerRuntime.currentState())
+        assertEquals(RecordingStateMachine.State.IDLE, contender.currentState())
+        assertTrue(contenderListener.events.isEmpty())
+        assertTrue(contenderEngines.isEmpty())
     }
 
     @Test
@@ -374,8 +513,23 @@ class DictationRuntimeTest {
     // --- failed recorder start ---
 
     @Test
+    fun `exception during start setup releases lease`() {
+        runtime = DictationRuntime(app, listener, leaseRegistry) { _, _ ->
+            throw IllegalStateException("setup failed")
+        }
+
+        assertThrows(IllegalStateException::class.java) { runtime.onTap() }
+
+        val nextRuntime = DictationRuntime(app, RecordingListener(), leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine)
+        }
+        nextRuntime.onTap()
+        assertEquals(RecordingStateMachine.State.RECORDING, nextRuntime.currentState())
+    }
+
+    @Test
     fun `failed engine start leaves runtime idle and fires no recording callbacks`() {
-        runtime = DictationRuntime(app, listener) { cacheDir, stateMachine ->
+        runtime = DictationRuntime(app, listener, leaseRegistry) { cacheDir, stateMachine ->
             FakeRecordingEngine(cacheDir, stateMachine).also { it.startResult = false; engines += it }
         }
         runtime.onTap()
@@ -383,6 +537,12 @@ class DictationRuntimeTest {
         assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
         assertEquals(listOf("startRequested"), listener.events)
         assertFalse(listener.events.contains("recordingStarted"))
+
+        val nextRuntime = DictationRuntime(app, RecordingListener(), leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine)
+        }
+        nextRuntime.onTap()
+        assertEquals(RecordingStateMachine.State.RECORDING, nextRuntime.currentState())
     }
 
     // --- shutdown ---
@@ -394,5 +554,33 @@ class DictationRuntimeTest {
         runtime.shutdown()
         assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
         assertTrue("shutdown runs the streaming teardown half", listener.events.contains("streamingTeardown"))
+
+        val nextRuntime = DictationRuntime(app, RecordingListener(), leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine)
+        }
+        nextRuntime.onTap()
+        assertEquals(RecordingStateMachine.State.RECORDING, nextRuntime.currentState())
+    }
+
+    @Test
+    fun `shutdown timeout retains lease until reader finish confirms microphone teardown`() {
+        runtime.onTap()
+        val stalledEngine = engines.single().also { it.teardownCompleted = false }
+
+        runtime.shutdown()
+
+        val contenderListener = RecordingListener()
+        val contenderEngines = mutableListOf<FakeRecordingEngine>()
+        val contender = DictationRuntime(app, contenderListener, leaseRegistry) { cacheDir, stateMachine ->
+            FakeRecordingEngine(cacheDir, stateMachine).also { contenderEngines += it }
+        }
+        contender.onTap()
+        assertEquals(RecordingStateMachine.State.IDLE, contender.currentState())
+        assertTrue(contenderEngines.isEmpty())
+
+        stalledEngine.finishAs(null, RecordingEngine.StopReason.USER, superseded = true)
+        contender.onTap()
+        assertEquals(RecordingStateMachine.State.RECORDING, contender.currentState())
+        assertEquals(1, contenderEngines.size)
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/DictationSessionLeaseRegistryTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/DictationSessionLeaseRegistryTest.kt
@@ -1,0 +1,36 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DictationSessionLeaseRegistryTest {
+
+    @Test
+    fun `only one lease can be held at a time`() {
+        val registry = InMemoryDictationSessionLeaseRegistry()
+
+        val first = registry.tryAcquire()
+
+        assertNotNull(first)
+        assertNull(registry.tryAcquire())
+    }
+
+    @Test
+    fun `stale lease cannot release a newer generation`() {
+        val registry = InMemoryDictationSessionLeaseRegistry()
+        val first = registry.tryAcquire()!!
+        assertTrue(registry.release(first))
+        val second = registry.tryAcquire()!!
+        assertNotEquals(first, second)
+        assertTrue(second.generation > first.generation)
+
+        assertFalse(registry.release(first))
+        assertNull(registry.tryAcquire())
+        assertTrue(registry.release(second))
+        assertNotNull(registry.tryAcquire())
+    }
+}


### PR DESCRIPTION
## Summary
- add one process-wide, in-memory dictation session lease registry shared by production `DictationRuntime` instances
- acquire before any host teardown, session setup, warm-up, or audio capture; reject a concurrent host without touching its state/listener/engine
- carry opaque generation leases through recorder, transcription, cleanup, watchdog, and error callbacks so stale work can only compare-and-release its exact session
- expose recorder teardown completion so cancel and host teardown retain ownership while an old `AudioRecord` reader is still alive

## Lifecycle decision
Active capture **does not survive host death by design**. Host teardown resets capture, cancels in-flight work, waits boundedly for the reader, and only then releases ownership. If reader teardown times out, the exact lease remains held until that reader callback confirms microphone release. This avoids invisible recording and delivery into the wrong host/destination; no active session is transferred to another input surface. Idle process coordination and existing caches may survive normally.

## Release-path map
- permission denial / recorder-start failure / exception during start setup: start `finally` compare-releases the acquired lease
- normal delivery, no-speech, junk, watchdog, cancellation, and pipeline errors: exact lease flows through the existing `resetToIdle` terminal funnel
- cancellation while the reader is still alive: reset returns UI/state to IDLE but retains the lease until `onRecordingFinished` confirms microphone teardown
- discarded/late recorder callbacks: release only the callback-captured lease; an older generation cannot clear a newer owner
- host teardown: cancel work, reset capture, await reader teardown, then release; timeout defers exact release to the late reader callback

## Tests
- two-runtime exclusion before listener/engine setup and host-neutral toast
- normal completion, cancellation, start failure, setup exception, and host teardown hand ownership to another runtime
- delayed cancel/host teardown keeps contenders blocked until reader completion
- stale async callbacks and old teardown completions cannot release a newer generation
- direct registry exclusivity, monotonic generations, and compare-and-release regression coverage

Verification on `7e1d5cc`:
- `make test` — **153 suites, 1,598 tests, 0 failures/errors/skips**
- `./gradlew assembleGithubDebug --console=plain` — **BUILD SUCCESSFUL**
- `codex review --uncommitted` — no actionable correctness issues after addressing teardown-timeout and stale-reset findings

No persistence, Application subclass, host reference in the singleton, dependency, IME UI, or user-visible one-host behavior change.

Refs #143
