### PR TITLE
Add cloud-live transcription seam with lossless batch fallback

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
@@ -1,0 +1,84 @@
+package com.trevornk.ramblr
+
+import java.util.concurrent.Executor
+
+/** Provider-neutral lifecycle for one push-to-talk cloud transcription attempt.
+ *
+ * Implementations connect asynchronously. [startActivity], [sendPcm], and [endActivity] may be
+ * called before setup completes and must preserve their wire order. [sendPcm] must copy the valid
+ * bytes before returning because RecordingEngine reuses its input buffer. Callbacks are serialized
+ * on the factory's documented callback executor. Exactly one [onTerminal] callback is emitted;
+ * interim callbacks stop before it. Cancellation and close are idempotent terminal operations.
+ */
+interface CloudLiveTranscriptionSession {
+    fun connect()
+    fun startActivity(): Boolean
+    fun sendPcm(buffer: ByteArray, length: Int): Boolean
+    fun endActivity(): Boolean
+    fun cancel()
+    fun close()
+}
+
+fun interface CloudLiveTranscriptionSessionFactory {
+    fun create(listener: CloudLiveTranscriptionListener): CloudLiveTranscriptionSession
+}
+
+interface CloudLiveTranscriptionListener {
+    fun onInterim(text: String, timing: CloudLiveTiming)
+    fun onTerminal(result: CloudLiveTerminal)
+}
+
+data class CloudLiveTiming(
+    val connectStartedAtMs: Long,
+    val socketOpenedAtMs: Long? = null,
+    val setupCompletedAtMs: Long? = null,
+    val firstInterimAtMs: Long? = null,
+    val activityEndedAtMs: Long? = null,
+    val finalAtMs: Long? = null,
+)
+
+enum class CloudLiveFailureReason {
+    INVALID_REQUEST,
+    SETUP_TIMEOUT,
+    FINAL_TIMEOUT,
+    BUFFER_LIMIT,
+    SEND_FAILED,
+    PROTOCOL_ERROR,
+    NETWORK_ERROR,
+    CANCELLED,
+}
+
+sealed class CloudLiveTerminal {
+    abstract val timing: CloudLiveTiming
+
+    data class Success(val text: String, override val timing: CloudLiveTiming) : CloudLiveTerminal()
+    data class Failure(
+        val reason: CloudLiveFailureReason,
+        val message: String,
+        override val timing: CloudLiveTiming,
+    ) : CloudLiveTerminal()
+}
+
+/** Serializes callbacks even when the supplied executor is a pool. */
+internal class SerialCallbackExecutor(private val delegate: Executor) : Executor {
+    private val tasks = ArrayDeque<Runnable>()
+    private var running = false
+
+    override fun execute(command: Runnable) {
+        val shouldStart = synchronized(tasks) {
+            tasks.addLast(command)
+            if (running) false else { running = true; true }
+        }
+        if (shouldStart) delegate.execute(::drain)
+    }
+
+    private fun drain() {
+        while (true) {
+            val task = synchronized(tasks) {
+                if (tasks.isEmpty()) { running = false; return }
+                tasks.removeFirst()
+            }
+            task.run()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
@@ -59,7 +59,21 @@ sealed class CloudLiveTerminal {
     ) : CloudLiveTerminal()
 }
 
-/** Serializes callbacks even when the supplied executor is a pool. */
+/**
+ * Serializes callbacks even when the supplied executor is a pool.
+ *
+ * One instance is shared factory-wide by every session, so a single throwing listener callback
+ * must never be able to take the executor down with it. [drain] therefore keeps its bookkeeping
+ * consistent no matter what a task does: it always leaves via [nextTaskOrFinish], which clears
+ * `running` in the same critical section as the emptiness check, so a later [execute] is
+ * guaranteed either to be picked up by the in-flight drain or to start a fresh one. Before this,
+ * a throwing task unwound `drain` with `running == true` and a non-empty queue, permanently
+ * wedging cloud-live for the whole process.
+ *
+ * Failures are not swallowed: they are rethrown from [drain] once the queue is empty, on the
+ * delegate's own thread, so its uncaught-exception handler still reports them. Additional
+ * failures in the same drain ride along as suppressed exceptions.
+ */
 internal class SerialCallbackExecutor(private val delegate: Executor) : Executor {
     private val tasks = ArrayDeque<Runnable>()
     private var running = false
@@ -73,12 +87,26 @@ internal class SerialCallbackExecutor(private val delegate: Executor) : Executor
     }
 
     private fun drain() {
+        var failure: Throwable? = null
         while (true) {
-            val task = synchronized(tasks) {
-                if (tasks.isEmpty()) { running = false; return }
-                tasks.removeFirst()
+            val task = nextTaskOrFinish() ?: break
+            try {
+                task.run()
+            } catch (t: Throwable) {
+                if (failure == null) failure = t else failure.addSuppressed(t)
             }
-            task.run()
+        }
+        failure?.let { throw it }
+    }
+
+    /** The next queued task, or null after marking this drain finished. Clearing `running` shares
+     *  the emptiness check's critical section so no [execute] can be stranded un-drained. */
+    private fun nextTaskOrFinish(): Runnable? = synchronized(tasks) {
+        if (tasks.isEmpty()) {
+            running = false
+            null
+        } else {
+            tasks.removeFirst()
         }
     }
 }

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
@@ -559,12 +559,22 @@ class DictationRuntime internal constructor(
                     }
                 }
             })
+            // Overwriting the field is the LAST reference anyone holds to an incumbent, so it must
+            // be cancelled first -- otherwise a rapid abandon->restart leaves an authenticated,
+            // still-open microphone socket with no owner and no armed timeout (its catch block
+            // below already got this right).
+            cancelCloudLiveAttempt()
             cloudLiveAttempt = attempt
             val session = requireNotNull(attempt.session)
             session.connect()
             if (!session.startActivity()) throw IllegalStateException("Cloud-live start rejected")
             attempt
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            // Never fails the dictation -- cloud-live is an optional tee -- but a silent catch here
+            // meant a misconfigured endpoint, bad model id or blank key (all init `require`s)
+            // disabled the feature with zero diagnostics. Control flow is unchanged; this only
+            // makes the cause visible.
+            Log.w(TAG, "Cloud-live attempt could not start; continuing with the batch pipeline", e)
             if (cloudLiveAttempt === attempt) cloudLiveAttempt = null
             attempt.session?.let { session -> runCatching { session.cancel(); session.close() } }
             null
@@ -736,6 +746,11 @@ class DictationRuntime internal constructor(
         // teardown and leave the new reader keeping the mic hot after the service appears off.
         if (recordingEngine === engine) recordingEngine = null
         if (result.discarded) {
+            // The attempt is abandoned with it: nothing downstream will ever claim or time it out
+            // (setupTimeout is cancelled once setup lands, finalTimeout is only armed by
+            // endActivity, and stopAndTranscribe never ran), so without this the authenticated
+            // microphone socket stays open with no reference held anywhere.
+            cancelCloudLiveAttemptForLeaseOnMain(lease)
             // During shutdown the host deliberately keeps ownership until reader teardown AND
             // cancellation finish below. Every other discarded handoff can release immediately.
             if (!shuttingDown) {
@@ -782,6 +797,9 @@ class DictationRuntime internal constructor(
         when (resolveLateRecording(token, guard.isCurrent(token), stateMachine.current())) {
             LateRecordingResolution.CONTINUE_TRANSCRIPTION -> thread { continueWithCloudLiveOrBatch(result, token, lease) }
             LateRecordingResolution.DISCARD -> {
+                // Abandoned without reaching resetToIdle: the attempt would otherwise keep an
+                // authenticated, un-timed-out microphone socket open with no owner.
+                cloudLiveAttempt?.takeIf { it.lease === lease }?.let(::cancelCloudLiveAttempt)
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
                 releaseSessionLease(lease)
@@ -811,6 +829,8 @@ class DictationRuntime internal constructor(
     ) {
         handler.post {
             if (stateMachine.current() != RecordingStateMachine.State.TRANSCRIBING || activeToken != 0) {
+                // Same abandon-without-resetToIdle shape as the other discard paths.
+                cloudLiveAttempt?.takeIf { it.lease === lease }?.let(::cancelCloudLiveAttempt)
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
                 releaseSessionLease(lease)
@@ -847,6 +867,10 @@ class DictationRuntime internal constructor(
         }
         handler.post {
             if (cloudLiveAttempt !== attempt || sessionLease !== lease || !guard.isCurrent(token)) {
+                // This attempt can never be claimed now (recordingResult was never set and no
+                // finalWait was armed, so resolveCloudLiveAttempt would bail forever) -- cancel it
+                // rather than leaving an inert, still-open authenticated socket behind.
+                cancelCloudLiveAttempt(attempt)
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
                 return@post
@@ -910,6 +934,21 @@ class DictationRuntime internal constructor(
         attempt.finalWait?.let(handler::removeCallbacks)
         attempt.finalWait = null
         attempt.session?.let { session -> runCatching { session.cancel(); session.close() } }
+    }
+
+    /**
+     * Cancels the live attempt belonging to [lease] from a path that abandons its recording
+     * without reaching [resetToIdle] -- the reader thread's `discarded` handoff, and the
+     * main-thread late/max-duration resolutions that discard.
+     *
+     * Lease-compared (never the bare field) so a stalled old reader's late handoff can't tear down
+     * the attempt of the *new* dictation the user has already started -- the same identity guard
+     * `recordingEngine === engine` uses. Hops to main because [cancelCloudLiveAttempt] touches
+     * handler callbacks and the field the main-looper arbitration owns; already-on-main callers
+     * just see a queued no-op after the field is cleared.
+     */
+    private fun cancelCloudLiveAttemptForLeaseOnMain(lease: DictationSessionLease) {
+        handler.post { cloudLiveAttempt?.takeIf { it.lease === lease }?.let(::cancelCloudLiveAttempt) }
     }
 
     private fun continueTranscription(

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
@@ -66,6 +66,10 @@ interface RuntimeListener {
      *  surface it (live field partial or feedback bubble). Main thread (posted). */
     fun onStreamingPartial(text: String)
 
+    /** Provider-neutral cloud-live interim. IME may render it generation-safely; accessibility
+     * deliberately inherits this no-op and remains final-only. Main thread. */
+    fun onCloudLiveInterim(text: String) {}
+
     /**
      * A finished dictation result is ready to deliver. The host owns delivery: the a11y host
      * routes this through its candidate-scan injection (or preview-before-inject when [rawText]
@@ -129,6 +133,11 @@ class DictationRuntime internal constructor(
     private val context: Context,
     private val listener: RuntimeListener,
     private val leaseRegistry: DictationSessionLeaseRegistry = ProcessDictationSessionLeaseRegistry,
+    /** Explicit internal seam: null in every shipped host, so this slice changes no default or
+     * provider catalog. A later opt-in wires a configured provider factory here. */
+    private val cloudLiveFactory: CloudLiveTranscriptionSessionFactory? = null,
+    /** Test-only observation seam proving the preserved-PCM batch path is claimed once. */
+    private val onCloudLiveBatchFallback: () -> Unit = {},
     /** Test seam: lets host-side unit tests substitute a fake engine at the capture boundary.
      *  The default is exactly the pre-extraction construction. */
     private val engineFactory: (File, RecordingStateMachine) -> RecordingEngine =
@@ -142,6 +151,7 @@ class DictationRuntime internal constructor(
 
         /** Backstop if no transcription/cleanup callback ever fires; covers transcription + cleanup callTimeouts. */
         private const val WATCHDOG_TIMEOUT_MS = 400_000L
+        private const val CLOUD_LIVE_FINAL_WAIT_MS = 2_500L
     }
 
     private val stateMachine = RecordingStateMachine()
@@ -150,6 +160,17 @@ class DictationRuntime internal constructor(
     @Volatile private var sessionLease: DictationSessionLease? = null
     @Volatile private var shuttingDown = false
     @Volatile private var shutdownLeaseAwaitingReader: DictationSessionLease? = null
+
+    private class CloudLiveAttempt(val lease: DictationSessionLease) {
+        var session: CloudLiveTranscriptionSession? = null
+        var terminal: CloudLiveTerminal? = null
+        var recordingResult: RecordingEngine.Result? = null
+        var token: Int = 0
+        var claimed = false
+        var finalWait: Runnable? = null
+    }
+
+    @Volatile private var cloudLiveAttempt: CloudLiveAttempt? = null
 
     /** Releases only the exact session captured by the caller; stale callbacks are harmless. */
     private fun releaseSessionLease(lease: DictationSessionLease?) {
@@ -384,6 +405,7 @@ class DictationRuntime internal constructor(
         }
         sessionLease = lease
         var recordingStarted = false
+        var liveAttempt: CloudLiveAttempt? = null
         try {
             if (context.checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
                 != android.content.pm.PackageManager.PERMISSION_GRANTED) {
@@ -399,6 +421,7 @@ class DictationRuntime internal constructor(
         // bubble throttle -- verbatim the pre-extraction startRecording prologue, now behind the
         // listener seam because every one of those pieces is host delivery state.
             listener.onRecordingStartRequested()
+            liveAttempt = beginCloudLiveAttempt(lease)
             val streamingActive = streamingTranscriberSlot.get() != null
             if (streamingActive) streamingTranscriberSlot.use { it.beginSession() }
 
@@ -437,7 +460,7 @@ class DictationRuntime internal constructor(
         } else null
             aacEncoderSession = aacSession
 
-            val onChunk: (ByteArray, Int) -> Unit = when {
+            val existingOnChunk: (ByteArray, Int) -> Unit = when {
             streamingActive && autoStopSession != null && aacSession != null -> { buf, len ->
                 handleStreamingChunk(buf, len)
                 autoStopSession.onChunk(buf, len)
@@ -460,6 +483,12 @@ class DictationRuntime internal constructor(
             aacSession != null -> aacSession::onChunk
             else -> { _, _ -> }
         }
+            val onChunk: (ByteArray, Int) -> Unit = if (liveAttempt == null) existingOnChunk else { buf, len ->
+                existingOnChunk(buf, len)
+                // Cloud live is an optional tee. Its contract copies before returning; failure is
+                // terminal to only that attempt and never interrupts the PCM file write.
+                runCatching { liveAttempt.session?.sendPcm(buf, len) }
+            }
 
             val engine = engineFactory(context.cacheDir, stateMachine)
             val started = engine.start(
@@ -501,7 +530,44 @@ class DictationRuntime internal constructor(
             acquireTranscriptionWakeLock()
             listener.onRecordingStarted()
         } finally {
-            if (!recordingStarted) releaseSessionLease(lease)
+            if (!recordingStarted) {
+                cancelCloudLiveAttempt(liveAttempt)
+                releaseSessionLease(lease)
+            }
+        }
+    }
+
+    private fun beginCloudLiveAttempt(lease: DictationSessionLease): CloudLiveAttempt? {
+        val factory = cloudLiveFactory ?: return null
+        val attempt = CloudLiveAttempt(lease)
+        return try {
+            attempt.session = factory.create(object : CloudLiveTranscriptionListener {
+                override fun onInterim(text: String, timing: CloudLiveTiming) {
+                    handler.post {
+                        if (cloudLiveAttempt === attempt && sessionLease === lease &&
+                            stateMachine.current() == RecordingStateMachine.State.RECORDING && !attempt.claimed) {
+                            listener.onCloudLiveInterim(text)
+                        }
+                    }
+                }
+
+                override fun onTerminal(result: CloudLiveTerminal) {
+                    handler.post {
+                        if (cloudLiveAttempt !== attempt || sessionLease !== lease || attempt.claimed) return@post
+                        attempt.terminal = result
+                        resolveCloudLiveAttempt(attempt)
+                    }
+                }
+            })
+            cloudLiveAttempt = attempt
+            val session = requireNotNull(attempt.session)
+            session.connect()
+            if (!session.startActivity()) throw IllegalStateException("Cloud-live start rejected")
+            attempt
+        } catch (_: Exception) {
+            if (cloudLiveAttempt === attempt) cloudLiveAttempt = null
+            attempt.session?.let { session -> runCatching { session.cancel(); session.close() } }
+            null
         }
     }
 
@@ -510,6 +576,9 @@ class DictationRuntime internal constructor(
         val lease = sessionLease ?: return
         if (!stateMachine.tryStartTranscribing()) return
         activeToken = guard.start()
+        cloudLiveAttempt?.takeIf { it.lease === lease }?.let { attempt ->
+            runCatching { attempt.session?.endActivity() }
+        }
         pipelineTiming.start(PipelineTiming(stopTapAtMs = System.currentTimeMillis(), correlationId = correlationIdFor(activeToken)))
         armWatchdog(activeToken, lease)
         listener.onEnterTranscribingUi()
@@ -616,6 +685,7 @@ class DictationRuntime internal constructor(
     internal fun resetToIdle(expectedLease: DictationSessionLease) {
         if (sessionLease !== expectedLease) return
         try {
+            cancelCloudLiveAttempt()
             cancelWatchdog()
             guard.cancel()
             activeToken = 0
@@ -699,7 +769,7 @@ class DictationRuntime internal constructor(
                 return
             }
         }
-        continueTranscription(result, token, lease)
+        continueWithCloudLiveOrBatch(result, token, lease)
     }
 
     /** Main-thread resolution for a recording that finished without a token (#66/#90) — see
@@ -710,7 +780,7 @@ class DictationRuntime internal constructor(
     ) {
         val token = activeToken
         when (resolveLateRecording(token, guard.isCurrent(token), stateMachine.current())) {
-            LateRecordingResolution.CONTINUE_TRANSCRIPTION -> thread { continueTranscription(result, token, lease) }
+            LateRecordingResolution.CONTINUE_TRANSCRIPTION -> thread { continueWithCloudLiveOrBatch(result, token, lease) }
             LateRecordingResolution.DISCARD -> {
                 result.pcmFile?.delete()
                 result.compressedFile?.delete()
@@ -748,6 +818,9 @@ class DictationRuntime internal constructor(
             }
             val token = guard.start()
             activeToken = token
+            cloudLiveAttempt?.takeIf { it.lease === lease }?.let { attempt ->
+                runCatching { attempt.session?.endActivity() }
+            }
             // #115: max-duration auto-stop has no real user "stop tap" -- the cap itself is the
             // trigger -- so anchor the timeline here instead, at the moment this app-side decided
             // the dictation is over. drainAtMs is set to the same instant since the drain already
@@ -758,8 +831,85 @@ class DictationRuntime internal constructor(
             armWatchdog(token, lease)
             listener.onEnterTranscribingUi()
             toast("Recording limit reached (10 min) — transcribing…")
-            thread { continueTranscription(result, token, lease) }
+            thread { continueWithCloudLiveOrBatch(result, token, lease) }
         }
+    }
+
+    private fun continueWithCloudLiveOrBatch(
+        result: RecordingEngine.Result,
+        token: Int,
+        lease: DictationSessionLease,
+    ) {
+        val attempt = cloudLiveAttempt
+        if (attempt == null || attempt.lease !== lease) {
+            continueTranscription(result, token, lease)
+            return
+        }
+        handler.post {
+            if (cloudLiveAttempt !== attempt || sessionLease !== lease || !guard.isCurrent(token)) {
+                result.pcmFile?.delete()
+                result.compressedFile?.delete()
+                return@post
+            }
+            attempt.recordingResult = result
+            attempt.token = token
+            resolveCloudLiveAttempt(attempt)
+            if (!attempt.claimed && attempt.finalWait == null) {
+                val timeout = Runnable {
+                    attempt.finalWait = null
+                    if (cloudLiveAttempt === attempt && !attempt.claimed) startCloudLiveBatchFallback(attempt)
+                }
+                attempt.finalWait = timeout
+                handler.postDelayed(timeout, CLOUD_LIVE_FINAL_WAIT_MS)
+            }
+        }
+    }
+
+    /** Main-thread arbitration point: preserved PCM is owned by exactly one of live success or the
+     * unchanged batch pipeline. A terminal event alone cannot claim it until reader handoff. */
+    private fun resolveCloudLiveAttempt(attempt: CloudLiveAttempt) {
+        val result = attempt.recordingResult ?: return
+        val terminal = attempt.terminal ?: return
+        if (attempt.claimed || cloudLiveAttempt !== attempt || sessionLease !== attempt.lease) return
+        when (terminal) {
+            is CloudLiveTerminal.Success -> {
+                if (terminal.text.isBlank() || result.pcmFile == null ||
+                    isBelowMinimumDuration(result.pcmFile.length(), SAMPLE_RATE)) {
+                    startCloudLiveBatchFallback(attempt)
+                    return
+                }
+                attempt.claimed = true
+                attempt.finalWait?.let(handler::removeCallbacks)
+                attempt.finalWait = null
+                cloudLiveAttempt = null
+                runCatching { attempt.session?.close() }
+                result.pcmFile.delete()
+                result.compressedFile?.delete()
+                thread { handleTranscriptionResult(terminal.text, attempt.token, attempt.lease) }
+            }
+            is CloudLiveTerminal.Failure -> startCloudLiveBatchFallback(attempt)
+        }
+    }
+
+    private fun startCloudLiveBatchFallback(attempt: CloudLiveAttempt) {
+        val result = attempt.recordingResult ?: return
+        if (attempt.claimed || cloudLiveAttempt !== attempt || sessionLease !== attempt.lease) return
+        attempt.claimed = true
+        attempt.finalWait?.let(handler::removeCallbacks)
+        attempt.finalWait = null
+        cloudLiveAttempt = null
+        runCatching { attempt.session?.close() }
+        onCloudLiveBatchFallback()
+        thread { continueTranscription(result, attempt.token, attempt.lease) }
+    }
+
+    private fun cancelCloudLiveAttempt(attempt: CloudLiveAttempt? = cloudLiveAttempt) {
+        if (attempt == null) return
+        if (cloudLiveAttempt === attempt) cloudLiveAttempt = null
+        attempt.claimed = true
+        attempt.finalWait?.let(handler::removeCallbacks)
+        attempt.finalWait = null
+        attempt.session?.let { session -> runCatching { session.cancel(); session.close() } }
     }
 
     private fun continueTranscription(
@@ -1452,6 +1602,7 @@ class DictationRuntime internal constructor(
         }
         val lease = sessionLease
         if (recordingEngine != null) shutdownLeaseAwaitingReader = lease
+        cancelCloudLiveAttempt()
         inFlightCall.cancel()
         stateMachine.reset()
         cancelWatchdog()

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
@@ -66,6 +66,7 @@ class GeminiCloudLiveTranscriptionClient(
         private var socket: WebSocket? = null
         private var connected = false
         private var setupComplete = false
+        private var draining = false
         private var startRequested = false
         private var endRequested = false
         private var setupTimeout: ScheduledFuture<*>? = null
@@ -123,32 +124,83 @@ class GeminiCloudLiveTranscriptionClient(
             return enqueue(message)
         }
 
+        /**
+         * Appends [message] to [pending] -- the single ordering authority -- then drains the queue
+         * if no other thread already owns the drain.
+         *
+         * Nothing is ever handed straight to the socket, even after the handshake lands. A direct
+         * send would let a message enqueued *later* reach the wire ahead of one still sitting in
+         * the queue: the recorder thread's next PCM chunk used to overtake the not-yet-flushed
+         * `activityStart` while [onSetupComplete] was mid-flush, and with
+         * `automaticActivityDetection.disabled = true` the server drops audio that arrives before
+         * activityStart. Routing every message through the queue makes append order == wire order
+         * by construction, which is exactly what [CloudLiveTranscriptionSession] promises.
+         *
+         * The monitor is never held across a send: OkHttp's [WebSocket.send] enqueues onto its own
+         * writer rather than blocking on the network, but keeping it outside the lock also means a
+         * slow writer can never stall the recorder thread's next `sendPcm`.
+         */
         private fun enqueue(message: String): Boolean {
-            var sendNow: WebSocket? = null
-            synchronized(lock) {
+            val buffered = synchronized(lock) {
                 if (terminal.get()) return false
-                if (setupComplete) {
-                    sendNow = socket
+                val bytes = message.toByteArray(Charsets.UTF_8).size.toLong()
+                if (pendingBytes + bytes > MAX_PENDING_BYTES) {
+                    false // Failure is completed outside this monitor.
                 } else {
-                    val bytes = message.toByteArray(Charsets.UTF_8).size.toLong()
-                    if (pendingBytes + bytes > MAX_PENDING_BYTES) {
-                        // Failure is completed outside this monitor.
-                    } else {
-                        pending.addLast(message)
-                        pendingBytes += bytes
-                        return true
-                    }
+                    pending.addLast(message)
+                    pendingBytes += bytes
+                    true
                 }
             }
-            if (sendNow == null) {
+            if (!buffered) {
                 fail(CloudLiveFailureReason.BUFFER_LIMIT, "Live transcription outbound buffer limit reached")
                 return false
             }
-            if (sendNow!!.queueSize() > MAX_WEBSOCKET_QUEUE_BYTES || !sendNow!!.send(message)) {
-                fail(CloudLiveFailureReason.SEND_FAILED, "Live transcription send failed")
-                return false
-            }
+            drainPending()
             return true
+        }
+
+        /**
+         * Sends every queued message in FIFO order. At most one thread drains at a time; whoever
+         * loses the race simply returns, because the winner is guaranteed to pick up its message
+         * (the emptiness check that ends a drain and the `draining = false` that reopens it happen
+         * in the same critical section, so no enqueue can be stranded).
+         */
+        private fun drainPending() {
+            val owned = synchronized(lock) {
+                if (terminal.get() || !setupComplete || draining) return
+                draining = true
+                true
+            }
+            if (!owned) return
+            var failure: String? = null
+            while (true) {
+                val message = takeNextPendingOrEndDrain() ?: break
+                // A missing socket after setup is a released/never-opened connection, not a full
+                // outbound buffer -- report what actually happened.
+                val ws = synchronized(lock) { socket }
+                if (ws == null) { failure = "Live transcription socket unavailable"; break }
+                if (ws.queueSize() > MAX_WEBSOCKET_QUEUE_BYTES || !ws.send(message)) {
+                    failure = "Live transcription send failed"
+                    break
+                }
+            }
+            if (failure != null) {
+                synchronized(lock) { draining = false }
+                fail(CloudLiveFailureReason.SEND_FAILED, failure)
+            }
+        }
+
+        /** Pops the next queued message, or ends this drain (in the same critical section as the
+         *  emptiness check) and returns null. */
+        private fun takeNextPendingOrEndDrain(): String? = synchronized(lock) {
+            if (terminal.get() || pending.isEmpty()) {
+                draining = false
+                return null
+            }
+            val next = pending.removeFirst()
+            pendingBytes -= next.toByteArray(Charsets.UTF_8).size.toLong()
+            next
         }
 
         override fun cancel() = fail(CloudLiveFailureReason.CANCELLED, "Live transcription cancelled")
@@ -159,25 +211,14 @@ class GeminiCloudLiveTranscriptionClient(
         }
 
         private fun onSetupComplete() {
-            val messages: List<String>
-            val ws: WebSocket
             synchronized(lock) {
                 if (terminal.get() || setupComplete) return
                 setupComplete = true
                 timing = timing.copy(setupCompletedAtMs = nowMs())
                 setupTimeout?.cancel(false)
                 setupTimeout = null
-                ws = socket ?: return
-                messages = pending.toList()
-                pending.clear()
-                pendingBytes = 0
             }
-            for (message in messages) {
-                if (ws.queueSize() > MAX_WEBSOCKET_QUEUE_BYTES || !ws.send(message)) {
-                    fail(CloudLiveFailureReason.SEND_FAILED, "Live transcription send failed")
-                    return
-                }
-            }
+            drainPending()
             synchronized(lock) { if (endRequested && !terminal.get()) armFinalTimeoutLocked() }
         }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
@@ -1,0 +1,303 @@
+package com.trevornk.ramblr
+
+import java.util.Base64
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.ByteString
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Production Gemini 3.5 Transcribe Live WebSocket factory.
+ *
+ * Authentication uses the existing device-resident Gemini API key in an HTTP header, never a URL.
+ * OkHttp invokes socket methods off-main; listener callbacks are serialized on [callbackExecutor]
+ * (also off-main by default). The runtime is responsible for explicitly hopping UI work to main.
+ */
+class GeminiCloudLiveTranscriptionClient(
+    private val httpClient: OkHttpClient = NetworkClients.shared,
+    // OkHttp's WebSocket API accepts an HTTPS HttpUrl and performs the WSS upgrade itself.
+    private val endpoint: HttpUrl = DEFAULT_HTTP_ENDPOINT.toHttpUrl(),
+    private val apiKey: String,
+    private val model: String = DEFAULT_MODEL,
+    private val languageCodes: List<String> = emptyList(),
+    private val customVocabulary: List<String> = emptyList(),
+    callbackExecutor: Executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "GeminiLive-callback").apply { isDaemon = true }
+    },
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "GeminiLive-timeout").apply { isDaemon = true }
+    },
+    private val setupTimeoutMs: Long = DEFAULT_SETUP_TIMEOUT_MS,
+    private val finalTimeoutMs: Long = DEFAULT_FINAL_TIMEOUT_MS,
+    private val nowMs: () -> Long = System::currentTimeMillis,
+    internal val allowTestEndpoint: Boolean = false,
+) : CloudLiveTranscriptionSessionFactory {
+    private val callbacks = SerialCallbackExecutor(callbackExecutor)
+
+    init {
+        require(endpoint.scheme == "https" || (allowTestEndpoint && endpoint.scheme == "http"))
+        require(endpoint.encodedPath == ENDPOINT_PATH && endpoint.query == null && endpoint.fragment == null) { "Unexpected Gemini Live endpoint" }
+        require(allowTestEndpoint || endpoint.host == GEMINI_HOST) { "Unexpected Gemini Live host" }
+        require(apiKey.isNotBlank()) { "Gemini API key is blank" }
+        require(MODEL_ID.matches(model) && model == DEFAULT_MODEL) { "Invalid Gemini Live model id" }
+        require(languageCodes.all(LANGUAGE_CODE::matches)) { "Invalid language code" }
+        require(customVocabulary.size <= MAX_CUSTOM_VOCABULARY && customVocabulary.none { it.isBlank() }) { "Invalid custom vocabulary" }
+        require(setupTimeoutMs > 0 && finalTimeoutMs > 0)
+    }
+
+    override fun create(listener: CloudLiveTranscriptionListener): CloudLiveTranscriptionSession = Session(listener)
+
+    private inner class Session(private val listener: CloudLiveTranscriptionListener) : CloudLiveTranscriptionSession {
+        private val lock = Any()
+        private val terminal = AtomicBoolean(false)
+        private val pending = ArrayDeque<String>()
+        private var pendingBytes = 0L
+        private var socket: WebSocket? = null
+        private var connected = false
+        private var setupComplete = false
+        private var startRequested = false
+        private var endRequested = false
+        private var setupTimeout: ScheduledFuture<*>? = null
+        private var finalTimeout: ScheduledFuture<*>? = null
+        private var timing = CloudLiveTiming(connectStartedAtMs = nowMs())
+
+        override fun connect() {
+            synchronized(lock) {
+                if (connected || terminal.get()) return
+                connected = true
+                timing = timing.copy(connectStartedAtMs = nowMs())
+                setupTimeout = scheduler.schedule(
+                    { fail(CloudLiveFailureReason.SETUP_TIMEOUT, "Live transcription setup timed out") },
+                    setupTimeoutMs,
+                    TimeUnit.MILLISECONDS,
+                )
+                val request = Request.Builder().url(endpoint).header(API_KEY_HEADER, apiKey).build()
+                socket = httpClient.newWebSocket(request, SocketListener())
+            }
+        }
+
+        override fun startActivity(): Boolean = enqueueControl(activityStartJson(), isStart = true)
+
+        override fun sendPcm(buffer: ByteArray, length: Int): Boolean {
+            if (length < 0 || length > buffer.size) {
+                fail(CloudLiveFailureReason.INVALID_REQUEST, "Invalid PCM length")
+                return false
+            }
+            val copy = buffer.copyOf(length)
+            val encoded = Base64.getEncoder().encodeToString(copy)
+            val message = audioJson(encoded)
+            return enqueue(message)
+        }
+
+        override fun endActivity(): Boolean {
+            val accepted = enqueueControl(activityEndJson(), isStart = false)
+            if (accepted) synchronized(lock) {
+                timing = timing.copy(activityEndedAtMs = nowMs())
+                if (setupComplete) armFinalTimeoutLocked()
+            }
+            return accepted
+        }
+
+        private fun enqueueControl(message: String, isStart: Boolean): Boolean {
+            synchronized(lock) {
+                if (terminal.get()) return false
+                if (isStart) {
+                    if (startRequested || endRequested) return false
+                    startRequested = true
+                } else {
+                    if (!startRequested || endRequested) return false
+                    endRequested = true
+                }
+            }
+            return enqueue(message)
+        }
+
+        private fun enqueue(message: String): Boolean {
+            var sendNow: WebSocket? = null
+            synchronized(lock) {
+                if (terminal.get()) return false
+                if (setupComplete) {
+                    sendNow = socket
+                } else {
+                    val bytes = message.toByteArray(Charsets.UTF_8).size.toLong()
+                    if (pendingBytes + bytes > MAX_PENDING_BYTES) {
+                        // Failure is completed outside this monitor.
+                    } else {
+                        pending.addLast(message)
+                        pendingBytes += bytes
+                        return true
+                    }
+                }
+            }
+            if (sendNow == null) {
+                fail(CloudLiveFailureReason.BUFFER_LIMIT, "Live transcription outbound buffer limit reached")
+                return false
+            }
+            if (sendNow!!.queueSize() > MAX_WEBSOCKET_QUEUE_BYTES || !sendNow!!.send(message)) {
+                fail(CloudLiveFailureReason.SEND_FAILED, "Live transcription send failed")
+                return false
+            }
+            return true
+        }
+
+        override fun cancel() = fail(CloudLiveFailureReason.CANCELLED, "Live transcription cancelled")
+
+        override fun close() {
+            if (!terminal.get()) cancel()
+            synchronized(lock) { socket?.close(NORMAL_CLOSE, "done") }
+        }
+
+        private fun onSetupComplete() {
+            val messages: List<String>
+            val ws: WebSocket
+            synchronized(lock) {
+                if (terminal.get() || setupComplete) return
+                setupComplete = true
+                timing = timing.copy(setupCompletedAtMs = nowMs())
+                setupTimeout?.cancel(false)
+                setupTimeout = null
+                ws = socket ?: return
+                messages = pending.toList()
+                pending.clear()
+                pendingBytes = 0
+            }
+            for (message in messages) {
+                if (ws.queueSize() > MAX_WEBSOCKET_QUEUE_BYTES || !ws.send(message)) {
+                    fail(CloudLiveFailureReason.SEND_FAILED, "Live transcription send failed")
+                    return
+                }
+            }
+            synchronized(lock) { if (endRequested && !terminal.get()) armFinalTimeoutLocked() }
+        }
+
+        private fun armFinalTimeoutLocked() {
+            if (finalTimeout != null) return
+            finalTimeout = scheduler.schedule(
+                { fail(CloudLiveFailureReason.FINAL_TIMEOUT, "Live transcription final timed out") },
+                finalTimeoutMs,
+                TimeUnit.MILLISECONDS,
+            )
+        }
+
+        private fun onText(text: String) {
+            if (text.toByteArray(Charsets.UTF_8).size > MAX_INBOUND_BYTES) {
+                fail(CloudLiveFailureReason.PROTOCOL_ERROR, "Live transcription message too large")
+                return
+            }
+            val root = try { JSONObject(text) } catch (_: Exception) {
+                fail(CloudLiveFailureReason.PROTOCOL_ERROR, "Malformed live transcription event")
+                return
+            }
+            root.optJSONObject("error")?.let {
+                fail(CloudLiveFailureReason.PROTOCOL_ERROR, it.optString("message").ifBlank { "Gemini Live error" })
+                return
+            }
+            if (root.has("setupComplete")) {
+                onSetupComplete()
+                return
+            }
+            val content = root.optJSONObject("serverContent") ?: return
+            content.optJSONObject("interimInputTranscription")?.optString("text")?.takeIf { it.isNotBlank() }?.let { interim ->
+                val snapshot = synchronized(lock) {
+                    if (terminal.get()) return@let
+                    if (timing.firstInterimAtMs == null) timing = timing.copy(firstInterimAtMs = nowMs())
+                    timing
+                }
+                callbacks.execute { if (!terminal.get()) listener.onInterim(interim, snapshot) }
+            }
+            content.optJSONObject("inputTranscription")?.optString("text")?.trim()?.takeIf { it.isNotBlank() }?.let(::succeed)
+        }
+
+        private fun succeed(text: String) {
+            val result = synchronized(lock) {
+                timing = timing.copy(finalAtMs = nowMs())
+                CloudLiveTerminal.Success(text, timing)
+            }
+            complete(result)
+        }
+
+        private fun fail(reason: CloudLiveFailureReason, message: String) {
+            val safe = UrlRedaction.redact(message.replace(apiKey, "[REDACTED]"))
+                ?: "Live transcription failed"
+            val result = synchronized(lock) { CloudLiveTerminal.Failure(reason, safe, timing) }
+            complete(result)
+        }
+
+        private fun complete(result: CloudLiveTerminal) {
+            if (!terminal.compareAndSet(false, true)) return
+            synchronized(lock) {
+                setupTimeout?.cancel(false); setupTimeout = null
+                finalTimeout?.cancel(false); finalTimeout = null
+                pending.clear(); pendingBytes = 0
+                socket?.close(NORMAL_CLOSE, "done")
+            }
+            callbacks.execute { listener.onTerminal(result) }
+        }
+
+        private inner class SocketListener : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                synchronized(lock) { timing = timing.copy(socketOpenedAtMs = nowMs()) }
+                if (!webSocket.send(setupJson(model, languageCodes, customVocabulary))) {
+                    fail(CloudLiveFailureReason.SEND_FAILED, "Live transcription setup send failed")
+                }
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) = onText(text)
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                fail(CloudLiveFailureReason.PROTOCOL_ERROR, "Unexpected binary live transcription event")
+            }
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                fail(CloudLiveFailureReason.NETWORK_ERROR, t.message ?: "Live transcription network failure")
+            }
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                if (!terminal.get()) fail(CloudLiveFailureReason.NETWORK_ERROR, "Live transcription connection closed")
+            }
+        }
+    }
+
+    companion object {
+        const val DEFAULT_MODEL = "gemini-3.5-transcribe-live"
+        const val ENDPOINT_PATH = "/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+        const val GEMINI_HOST = "generativelanguage.googleapis.com"
+        const val DEFAULT_WSS_ENDPOINT = "wss://$GEMINI_HOST$ENDPOINT_PATH"
+        internal const val DEFAULT_HTTP_ENDPOINT = "https://$GEMINI_HOST$ENDPOINT_PATH"
+        const val MAX_CUSTOM_VOCABULARY = 1000
+        const val DEFAULT_SETUP_TIMEOUT_MS = 10_000L
+        const val DEFAULT_FINAL_TIMEOUT_MS = 2_000L
+        const val MAX_PENDING_BYTES = 2L * 1024 * 1024
+        const val MAX_WEBSOCKET_QUEUE_BYTES = 4L * 1024 * 1024
+        const val MAX_INBOUND_BYTES = 256 * 1024
+        private const val API_KEY_HEADER = "x-goog-api-key"
+        private const val NORMAL_CLOSE = 1000
+        private val MODEL_ID = Regex("[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+        private val LANGUAGE_CODE = Regex("[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*")
+
+        fun setupJson(model: String, languageCodes: List<String>, customVocabulary: List<String>): String =
+            JSONObject().put("setup", JSONObject()
+                .put("model", "models/$model")
+                .put("generationConfig", JSONObject().put("responseModalities", JSONArray().put("TEXT")))
+                .put("inputAudioTranscription", JSONObject()
+                    .put("languageCodes", JSONArray(languageCodes))
+                    .put("customVocabulary", JSONArray(customVocabulary))
+                    .put("mode", "VERBATIM"))
+                .put("realtimeInputConfig", JSONObject().put("automaticActivityDetection", JSONObject().put("disabled", true))))
+                .toString()
+
+        private fun activityStartJson() = JSONObject().put("realtimeInput", JSONObject().put("activityStart", JSONObject())).toString()
+        private fun activityEndJson() = JSONObject().put("realtimeInput", JSONObject().put("activityEnd", JSONObject())).toString()
+        private fun audioJson(base64: String) = JSONObject().put("realtimeInput", JSONObject().put("audio", JSONObject()
+            .put("data", base64)
+            .put("mimeType", "audio/pcm;rate=16000"))).toString()
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/ImePanelController.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ImePanelController.kt
@@ -166,6 +166,9 @@ internal class ImePanelController(
         override fun onIdleUi() { if (active) renderState(ImeUiState.IDLE) }
         override fun onStreamingTeardown() = Unit
         override fun onStreamingPartial(text: String) { if (active) renderPartial(text) }
+        override fun onCloudLiveInterim(text: String) {
+            if (active && deliveryTicket != null && latestUiTicket === deliveryTicket) renderPartial(text)
+        }
         override fun onUserMessage(message: String) {
             if (!active) return
             renderState(ImeUiState.ERROR)

--- a/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
@@ -5,6 +5,10 @@ import android.app.Application
 import android.os.Looper
 import java.io.File
 import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -45,6 +49,7 @@ class DictationRuntimeTest {
     private lateinit var engines: MutableList<FakeRecordingEngine>
     private lateinit var leaseRegistry: InMemoryDictationSessionLeaseRegistry
     private lateinit var runtime: DictationRuntime
+    private lateinit var batchServer: MockWebServer
 
     /** Records every listener callback in arrival order, so ordering assertions are direct. */
     private class RecordingListener : RuntimeListener {
@@ -135,9 +140,15 @@ class DictationRuntimeTest {
         listener = RecordingListener()
         engines = mutableListOf()
         leaseRegistry = InMemoryDictationSessionLeaseRegistry()
+        batchServer = MockWebServer().apply { start() }
         runtime = DictationRuntime(app, listener, leaseRegistry) { cacheDir, stateMachine ->
             FakeRecordingEngine(cacheDir, stateMachine).also { engines += it }
         }
+    }
+
+    @After
+    fun tearDown() {
+        batchServer.shutdown()
     }
 
     private fun idleMainLooper() = shadowOf(Looper.getMainLooper()).idle()
@@ -658,40 +669,12 @@ class DictationRuntimeTest {
         assertEquals(listOf("hello live"), listener.delivered.map { it.text })
         assertEquals(0, fallbacks)
         assertFalse(pcm.exists())
+        assertTrue("a claimed live success must release the socket", session.closes >= 1)
         assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
         session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.NETWORK_ERROR, "late", CloudLiveTiming(1)))
         idleMainLooper()
         assertEquals(1, listener.delivered.size)
         assertEquals(0, fallbacks)
-    }
-
-    @Test
-    fun `live failure keeps preserved pcm and starts existing batch fallback exactly once`() {
-        val liveFactory = FakeCloudLiveFactory()
-        var fallbacks = 0
-        runtime = DictationRuntime(
-            app, listener, leaseRegistry,
-            cloudLiveFactory = liveFactory,
-            onCloudLiveBatchFallback = { fallbacks++ },
-        ) { cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it } }
-        val pcm = realSizedPcm()
-
-        runtime.onTap(); runtime.onTap()
-        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
-        val session = liveFactory.sessions.single()
-        session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.NETWORK_ERROR, "drop", CloudLiveTiming(1)))
-
-        val deadline = System.currentTimeMillis() + 5_000
-        while (System.currentTimeMillis() < deadline && runtime.currentState() != RecordingStateMachine.State.IDLE) {
-            idleMainLooper(); Thread.sleep(10)
-        }
-        assertEquals(1, fallbacks)
-        assertFalse(pcm.exists())
-        assertTrue(listener.delivered.isEmpty())
-        session.complete(CloudLiveTerminal.Success("late", CloudLiveTiming(1, finalAtMs = 2)))
-        idleMainLooper()
-        assertEquals(1, fallbacks)
-        assertTrue(listener.delivered.isEmpty())
     }
 
     @Test
@@ -742,6 +725,255 @@ class DictationRuntimeTest {
         assertTrue(listener.delivered.isEmpty())
     }
 
+    // --- cloud-live attempt lifetime: no exit path may orphan an authenticated socket ---
+
+    /**
+     * Every path that abandons a recording without going through [DictationRuntime.resetToIdle]
+     * used to leave `cloudLiveAttempt` untouched. That is not a benign leak: `setupTimeout` is
+     * cancelled once setup lands and `finalTimeout` is only armed by `endActivity()`, so an
+     * abandoned attempt has NEITHER timeout armed and nothing ever calls `close()`/`cancel()` --
+     * an authenticated WSS carrying the user's microphone audio stays open with no reference
+     * held anywhere, one per cycle.
+     */
+    private fun cloudLiveRuntime(liveFactory: FakeCloudLiveFactory, onFallback: () -> Unit = {}) {
+        runtime = DictationRuntime(
+            app, listener, leaseRegistry,
+            cloudLiveFactory = liveFactory,
+            onCloudLiveBatchFallback = onFallback,
+        ) { cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it } }
+    }
+
+    @Test
+    fun `discarded reader handoff cancels the cloud live session instead of orphaning it`() {
+        val liveFactory = FakeCloudLiveFactory()
+        cloudLiveRuntime(liveFactory)
+
+        runtime.onTap()
+        val session = liveFactory.sessions.single()
+        // A superseded reader drain takes onRecordingFinished's `result.discarded` early return:
+        // the lease is released and the method returns without ever touching the attempt.
+        engines.single().finishAs(realSizedPcm(), RecordingEngine.StopReason.USER, superseded = true)
+        idleMainLooper()
+
+        assertEquals("the abandoned live session must be cancelled", 1, session.cancels)
+        assertTrue("and its socket closed", session.closes >= 1)
+    }
+
+    @Test
+    fun `late recording resolved as discard cancels the cloud live session`() {
+        val liveFactory = FakeCloudLiveFactory()
+        cloudLiveRuntime(liveFactory)
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = liveFactory.sessions.single()
+        // Reader drains with no token yet (#66), so resolution is posted to main...
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        // ...and before it runs, a non-serialized host teardown resets the state machine and the
+        // guard without going through resetToIdle, so the resolution lands on DISCARD.
+        runtime.finishShutdownAndReleaseTranscribers()
+        idleMainLooper()
+
+        assertFalse("discarded audio is still deleted", pcm.exists())
+        assertEquals("the abandoned live session must be cancelled", 1, session.cancels)
+    }
+
+    @Test
+    fun `cloud live handoff that arrives too late to be claimed cancels its session`() {
+        val liveFactory = FakeCloudLiveFactory()
+        cloudLiveRuntime(liveFactory)
+        val pcm = realSizedPcm()
+
+        runtime.onTap(); runtime.onTap() // TRANSCRIBING, token 1
+        val session = liveFactory.sessions.single()
+        // Reader handoff posts continueWithCloudLiveOrBatch's main-thread arbitration...
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        // ...and the lease/guard go stale underneath it, so it takes the discard branch with
+        // cloudLiveAttempt still pointing at this attempt and no finalWait ever armed.
+        runtime.finishShutdownAndReleaseTranscribers()
+        idleMainLooper()
+
+        assertFalse(pcm.exists())
+        assertEquals("the permanently-inert attempt must be cancelled", 1, session.cancels)
+    }
+
+    @Test
+    fun `max duration auto stop that cannot mint a token cancels the cloud live session`() {
+        val liveFactory = FakeCloudLiveFactory()
+        cloudLiveRuntime(liveFactory)
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = liveFactory.sessions.single()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.MAX_DURATION)
+        runtime.finishShutdownAndReleaseTranscribers()
+        idleMainLooper()
+
+        assertFalse(pcm.exists())
+        assertEquals("the abandoned live session must be cancelled", 1, session.cancels)
+    }
+
+    @Test
+    fun `max duration auto stop with cloud live active ends activity and delivers the live final`() {
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        cloudLiveRuntime(liveFactory) { fallbacks++ }
+        val pcm = realSizedPcm()
+
+        runtime.onTap() // RECORDING; no stop tap -- the duration cap is the trigger
+        val session = liveFactory.sessions.single()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.MAX_DURATION)
+        idleMainLooper() // main-thread token mint + endActivity + transcribing UI
+
+        assertTrue(listener.events.contains("transcribingUi"))
+        assertEquals("the cap must end the live activity, exactly as a stop tap does", 1, session.ends)
+
+        session.complete(CloudLiveTerminal.Success("capped live", CloudLiveTiming(1, finalAtMs = 2)))
+        awaitDelivery()
+
+        assertEquals(listOf("capped live"), listener.delivered.map { it.text })
+        assertEquals(0, fallbacks)
+        assertFalse(pcm.exists())
+        assertTrue("a claimed live success must release the socket", session.closes >= 1)
+        assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
+    }
+
+    @Test
+    fun `a restart after an abandoned recording never leaves the incumbent attempt uncancelled`() {
+        val liveFactory = FakeCloudLiveFactory()
+        cloudLiveRuntime(liveFactory)
+
+        runtime.onTap()
+        val first = liveFactory.sessions.single()
+        // Abandon this recording down a path that does NOT funnel through resetToIdle: the reader
+        // drains tokenless, the machine is already back at IDLE, so resolution lands on DISCARD
+        // and the lease is released with the attempt untouched.
+        engines.single().finishAs(realSizedPcm(), RecordingEngine.StopReason.USER)
+        runtime.finishShutdownAndReleaseTranscribers()
+        idleMainLooper()
+
+        // The next dictation overwrites `cloudLiveAttempt`; whatever the incumbent was, it must
+        // already have been cancelled rather than having its last reference silently dropped.
+        runtime.onTap()
+        idleMainLooper()
+        assertEquals(2, liveFactory.sessions.size)
+        val second = liveFactory.sessions.last()
+
+        assertEquals("the superseded attempt must never outlive the restart", 1, first.cancels)
+        assertEquals("and the new one must still be live", 0, second.cancels)
+    }
+
+    private fun awaitDelivery() {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline && listener.delivered.isEmpty()) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun `live failure keeps preserved pcm and the batch fallback actually delivers its transcript`() {
+        // The point of the fallback is that the preserved PCM reaches a real batch call -- a
+        // fallback counter alone would pass just as happily if the handover had passed a deleted
+        // file, a stale lease or a superseded token. Stub a provider and assert the transcript.
+        stubBatchProvider("batch rescue")
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        cloudLiveRuntime(liveFactory) { fallbacks++ }
+        val pcm = realSizedPcm()
+
+        runtime.onTap(); runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        val session = liveFactory.sessions.single()
+        session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.NETWORK_ERROR, "drop", CloudLiveTiming(1)))
+        awaitDelivery()
+
+        assertEquals(1, fallbacks)
+        assertEquals(listOf("batch rescue"), listener.delivered.map { it.text })
+        assertFalse("the batch call consumed and deleted the preserved PCM", pcm.exists())
+        assertTrue("the abandoned live socket must be released", session.closes >= 1)
+        awaitIdle()
+
+        // A late live success cannot resurrect a second delivery.
+        session.complete(CloudLiveTerminal.Success("late", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        assertEquals(1, fallbacks)
+        assertEquals(1, listener.delivered.size)
+    }
+
+    @Test
+    fun `a live terminal arriving before the reader handoff is resolved by the handoff itself`() {
+        // Both existing tests call finishAs before complete(), so resolveCloudLiveAttempt is only
+        // ever re-entered from onTerminal. This is the other ordering: the terminal lands first
+        // and parks, and continueWithCloudLiveOrBatch's own resolve call is what claims it.
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        cloudLiveRuntime(liveFactory) { fallbacks++ }
+        val pcm = realSizedPcm()
+
+        runtime.onTap(); runtime.onTap()
+        val session = liveFactory.sessions.single()
+        session.complete(CloudLiveTerminal.Success("early final", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        assertTrue("a terminal alone cannot claim before reader handoff", listener.delivered.isEmpty())
+
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        awaitDelivery()
+
+        assertEquals(listOf("early final"), listener.delivered.map { it.text })
+        assertEquals(0, fallbacks)
+        assertFalse(pcm.exists())
+        assertTrue(session.closes >= 1)
+        awaitIdle()
+    }
+
+    @Test
+    fun `a terminal landing as the final wait expires still yields exactly one delivery`() {
+        stubBatchProvider("batch rescue")
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        cloudLiveRuntime(liveFactory) { fallbacks++ }
+        val pcm = realSizedPcm()
+
+        runtime.onTap(); runtime.onTap()
+        val session = liveFactory.sessions.single()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        idleMainLooper() // arms the bounded final wait
+
+        // The wait expires and the live final lands in the same main-looper turn: whichever wins,
+        // exactly one of them may claim the preserved PCM.
+        shadowOf(Looper.getMainLooper()).idleFor(2_501, TimeUnit.MILLISECONDS)
+        session.complete(CloudLiveTerminal.Success("racing final", CloudLiveTiming(1, finalAtMs = 2)))
+        awaitDelivery()
+        awaitIdle()
+
+        assertEquals("the timeout claimed it; the live final must not double-deliver", 1, fallbacks)
+        assertEquals(listOf("batch rescue"), listener.delivered.map { it.text })
+        assertFalse(pcm.exists())
+    }
+
+    /** Points the batch pipeline at a MockWebServer returning [transcript], so the fallback's
+     *  handover is proven by a real delivery instead of an empty-delivery tautology. */
+    private fun stubBatchProvider(transcript: String) {
+        batchServer.enqueue(MockResponse().setBody(JSONObject().put("text", transcript).toString()))
+        val base = batchServer.url("/v1").toString().trimEnd('/')
+        ProviderChainStore.save(
+            app,
+            ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-mini", baseUrlOverride = base, transcriptionModel = "gpt-transcribe"))),
+        )
+        ProviderCredentialStore.set(app, ProviderKind.OPENAI, "test-batch-key")
+        app.getSharedPreferences("ramblr", android.content.Context.MODE_PRIVATE).edit()
+            .putBoolean("use_local", false).apply()
+        PostProcessingToggle.setEnabled(app, false)
+    }
+
+    private fun awaitIdle() {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline && runtime.currentState() != RecordingStateMachine.State.IDLE) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+        assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
+    }
+
     private class FakeCloudLiveFactory : CloudLiveTranscriptionSessionFactory {
         val sessions = mutableListOf<FakeCloudLiveSession>()
         var acceptPcm = true
@@ -757,6 +989,7 @@ class DictationRuntimeTest {
         var starts = 0
         var ends = 0
         var cancels = 0
+        var closes = 0
         var lastSendAccepted = true
         val pcm = mutableListOf<ByteArray>()
         override fun connect() { connects++ }
@@ -768,7 +1001,7 @@ class DictationRuntimeTest {
         }
         override fun endActivity(): Boolean { ends++; return true }
         override fun cancel() { cancels++ }
-        override fun close() = Unit
+        override fun close() { closes++ }
         fun interim(text: String) = listener.onInterim(text, CloudLiveTiming(1, firstInterimAtMs = 2))
         fun complete(result: CloudLiveTerminal) = listener.onTerminal(result)
     }

--- a/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/DictationRuntimeTest.kt
@@ -4,6 +4,8 @@ import android.Manifest
 import android.app.Application
 import android.os.Looper
 import java.io.File
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -68,6 +70,7 @@ class DictationRuntimeTest {
             streamingTeardownLoopers += Looper.myLooper()
         }
         override fun onStreamingPartial(text: String) { events += "partial:$text" }
+        override fun onCloudLiveInterim(text: String) { events += "cloud:$text" }
         override fun deliverText(
             text: String,
             rawText: String?,
@@ -617,5 +620,156 @@ class DictationRuntimeTest {
         stalledEngine.finishAs(null, RecordingEngine.StopReason.USER, superseded = true)
         contender.onTap()
         assertEquals(RecordingStateMachine.State.RECORDING, contender.currentState())
+    }
+
+    @Test
+    fun `authoritative live final uses existing delivery path and suppresses batch exactly once`() {
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        runtime = DictationRuntime(
+            app, listener, leaseRegistry,
+            cloudLiveFactory = liveFactory,
+            onCloudLiveBatchFallback = { fallbacks++ },
+        ) { cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it } }
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = liveFactory.sessions.single()
+        assertEquals(1, session.connects)
+        assertEquals(1, session.starts)
+        val reused = byteArrayOf(1, 2, 3, 4)
+        engines.single().onChunk!!(reused, 3)
+        reused.fill(9)
+        assertArrayEquals(byteArrayOf(1, 2, 3), session.pcm.single())
+        session.interim("hel")
+        idleMainLooper()
+        assertTrue(listener.events.contains("cloud:hel"))
+
+        runtime.onTap()
+        assertEquals(1, session.ends)
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(CloudLiveTerminal.Success("hello live", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        val deliveryDeadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deliveryDeadline && listener.delivered.isEmpty()) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+
+        assertEquals(listOf("hello live"), listener.delivered.map { it.text })
+        assertEquals(0, fallbacks)
+        assertFalse(pcm.exists())
+        assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
+        session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.NETWORK_ERROR, "late", CloudLiveTiming(1)))
+        idleMainLooper()
+        assertEquals(1, listener.delivered.size)
+        assertEquals(0, fallbacks)
+    }
+
+    @Test
+    fun `live failure keeps preserved pcm and starts existing batch fallback exactly once`() {
+        val liveFactory = FakeCloudLiveFactory()
+        var fallbacks = 0
+        runtime = DictationRuntime(
+            app, listener, leaseRegistry,
+            cloudLiveFactory = liveFactory,
+            onCloudLiveBatchFallback = { fallbacks++ },
+        ) { cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it } }
+        val pcm = realSizedPcm()
+
+        runtime.onTap(); runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        val session = liveFactory.sessions.single()
+        session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.NETWORK_ERROR, "drop", CloudLiveTiming(1)))
+
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline && runtime.currentState() != RecordingStateMachine.State.IDLE) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+        assertEquals(1, fallbacks)
+        assertFalse(pcm.exists())
+        assertTrue(listener.delivered.isEmpty())
+        session.complete(CloudLiveTerminal.Success("late", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        assertEquals(1, fallbacks)
+        assertTrue(listener.delivered.isEmpty())
+    }
+
+    @Test
+    fun `live send failure without callback reaches bounded preserved pcm fallback once`() {
+        val liveFactory = FakeCloudLiveFactory().apply { acceptPcm = false }
+        var fallbacks = 0
+        runtime = DictationRuntime(
+            app, listener, leaseRegistry,
+            cloudLiveFactory = liveFactory,
+            onCloudLiveBatchFallback = { fallbacks++ },
+        ) { cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it } }
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        engines.single().onChunk!!(byteArrayOf(1, 2), 2)
+        assertFalse(liveFactory.sessions.single().lastSendAccepted)
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        idleMainLooper()
+        shadowOf(Looper.getMainLooper()).idleFor(2_501, TimeUnit.MILLISECONDS)
+
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline && runtime.currentState() != RecordingStateMachine.State.IDLE) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+        assertEquals(1, fallbacks)
+        assertFalse(pcm.exists())
+        liveFactory.sessions.single().complete(CloudLiveTerminal.Success("late", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        assertEquals(1, fallbacks)
+        assertTrue(listener.delivered.isEmpty())
+    }
+
+    @Test
+    fun `shutdown cancels cloud live session before late callbacks`() {
+        val liveFactory = FakeCloudLiveFactory()
+        runtime = DictationRuntime(app, listener, leaseRegistry, cloudLiveFactory = liveFactory) {
+            cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it }
+        }
+        runtime.onTap()
+        val session = liveFactory.sessions.single()
+        runtime.beginShutdown()
+        assertEquals(1, session.cancels)
+        session.interim("late")
+        session.complete(CloudLiveTerminal.Success("late", CloudLiveTiming(1, finalAtMs = 2)))
+        idleMainLooper()
+        assertFalse(listener.events.contains("cloud:late"))
+        assertTrue(listener.delivered.isEmpty())
+    }
+
+    private class FakeCloudLiveFactory : CloudLiveTranscriptionSessionFactory {
+        val sessions = mutableListOf<FakeCloudLiveSession>()
+        var acceptPcm = true
+        override fun create(listener: CloudLiveTranscriptionListener): CloudLiveTranscriptionSession =
+            FakeCloudLiveSession(listener, acceptPcm).also(sessions::add)
+    }
+
+    private class FakeCloudLiveSession(
+        private val listener: CloudLiveTranscriptionListener,
+        private val acceptPcm: Boolean,
+    ) : CloudLiveTranscriptionSession {
+        var connects = 0
+        var starts = 0
+        var ends = 0
+        var cancels = 0
+        var lastSendAccepted = true
+        val pcm = mutableListOf<ByteArray>()
+        override fun connect() { connects++ }
+        override fun startActivity(): Boolean { starts++; return true }
+        override fun sendPcm(buffer: ByteArray, length: Int): Boolean {
+            pcm += buffer.copyOf(length)
+            lastSendAccepted = acceptPcm
+            return acceptPcm
+        }
+        override fun endActivity(): Boolean { ends++; return true }
+        override fun cancel() { cancels++ }
+        override fun close() = Unit
+        fun interim(text: String) = listener.onInterim(text, CloudLiveTiming(1, firstInterimAtMs = 2))
+        fun complete(result: CloudLiveTerminal) = listener.onTerminal(result)
     }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
@@ -1,12 +1,15 @@
 package com.trevornk.ramblr
 
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okio.ByteString
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
@@ -21,6 +24,7 @@ import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 
 class GeminiCloudLiveTranscriptionClientTest {
@@ -170,6 +174,135 @@ class GeminiCloudLiveTranscriptionClientTest {
         assertEquals(CloudLiveFailureReason.FINAL_TIMEOUT, (finalListener.result as CloudLiveTerminal.Failure).reason)
     }
 
+    /**
+     * The blocker this covers: `onSetupComplete` used to flip `setupComplete` and snapshot the
+     * buffered queue inside the lock, then flush OUTSIDE it. A recorder-thread `sendPcm` landing
+     * in that window saw `setupComplete == true`, took the direct-send branch, and reached the
+     * socket AHEAD of the still-unflushed `activityStart`. With
+     * `automaticActivityDetection.disabled = true` that audio is dropped by the server, so the
+     * ordering contract in [CloudLiveTranscriptionSession] is load-bearing, not cosmetic.
+     *
+     * The existing wire-order test drives everything from one thread and cannot see this; this
+     * one holds the flush open inside the fake socket's `send` and pumps a second chunk from
+     * another thread while the drain is suspended mid-flight.
+     */
+    @Test fun `pcm enqueued while the handshake flush is mid drain cannot overtake activity start`() {
+        val socket = GatedWebSocket(gateOn = "activityStart")
+        val client = FakeWebSocketClient(socket)
+        val listener = RecordingListener()
+        val session = factory(httpClient = client, setupTimeoutMs = 30_000).create(listener)
+
+        session.connect()
+        val socketListener = requireNotNull(client.socketListener) { "connect() must open a socket" }
+        socketListener.onOpen(socket, upgradeResponse())
+        assertTrue(session.startActivity())
+        assertTrue(session.sendPcm(byteArrayOf(1), 1)) // "AQ=="
+
+        // OkHttp's reader thread delivers setupComplete; the fake socket suspends the drain
+        // exactly where the real one would be waiting on the network for activityStart.
+        val flusher = Thread({ socketListener.onMessage(socket, "{\"setupComplete\":{}}") }, "flush")
+        flusher.start()
+        assertTrue("flush must reach activityStart", socket.gateReached.await(5, TimeUnit.SECONDS))
+
+        // ...and the recorder thread pumps its next chunk right into that window.
+        val pump = Thread({ assertTrue(session.sendPcm(byteArrayOf(2), 1)) }, "recorder") // "Ag=="
+        pump.start()
+        pump.join(5_000)
+        assertFalse("sendPcm must never block on the flush", pump.isAlive)
+
+        socket.releaseGate.countDown()
+        flusher.join(5_000)
+        assertFalse(flusher.isAlive)
+        socket.awaitSent(4)
+
+        assertEquals(
+            listOf("setup", "activityStart", "audio:AQ==", "audio:Ag=="),
+            socket.sent.map(::wireKind),
+        )
+        session.cancel()
+    }
+
+    /**
+     * BUFFER_LIMIT must mean what it says. It used to also be reported when the post-handshake
+     * direct-send branch found a null socket -- a released/never-opened connection, not a full
+     * outbound buffer -- which is now [CloudLiveFailureReason.SEND_FAILED] with its own message.
+     * This pins the genuinely-reachable direction: pre-handshake buffering really does overflow.
+     */
+    @Test fun `outbound buffer overflow before the handshake reports buffer limit`() {
+        val socket = GatedWebSocket(gateOn = "\u0000never")
+        val client = FakeWebSocketClient(socket)
+        val listener = RecordingListener()
+        val session = factory(httpClient = client, setupTimeoutMs = 30_000).create(listener)
+
+        session.connect()
+        socket.let { client.socketListener!!.onOpen(it, upgradeResponse()) }
+        assertTrue(session.startActivity())
+
+        // Nothing has been flushed yet (no setupComplete), so these accumulate against the 2MB cap.
+        val chunk = ByteArray(768 * 1024)
+        assertTrue("first chunk fits under the cap", session.sendPcm(chunk, chunk.size))
+        assertFalse("the second overflows it", session.sendPcm(chunk, chunk.size))
+
+        assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+        val failure = listener.result as CloudLiveTerminal.Failure
+        assertEquals(CloudLiveFailureReason.BUFFER_LIMIT, failure.reason)
+        assertTrue(failure.message.contains("buffer limit"))
+    }
+
+    private fun wireKind(message: String): String {
+        val root = JSONObject(message)
+        if (root.has("setup")) return "setup"
+        val realtime = root.getJSONObject("realtimeInput")
+        return when {
+            realtime.has("activityStart") -> "activityStart"
+            realtime.has("activityEnd") -> "activityEnd"
+            else -> "audio:" + realtime.getJSONObject("audio").getString("data")
+        }
+    }
+
+    private fun upgradeResponse(): Response = Response.Builder()
+        .request(Request.Builder().url("https://example.com/").build())
+        .protocol(Protocol.HTTP_1_1)
+        .code(101)
+        .message("Switching Protocols")
+        .build()
+
+    /** Hands the session a socket the test fully controls, and captures its [WebSocketListener]. */
+    private class FakeWebSocketClient(private val socket: WebSocket) : OkHttpClient() {
+        @Volatile var socketListener: WebSocketListener? = null
+        override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+            socketListener = listener
+            return socket
+        }
+    }
+
+    /** Records wire order, and suspends inside `send` for the first message matching [gateOn]. */
+    private class GatedWebSocket(private val gateOn: String) : WebSocket {
+        val sent: MutableList<String> = Collections.synchronizedList(mutableListOf<String>())
+        val gateReached = CountDownLatch(1)
+        val releaseGate = CountDownLatch(1)
+        private val sentSignal = Semaphore(0)
+
+        override fun request(): Request = Request.Builder().url("https://example.com/").build()
+        override fun queueSize(): Long = 0
+        override fun send(text: String): Boolean {
+            if (text.contains(gateOn)) {
+                gateReached.countDown()
+                releaseGate.await(5, TimeUnit.SECONDS)
+            }
+            sent += text
+            sentSignal.release()
+            return true
+        }
+        override fun send(bytes: ByteString): Boolean = true
+        override fun close(code: Int, reason: String?): Boolean = true
+        override fun cancel() = Unit
+
+        fun awaitSent(count: Int) {
+            assertTrue("expected $count sends, saw ${sent.size}", sentSignal.tryAcquire(count, 5, TimeUnit.SECONDS))
+        }
+    }
+
     private fun factory(
         apiKey: String = "test-key",
         endpoint: okhttp3.HttpUrl = server.url("/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"),
@@ -178,8 +311,9 @@ class GeminiCloudLiveTranscriptionClientTest {
         vocabulary: List<String> = listOf("Ramblr"),
         setupTimeoutMs: Long = 2_000,
         finalTimeoutMs: Long = 2_000,
+        httpClient: OkHttpClient = OkHttpClient(),
     ) = GeminiCloudLiveTranscriptionClient(
-        httpClient = OkHttpClient(),
+        httpClient = httpClient,
         endpoint = endpoint,
         apiKey = apiKey,
         model = model,

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
@@ -1,0 +1,229 @@
+package com.trevornk.ramblr
+
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+class GeminiCloudLiveTranscriptionClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var scheduler: ScheduledThreadPoolExecutor
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        scheduler = ScheduledThreadPoolExecutor(1)
+    }
+
+    @After fun tearDown() {
+        scheduler.shutdownNow()
+        server.shutdown()
+    }
+
+    @Test fun `setup is exact verbatim live transcription shape`() {
+        val setup = GeminiCloudLiveTranscriptionClient.setupJson(
+            model = "gemini-3.5-transcribe-live",
+            languageCodes = listOf("en-US"),
+            customVocabulary = listOf("Ramblr", "HitSnooze"),
+        )
+        val root = JSONObject(setup)
+        assertEquals(setOf("setup"), root.keySet())
+        val body = root.getJSONObject("setup")
+        assertEquals("models/gemini-3.5-transcribe-live", body.getString("model"))
+        assertEquals(listOf("TEXT"), body.getJSONObject("generationConfig").getJSONArray("responseModalities").toStringList())
+        val transcription = body.getJSONObject("inputAudioTranscription")
+        assertEquals(listOf("en-US"), transcription.getJSONArray("languageCodes").toStringList())
+        assertEquals(listOf("Ramblr", "HitSnooze"), transcription.getJSONArray("customVocabulary").toStringList())
+        assertEquals("VERBATIM", transcription.getString("mode"))
+        assertTrue(body.getJSONObject("realtimeInputConfig").getJSONObject("automaticActivityDetection").getBoolean("disabled"))
+    }
+
+    @Test fun `endpoint model language and vocabulary validation rejects unsafe values`() {
+        assertThrows(IllegalArgumentException::class.java) { factory(endpoint = server.url("/wrong")) }
+        assertThrows(IllegalArgumentException::class.java) {
+            GeminiCloudLiveTranscriptionClient(
+                endpoint = "https://evil.example${GeminiCloudLiveTranscriptionClient.ENDPOINT_PATH}".toHttpUrl(),
+                apiKey = "key",
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) { factory(model = "models/bad?key=secret") }
+        assertThrows(IllegalArgumentException::class.java) { factory(languages = listOf("not a language!")) }
+        assertThrows(IllegalArgumentException::class.java) { factory(vocabulary = listOf("")) }
+        assertThrows(IllegalArgumentException::class.java) { factory(vocabulary = (1..1001).map { "term-$it" }) }
+    }
+
+    @Test fun `handshake gates activity and copied pcm then preserves wire order`() {
+        val received = Collections.synchronizedList(mutableListOf<String>())
+        val allMessages = CountDownLatch(4)
+        server.enqueue(MockResponse().withWebSocketUpgrade(object : ClosingWebSocketListener() {
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                received += text
+                if (received.size == 1) webSocket.send("{\"setupComplete\":{}}")
+                allMessages.countDown()
+            }
+        }))
+        val terminal = RecordingListener()
+        val session = factory().create(terminal)
+        val pcm = byteArrayOf(1, 2, 3, 4)
+
+        session.connect()
+        session.startActivity()
+        assertTrue(session.sendPcm(pcm, pcm.size))
+        pcm.fill(9)
+        session.endActivity()
+
+        assertTrue(allMessages.await(5, TimeUnit.SECONDS))
+        val upgrade = server.takeRequest(5, TimeUnit.SECONDS)!!
+        assertEquals("/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent", upgrade.path)
+        assertEquals("test-key", upgrade.getHeader("x-goog-api-key"))
+        assertFalse(upgrade.path!!.contains("test-key"))
+        assertEquals(setOf("setup"), JSONObject(received[0]).keySet())
+        assertTrue(JSONObject(received[1]).getJSONObject("realtimeInput").has("activityStart"))
+        val audio = JSONObject(received[2]).getJSONObject("realtimeInput").getJSONObject("audio")
+        assertEquals("audio/pcm;rate=16000", audio.getString("mimeType"))
+        assertEquals("AQIDBA==", audio.getString("data"))
+        assertTrue(JSONObject(received[3]).getJSONObject("realtimeInput").has("activityEnd"))
+        assertNull(terminal.result)
+        session.cancel()
+    }
+
+    @Test fun `interim and authoritative final parse and terminal callback exactly once`() {
+        val listener = RecordingListener()
+        val socket = scriptedSocket(
+            "{\"setupComplete\":{}}",
+            "{\"serverContent\":{\"interimInputTranscription\":{\"text\":\"hel\"}}}",
+            "{\"serverContent\":{\"inputTranscription\":{\"text\":\"hello\"}}}",
+            "{\"serverContent\":{\"inputTranscription\":{\"text\":\"late\"}}}",
+        )
+        val session = factory().create(listener)
+        session.connect(); session.startActivity(); session.endActivity()
+
+        assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+        Thread.sleep(50)
+        assertEquals(listOf("hel"), listener.interims)
+        assertEquals("hello", (listener.result as CloudLiveTerminal.Success).text)
+        assertEquals(1, listener.terminals)
+        assertTrue((listener.result as CloudLiveTerminal.Success).timing.setupCompletedAtMs != null)
+        assertTrue((listener.result as CloudLiveTerminal.Success).timing.finalAtMs != null)
+        socket.awaitMessages()
+    }
+
+    @Test fun `server error malformed event close and send failure are terminal once and redact key`() {
+        val secret = "credential-value"
+        val cases = listOf(
+            "{\"error\":{\"message\":\"bad key $secret\"}}",
+            "not-json",
+        )
+        cases.forEach { event ->
+            val listener = RecordingListener()
+            scriptedSocket("{\"setupComplete\":{}}", event)
+            val session = factory(apiKey = secret).create(listener)
+            session.connect(); session.startActivity()
+            assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+            val failure = listener.result as CloudLiveTerminal.Failure
+            assertFalse(failure.message.contains(secret))
+            assertEquals(1, listener.terminals)
+        }
+    }
+
+    @Test fun `cancel is terminal once and late messages cannot escape`() {
+        val listener = RecordingListener()
+        scriptedSocket("{\"setupComplete\":{}}", "{\"serverContent\":{\"inputTranscription\":{\"text\":\"late\"}}}", delayMs = 150)
+        val session = factory().create(listener)
+        session.connect(); session.startActivity(); session.cancel(); session.close()
+        assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+        Thread.sleep(250)
+        assertEquals(CloudLiveFailureReason.CANCELLED, (listener.result as CloudLiveTerminal.Failure).reason)
+        assertEquals(1, listener.terminals)
+    }
+
+    @Test fun `setup and final timeouts fail with distinct reasons`() {
+        val setupListener = RecordingListener()
+        server.enqueue(MockResponse().withWebSocketUpgrade(object : ClosingWebSocketListener() {}))
+        factory(setupTimeoutMs = 40).create(setupListener).connect()
+        assertTrue(setupListener.done.await(5, TimeUnit.SECONDS))
+        assertEquals(CloudLiveFailureReason.SETUP_TIMEOUT, (setupListener.result as CloudLiveTerminal.Failure).reason)
+
+        val finalListener = RecordingListener()
+        scriptedSocket("{\"setupComplete\":{}}")
+        val session = factory(finalTimeoutMs = 40).create(finalListener)
+        session.connect(); session.startActivity(); session.endActivity()
+        assertTrue(finalListener.done.await(5, TimeUnit.SECONDS))
+        assertEquals(CloudLiveFailureReason.FINAL_TIMEOUT, (finalListener.result as CloudLiveTerminal.Failure).reason)
+    }
+
+    private fun factory(
+        apiKey: String = "test-key",
+        endpoint: okhttp3.HttpUrl = server.url("/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"),
+        model: String = "gemini-3.5-transcribe-live",
+        languages: List<String> = listOf("en-US"),
+        vocabulary: List<String> = listOf("Ramblr"),
+        setupTimeoutMs: Long = 2_000,
+        finalTimeoutMs: Long = 2_000,
+    ) = GeminiCloudLiveTranscriptionClient(
+        httpClient = OkHttpClient(),
+        endpoint = endpoint,
+        apiKey = apiKey,
+        model = model,
+        languageCodes = languages,
+        customVocabulary = vocabulary,
+        callbackExecutor = Executor { it.run() },
+        scheduler = scheduler,
+        setupTimeoutMs = setupTimeoutMs,
+        finalTimeoutMs = finalTimeoutMs,
+        allowTestEndpoint = true,
+    )
+
+    private fun scriptedSocket(vararg events: String, delayMs: Long = 0): ServerScript {
+        val script = ServerScript(events.toList(), delayMs)
+        server.enqueue(MockResponse().withWebSocketUpgrade(script))
+        return script
+    }
+
+    private open class ClosingWebSocketListener : WebSocketListener() {
+        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+            webSocket.close(code, reason)
+        }
+    }
+
+    private class ServerScript(private val events: List<String>, private val delayMs: Long) : ClosingWebSocketListener() {
+        private val received = CountDownLatch(1)
+        override fun onOpen(webSocket: WebSocket, response: Response) {
+            Thread {
+                if (delayMs > 0) Thread.sleep(delayMs)
+                events.forEach { webSocket.send(it) }
+            }.start()
+        }
+        override fun onMessage(webSocket: WebSocket, text: String) { received.countDown() }
+        fun awaitMessages() { assertTrue(received.await(5, TimeUnit.SECONDS)) }
+    }
+
+    private class RecordingListener : CloudLiveTranscriptionListener {
+        val interims = Collections.synchronizedList(mutableListOf<String>())
+        val done = CountDownLatch(1)
+        @Volatile var result: CloudLiveTerminal? = null
+        @Volatile var terminals = 0
+        override fun onInterim(text: String, timing: CloudLiveTiming) { interims += text }
+        override fun onTerminal(result: CloudLiveTerminal) { terminals++; this.result = result; done.countDown() }
+    }
+
+    private fun org.json.JSONArray.toStringList() = (0 until length()).map { getString(it) }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/SerialCallbackExecutorTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/SerialCallbackExecutorTest.kt
@@ -1,0 +1,163 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Direct coverage for [SerialCallbackExecutor], the serialization primitive the whole
+ * exactly-one-terminal cloud-live contract rests on. It had none: every
+ * [GeminiCloudLiveTranscriptionClient] test passes a same-thread `Executor { it.run() }`, which
+ * never exercises the queue/drain state machine at all.
+ *
+ * The blocker these cover: one listener callback throwing used to unwind `drain()` with
+ * `running == true` and a non-empty queue, so every later `execute()` computed `shouldStart =
+ * false`, enqueued, and was never drained again. Since the executor is a FACTORY-level field
+ * shared by every session the factory creates, a single throwing `onTerminal`/`onInterim`
+ * disabled cloud-live for the rest of the process lifetime.
+ */
+class SerialCallbackExecutorTest {
+
+    private val pools = mutableListOf<ExecutorService>()
+
+    private fun pool(threads: Int, thrown: MutableList<Throwable>? = null): ExecutorService =
+        Executors.newFixedThreadPool(threads) { runnable ->
+            Thread(runnable).apply {
+                isDaemon = true
+                if (thrown != null) setUncaughtExceptionHandler { _, t -> thrown += t }
+            }
+        }.also(pools::add)
+
+    private fun shutdownPools() = pools.forEach { it.shutdownNow() }
+
+    /** Total failures reported, counting suppressed ones attached to the same drain's throwable. */
+    private fun surfacedCount(thrown: List<Throwable>): Int =
+        thrown.sumOf { 1 + it.suppressed.size }
+
+    @Test fun `a throwing task does not wedge the executor for later tasks`() {
+        val thrown = CopyOnWriteArrayList<Throwable>()
+        val executor = SerialCallbackExecutor(pool(1, thrown))
+        val ran = CopyOnWriteArrayList<String>()
+        val afterThrow = CountDownLatch(2)
+
+        try {
+            executor.execute { ran += "first"; afterThrow.countDown() }
+            executor.execute { throw IllegalStateException("listener blew up") }
+            executor.execute { ran += "second"; afterThrow.countDown() }
+
+            assertTrue(
+                "tasks after a throwing one must still be delivered; ran=$ran",
+                afterThrow.await(5, TimeUnit.SECONDS),
+            )
+            assertEquals(listOf("first", "second"), ran)
+
+            // ...and the executor must still accept work afterwards, not just finish its backlog.
+            val later = CountDownLatch(1)
+            executor.execute { ran += "third"; later.countDown() }
+            assertTrue("the executor must stay usable after a throw", later.await(5, TimeUnit.SECONDS))
+            assertEquals(listOf("first", "second", "third"), ran)
+        } finally {
+            shutdownPools()
+        }
+    }
+
+    @Test fun `the thrown exception is surfaced on the delegate thread, never swallowed`() {
+        val thrown = CopyOnWriteArrayList<Throwable>()
+        val executor = SerialCallbackExecutor(pool(1, thrown))
+        val done = CountDownLatch(1)
+        val boom = IllegalStateException("listener blew up")
+
+        try {
+            executor.execute { throw boom }
+            executor.execute { done.countDown() }
+            assertTrue(done.await(5, TimeUnit.SECONDS))
+
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline && thrown.isEmpty()) Thread.sleep(10)
+            assertEquals("the failure must reach the delegate thread's uncaught handler", 1, thrown.size)
+            assertTrue(thrown.single() === boom || thrown.single().cause === boom)
+        } finally {
+            shutdownPools()
+        }
+    }
+
+    @Test fun `several consecutive throwing tasks still leave every survivor delivered in order`() {
+        val thrown = CopyOnWriteArrayList<Throwable>()
+        val executor = SerialCallbackExecutor(pool(2, thrown))
+        val ran = CopyOnWriteArrayList<Int>()
+        val survivors = CountDownLatch(5)
+
+        try {
+            repeat(10) { i ->
+                if (i % 2 == 0) executor.execute { throw RuntimeException("boom-$i") }
+                else executor.execute { ran += i; survivors.countDown() }
+            }
+            assertTrue("every non-throwing task must run; ran=$ran", survivors.await(5, TimeUnit.SECONDS))
+            assertEquals(listOf(1, 3, 5, 7, 9), ran)
+            // Every failure must be surfaced somewhere -- directly, or suppressed onto the first
+            // of its drain -- rather than silently dropped.
+            val deadline = System.currentTimeMillis() + 5_000
+            while (System.currentTimeMillis() < deadline && surfacedCount(thrown) < 5) Thread.sleep(10)
+            assertEquals(5, surfacedCount(thrown))
+        } finally {
+            shutdownPools()
+        }
+    }
+
+    @Test fun `ordering and mutual exclusion hold when the delegate is a real multi threaded pool`() {
+        val executor = SerialCallbackExecutor(pool(8))
+        val ran = CopyOnWriteArrayList<Int>()
+        val concurrent = AtomicInteger(0)
+        val overlapped = AtomicInteger(0)
+        val count = 400
+        val done = CountDownLatch(count)
+
+        try {
+            repeat(count) { i ->
+                executor.execute {
+                    if (concurrent.incrementAndGet() > 1) overlapped.incrementAndGet()
+                    ran += i
+                    concurrent.decrementAndGet()
+                    done.countDown()
+                }
+            }
+            assertTrue(done.await(10, TimeUnit.SECONDS))
+            assertEquals(0, overlapped.get())
+            assertEquals((0 until count).toList(), ran)
+        } finally {
+            shutdownPools()
+        }
+    }
+
+    @Test fun `a task enqueued from inside a running task is drained without re-entering`() {
+        // The same-thread delegate every client test uses: a nested execute() must be queued and
+        // run by the in-flight drain, not recursively re-entered.
+        val executor = SerialCallbackExecutor(Executor { it.run() })
+        val ran = CopyOnWriteArrayList<String>()
+        var depth = 0
+        var maxDepth = 0
+
+        executor.execute {
+            depth++; maxDepth = maxOf(maxDepth, depth)
+            ran += "outer"
+            executor.execute {
+                depth++; maxDepth = maxOf(maxDepth, depth)
+                ran += "nested"
+                depth--
+            }
+            assertFalse("the nested task must not run inside the outer one", ran.contains("nested"))
+            depth--
+        }
+
+        assertEquals(listOf("outer", "nested"), ran)
+        assertEquals(1, maxDepth)
+    }
+}


### PR DESCRIPTION
Implements the first production slice of #233: a provider-neutral cloud-live
session seam, a Gemini Live protocol client, and a conservative `DictationRuntime`
integration whose defining property is that **live transcription can never lose a
dictation**.

Not wired into any shipped host. `cloudLiveFactory` defaults to `null`, so every
current code path behaves exactly as it does on `main`. No default, provider
catalog, picker, or migration change.

## Evidence this is worth building

Measured in #227 against the preserved 15-fixture private corpus:

| | EOS→final p50 | WER |
|---|---:|---:|
| Current Gemini batch | 808 ms | 6.44% |
| `gemini-3.5-transcribe-live` | **262 ms** | **4.83%** |

30/30 successful calls, deterministic across two runs.

## Design

**`CloudLiveTranscription.kt`** — provider-neutral contract. Ordered
`startActivity`/`sendPcm`/`endActivity`, callable before setup completes;
`sendPcm` must copy before returning because `RecordingEngine` reuses its buffer;
exactly one terminal callback; idempotent cancel/close.

**`GeminiCloudLiveTranscriptionClient.kt`** — Gemini Live WebSocket over the
existing OkHttp stack, no new dependency. Manual push-to-talk boundaries
(`automaticActivityDetection.disabled = true`), because automatic VAD prematurely
finalized a long utterance during an internal pause in #227. Bounded outbound
buffering, endpoint/host validation, API key never logged or placed in a URL.

**`DictationRuntime`** — live capture is a *tee* off the existing `onChunk`; the
local PCM file remains the source of truth and is written identically whether or
not live is active. A single main-thread arbitration point (`resolveCloudLiveAttempt`)
gives the preserved recording to exactly one owner:

- live success (non-blank, past the minimum-duration gate) → existing cleanup and
  delivery pipeline, PCM deleted;
- any failure, blank final, setup/final timeout, send failure, protocol error, or
  cancellation → `continueTranscription` on the preserved PCM, unchanged.

A terminal event alone cannot claim the recording before reader handoff, so the
two paths cannot both run and cannot both be skipped. Interim text is exposed via
a defaulted `onCloudLiveInterim` that the accessibility host deliberately inherits
as a no-op — accessibility stays final-only, since it cannot cheaply retract
injected text. IME rendering is a follow-up.

## Verification

- `./gradlew testGithubDebugUnitTest --rerun-tasks` — 160 suites / 1,679 tests /
  0 failures / 0 errors / 0 skipped
- `./gradlew assembleGithubDebug --rerun-tasks` — succeeded
- New tests cover setup payload shape, handshake gating, PCM copy/order, activity
  boundaries, interim/final parsing, malformed events, exactly-once terminal,
  late events, cancellation, and fallback-exactly-once in both directions.

Not device-validated and not credential-validated; both gates belong to the
follow-up that actually enables the path.

Refs #233, #227.
