### PR TITLE
Harden Gemini client: block cross-host redirects, unify mode encoding

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClient.kt
@@ -164,10 +164,7 @@ class GeminiInteractionsTranscriberClient(
         val transcriptionConfig = JSONObject()
             .put("custom_vocabulary", JSONArray(customVocabulary))
             .put("language_codes", JSONArray(languageCodes))
-            .put("mode", when (mode) {
-                Mode.VERBATIM -> JSONObject().put("type", mode.wireValue)
-                Mode.SMART -> mode.wireValue
-            })
+            .put("mode", JSONObject().put("type", mode.wireValue))
         val body = JSONObject()
             .put("model", model)
             .put("store", false)

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClient.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * cleanup failures never replace the transcription result that caused cleanup.
  */
 class GeminiInteractionsTranscriberClient(
-    private val httpClient: OkHttpClient = NetworkClients.shared,
+    private val httpClient: OkHttpClient = NetworkClients.noRedirects,
     private val uploadEndpoint: HttpUrl = DEFAULT_UPLOAD_ENDPOINT.toHttpUrl(),
     private val interactionsEndpoint: HttpUrl = DEFAULT_INTERACTIONS_ENDPOINT.toHttpUrl(),
     private val filesEndpoint: HttpUrl = DEFAULT_FILES_ENDPOINT.toHttpUrl(),

--- a/app/src/main/kotlin/com/trevornk/ramblr/NetworkClients.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/NetworkClients.kt
@@ -22,4 +22,22 @@ object NetworkClients {
             .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .build()
     }
+
+    /**
+     * [shared], but refusing to follow redirects -- for calls that carry a credential header or an
+     * audio body to a host validated up front.
+     *
+     * OkHttp follows redirects by default and only strips `Authorization` on a host change; a
+     * custom credential header like `x-goog-api-key` is carried across hosts untouched. Validating
+     * a URL's origin before the call is therefore not sufficient on its own: a 3xx from the
+     * validated host can still redirect the request, its credential header, and its body to an
+     * arbitrary third-party host. Callers using this client see the 3xx as a plain unsuccessful
+     * response and fail the operation instead.
+     */
+    val noRedirects: OkHttpClient by lazy {
+        shared.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+    }
 }

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClientTest.kt
@@ -8,6 +8,7 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -30,7 +31,8 @@ class GeminiInteractionsTranscriberClientTest {
         server = MockWebServer()
         server.start()
         client = GeminiInteractionsTranscriberClient(
-            httpClient = OkHttpClient(),
+            // The production client, so redirect-following behavior under test is the real one.
+            httpClient = NetworkClients.noRedirects,
             uploadEndpoint = server.url("/upload/v1beta/files"),
             interactionsEndpoint = server.url("/v1beta/interactions"),
             filesEndpoint = server.url("/v1beta/files/"),
@@ -170,6 +172,69 @@ class GeminiInteractionsTranscriberClientTest {
             assertTrue("mode for $mode must be an object, was ${encoded?.javaClass}", encoded is JSONObject)
             assertEquals(mode.wireValue, (encoded as JSONObject).getString("type"))
             server.takeRequest()
+        }
+    }
+
+    /**
+     * A validated same-origin upload URL must not become a cross-host request via a redirect.
+     * OkHttp follows redirects by default and only strips `Authorization` when the host changes --
+     * `x-goog-api-key` is not stripped, so a followed 302 would hand both the audio body and the
+     * API key to whatever host the redirect names. The client must refuse to follow instead.
+     */
+    @Test fun `upload does not follow a redirect to another host`() {
+        val attacker = MockWebServer()
+        attacker.start()
+        try {
+            attacker.enqueue(MockResponse().setBody("""{"file":{"name":"files/pwned","uri":"https://files.example/pwned","mimeType":"audio/wav","state":"ACTIVE"}}"""))
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("X-Goog-Upload-URL", server.url("/resumable/session-1").toString()),
+            )
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(302)
+                    .setHeader("Location", attacker.url("/steal").toString()),
+            )
+
+            val (result, callbacks) = awaitResult()
+
+            assertEquals(1, callbacks)
+            assertNull(result.text)
+            assertNotNull(result.error)
+            assertEquals("attacker host must receive no request", 0, attacker.requestCount)
+        } finally {
+            attacker.shutdown()
+        }
+    }
+
+    /**
+     * Same guarantee on the key-bearing start call, which carries `x-goog-api-key` from the very
+     * first request.
+     */
+    @Test fun `upload start does not follow a redirect to another host`() {
+        val attacker = MockWebServer()
+        attacker.start()
+        try {
+            attacker.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("X-Goog-Upload-URL", attacker.url("/resumable/evil").toString()),
+            )
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(302)
+                    .setHeader("Location", attacker.url("/start").toString()),
+            )
+
+            val (result, callbacks) = awaitResult()
+
+            assertEquals(1, callbacks)
+            assertNull(result.text)
+            assertNotNull(result.error)
+            assertEquals("attacker host must receive no request", 0, attacker.requestCount)
+        } finally {
+            attacker.shutdown()
         }
     }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiInteractionsTranscriberClientTest.kt
@@ -144,8 +144,33 @@ class GeminiInteractionsTranscriberClientTest {
         server.takeRequest()
         val config = JSONObject(server.takeRequest().body.readUtf8())
             .getJSONObject("generation_config").getJSONObject("transcription_config")
-        assertEquals("smart", config.getString("mode"))
-        assertFalse(config.opt("mode") is JSONObject)
+        assertEquals("smart", config.getJSONObject("mode").getString("type"))
+    }
+
+    /**
+     * Both modes use the same `{"type": ...}` object shape. The live API accepts a bare string too
+     * (`mode: "smart"`), but only the object form is documented, and encoding the two modes
+     * differently invites a reader into thinking one of them is special. Verified against the live
+     * endpoint 2026-08-28: a bad enum is rejected with "Supported values: 'verbatim', 'smart'"
+     * under both shapes, so neither is a silently-ignored no-op.
+     */
+    @Test fun `both transcription modes use the documented object wire shape`() {
+        for (mode in GeminiInteractionsTranscriberClient.Mode.entries) {
+            enqueueSuccessfulUpload()
+            server.enqueue(MockResponse().setBody("""{"steps":[{"type":"model_output","content":[{"type":"text","text":"ok"}]}]}"""))
+            server.enqueue(MockResponse().setBody("{}"))
+
+            awaitResult(mode = mode)
+
+            server.takeRequest()
+            server.takeRequest()
+            val config = JSONObject(server.takeRequest().body.readUtf8())
+                .getJSONObject("generation_config").getJSONObject("transcription_config")
+            val encoded = config.opt("mode")
+            assertTrue("mode for $mode must be an object, was ${encoded?.javaClass}", encoded is JSONObject)
+            assertEquals(mode.wireValue, (encoded as JSONObject).getString("type"))
+            server.takeRequest()
+        }
     }
 
     @Test fun `successful callback does not wait for uploaded file deletion`() {


### PR DESCRIPTION
Two fixes to the #226 evaluation client, one of them a real security defect and
one of them me correcting my own mistake.

## 1. Cross-host redirect leak (the real one)

`GeminiInteractionsTranscriberClient` validated the origin of the initial
`X-Goog-Upload-URL` and then made the request on `NetworkClients.shared`, which
follows redirects by default. OkHttp strips only `Authorization` on a host
change — a custom credential header like `x-goog-api-key` rides along untouched.

So a 3xx from the validated host could hand **the dictation audio and the API
key** to an arbitrary third-party host, defeating the up-front origin check.

Adds `NetworkClients.noRedirects` and uses it here. A redirect now surfaces as a
plain unsuccessful response and fails the operation. The shipped transcription
and cleanup paths continue to use `NetworkClients.shared` unchanged — this is
deliberately not a global behavior change.

The new tests point the client at `NetworkClients.noRedirects` rather than a bare
`OkHttpClient()`, so they exercise the shipped configuration instead of a
stand-in. Both fail on `main`, with the attacker `MockWebServer` observing the
audio body and the key.

Not currently exploitable in a shipped build — nothing constructs this client at
runtime yet — but it must be fixed before #233 or anything else wires it in.

## 2. Reverting a change I made on a false premise

`2638a95` encoded smart mode as a bare string on the reviewer's claim that the
object form was rejected. **That claim was wrong, and I pushed it without
verifying.**

Probed against the live Interactions API on 2026-08-28:

| request | result |
|---|---|
| `mode: "smart"` | HTTP 200 |
| `mode: {"type":"smart"}` | HTTP 200 |
| `mode: "NONSENSE"` | HTTP 400 `Invalid enum value` |
| `mode: {"type":"NONSENSE"}` | HTTP 400 `Supported values: 'verbatim', 'smart'` |

Both shapes are accepted and both are validated, so neither is silently ignored.
This restores the documented object form for both modes; encoding two values of
one enum differently only invited a future reader to think smart was special.

Worth recording separately: on the `corr-01` / `corr-02` self-correction fixtures,
smart and verbatim return **byte-identical** text across repeated runs — smart
mode is accepted and validated but appears to be inert on this corpus. That is
consistent with the "no cleanup benefit from smart mode" observation in #226 and
is a caveat for anyone who later considers exposing it.

## Verification

- `./gradlew testGithubDebugUnitTest --rerun-tasks` — 159 suites / 1,671 tests /
  0 failures / 0 errors / 0 skipped
- `./gradlew assembleGithubDebug --rerun-tasks` — succeeded
- Each commit verified to pass on its own.

Refs #226.
