### PR TITLE
Wire cloud-live transcription into the IME host behind a default-off opt-in (#233 Phase 1)

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BenchmarkLogger.kt
@@ -107,6 +107,55 @@ data class PipelineStage(
 )
 
 /**
+ * One cloud-live transcription attempt's timing + outcome (#233 Phase 1 item 10).
+ *
+ * Exists because the live->batch fallback is deliberately LOSSLESS: when a live attempt fails,
+ * the preserved local recording runs the ordinary batch chain and the user gets the same text
+ * delivered the same way. Correct product behavior, but it makes a live failure *invisible* --
+ * on a real device there is otherwise no way to tell whether live actually served a dictation or
+ * whether it silently fell back on every single utterance. Without this block the whole device
+ * acceptance gate ("prove post-stop latency, setup timing, interim behavior, mid-stream
+ * network-drop fallback") is unfalsifiable, because no evidence survives the session.
+ *
+ * Every field is a derived DURATION or an enum name, never a wall-clock absolute: the raw
+ * [CloudLiveTiming] marks are only useful after a reader subtracts them, and the same
+ * "directly comparable elapsed ms" convention [PipelineStage] established is what makes a live
+ * line readable next to a batch one.
+ *
+ * Deliberately carries no transcript content of any kind -- not the interim text, not the final
+ * text, not a text sample. See [BenchmarkLogger]'s privacy note; raw/cleaned pairs live in
+ * [QualityLogger] behind its own off-by-default toggle.
+ *
+ * Durations are NOT clamped to zero. A negative value means the device's wall clock moved
+ * backwards mid-attempt, which is real signal a reader should see rather than have hidden.
+ */
+data class CloudLiveStage(
+    /** [CloudLiveOutcome]'s enum name -- how this attempt actually ended. Stored as a plain
+     *  string so this schema never takes a hard dependency on the enum living in this module,
+     *  mirroring [PipelineStage.injectMethod]. */
+    val outcome: String,
+    /** True when the preserved recording went to the unchanged batch pipeline instead of live
+     *  text being delivered. The single field that answers "did live actually serve this?". */
+    val fellBackToBatch: Boolean,
+    /** [CloudLiveFailureReason]'s enum name when the live session reported a terminal failure,
+     *  else null -- so `NETWORK_ERROR` is distinguishable from `SETUP_TIMEOUT` from a live
+     *  success whose final was simply unusable. */
+    val failureReason: String? = null,
+    /** Connection setup: `connectStartedAtMs` -> `setupCompletedAtMs`. Null when setup never
+     *  completed (e.g. SETUP_TIMEOUT), which is itself the answer. */
+    val setupMs: Long? = null,
+    /** Time to first interim: `connectStartedAtMs` -> `firstInterimAtMs`. Null when the session
+     *  never emitted an interim. */
+    val firstInterimMs: Long? = null,
+    /** End of audio to final: `activityEndedAtMs` -> `finalAtMs`. The headline number the whole
+     *  live feature exists to reduce -- how long after the user stops talking the text lands. */
+    val endOfAudioToFinalMs: Long? = null,
+    /** The live session's own failure message, always routed through [sanitizeError] first
+     *  (same bounded-exposure tradeoff [BenchmarkStage.error] documents). Null on success. */
+    val error: String? = null,
+)
+
+/**
  * Durable, append-only JSONL benchmark log for A/B testing transcription/cleanup provider+model
  * combinations across real-world dictation usage (#100). One line per completed dictation, each
  * line a self-contained JSON object -- deliberately NOT a JSON array, so a crash or a concurrent
@@ -182,6 +231,7 @@ object BenchmarkLogger {
         rawTextLength: Int? = null,
         cleanedTextLength: Int? = null,
         pipeline: PipelineStage? = null,
+        cloudLive: CloudLiveStage? = null,
     ) {
         runCatching {
             val line = buildLine(
@@ -192,6 +242,7 @@ object BenchmarkLogger {
                 rawTextLength = rawTextLength,
                 cleanedTextLength = cleanedTextLength,
                 pipeline = pipeline,
+                cloudLive = cloudLive,
             )
             val file = logFile(context)
             ioExecutor.execute {
@@ -216,6 +267,7 @@ object BenchmarkLogger {
         rawTextLength: Int?,
         cleanedTextLength: Int?,
         pipeline: PipelineStage? = null,
+        cloudLive: CloudLiveStage? = null,
     ): String {
         val root = JSONObject()
         root.put("timestamp", timestamp)
@@ -228,6 +280,9 @@ object BenchmarkLogger {
         // JSONObject.NULL (not an omitted key) mirrors transcription/cleanup's existing
         // null-vs-missing convention above so every line has a stable, predictable key set.
         root.put("pipeline", pipeline?.toJson() ?: JSONObject.NULL)
+        // Additive (#233 item 10), same convention again: a live attempt is rare (opt-in, and
+        // only on the IME host), so the overwhelming majority of lines carry a null here.
+        root.put("cloudLive", cloudLive?.toJson() ?: JSONObject.NULL)
         return root.toString()
     }
 
@@ -246,6 +301,15 @@ object BenchmarkLogger {
         .put("injectionAttemptMs", injectionAttemptMs ?: JSONObject.NULL)
         .put("injectMethod", injectMethod ?: JSONObject.NULL)
         .put("totalMs", totalMs ?: JSONObject.NULL)
+
+    private fun CloudLiveStage.toJson(): JSONObject = JSONObject()
+        .put("outcome", outcome)
+        .put("fellBackToBatch", fellBackToBatch)
+        .put("failureReason", failureReason ?: JSONObject.NULL)
+        .put("setupMs", setupMs ?: JSONObject.NULL)
+        .put("firstInterimMs", firstInterimMs ?: JSONObject.NULL)
+        .put("endOfAudioToFinalMs", endOfAudioToFinalMs ?: JSONObject.NULL)
+        .put("error", error ?: JSONObject.NULL)
 
     /** If [file] is at/over [ROTATE_AT_BYTES], truncates it down to its newest
      *  [KEEP_BYTES_AFTER_ROTATION] bytes, dropping any partial first line left over from the

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveToggle.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveToggle.kt
@@ -1,0 +1,38 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Opt-in switch for cloud *live* (streaming) transcription (#233 Phase 1).
+ *
+ * OFF by default, and deliberately so: live transcription streams audio to Gemini for the whole
+ * duration of a recording rather than uploading one file at the end, which costs roughly 1.8x the
+ * batch price and has had no real-device validation yet. Everything about it is experimental, so
+ * it has to be a thing the user reaches for, never a thing that happens to them.
+ *
+ * The toggle alone does NOT make live transcription run -- [CloudLiveWiring.factoryOrNull] is the
+ * single place that decides, and it additionally requires cloud transcription to be selected
+ * (`use_local == false`) and a Gemini credential to exist. This object owns only the user's
+ * stated intent; it is not a capability check.
+ *
+ * Same "ramblr" prefs file and object shape as [VocabularySuggestionsToggle] / [RawTextRetryToggle]
+ * / the rest of the toggle family.
+ */
+object CloudLiveToggle {
+    private const val PREFS_NAME = "ramblr"
+    const val KEY = "cloud_live_transcription_enabled"
+    const val DEFAULT = false
+
+    fun isEnabled(prefs: SharedPreferences): Boolean = prefs.getBoolean(KEY, DEFAULT)
+
+    fun setEnabled(prefs: SharedPreferences, enabled: Boolean) {
+        prefs.edit().putBoolean(KEY, enabled).apply()
+    }
+
+    fun isEnabled(context: Context): Boolean = isEnabled(prefs(context))
+
+    fun setEnabled(context: Context, enabled: Boolean) = setEnabled(prefs(context), enabled)
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
@@ -60,6 +60,62 @@ sealed class CloudLiveTerminal {
 }
 
 /**
+ * How one cloud-live attempt actually ended, from the runtime's arbitration point of view
+ * (#233 Phase 1 item 10). Deliberately finer-grained than [CloudLiveTerminal]'s two cases,
+ * because the two ways a *successful* live session still loses the recording to batch are
+ * exactly the ones a device trial has to be able to tell apart afterwards.
+ */
+enum class CloudLiveOutcome {
+    /** Live text was authoritative and went down the normal delivery path. */
+    LIVE_DELIVERED,
+    /** The session reported [CloudLiveTerminal.Success], but the final was unusable (blank, or
+     *  the preserved recording was below the minimum-duration floor), so batch served it. */
+    FALLBACK_UNUSABLE_FINAL,
+    /** The session reported [CloudLiveTerminal.Failure]; see [CloudLiveStage.failureReason]. */
+    FALLBACK_FAILED,
+    /** No terminal callback arrived at all before the runtime's bounded final wait expired --
+     *  the mid-stream-drop / wedged-socket case, which produces no [CloudLiveFailureReason]
+     *  because the session never got far enough to report one. */
+    FALLBACK_NO_TERMINAL,
+}
+
+/**
+ * Derives the benchmark record for one live attempt: durations only, no transcript content.
+ *
+ * Pure and free of Android/[android.content.Context] so the whole "what does a device trial
+ * actually see" question is unit-testable without a device. [timing] is the best marks known to
+ * the runtime -- a terminal's own timing when there is one, otherwise the last interim's, which
+ * is what makes [CloudLiveOutcome.FALLBACK_NO_TERMINAL] still able to report that setup landed
+ * and interims flowed before the session went quiet.
+ *
+ * Durations are simple subtractions of the marks the session already recorded; a mark that was
+ * never set yields null rather than a fabricated zero, because "never happened" and "happened
+ * instantly" are different findings.
+ */
+fun cloudLiveBenchmarkStage(
+    outcome: CloudLiveOutcome,
+    terminal: CloudLiveTerminal?,
+    timing: CloudLiveTiming?,
+): CloudLiveStage {
+    val marks = terminal?.timing ?: timing
+    val failure = terminal as? CloudLiveTerminal.Failure
+    return CloudLiveStage(
+        outcome = outcome.name,
+        fellBackToBatch = outcome != CloudLiveOutcome.LIVE_DELIVERED,
+        failureReason = failure?.reason?.name,
+        setupMs = marks?.let { m -> m.setupCompletedAtMs?.minus(m.connectStartedAtMs) },
+        firstInterimMs = marks?.let { m -> m.firstInterimAtMs?.minus(m.connectStartedAtMs) },
+        endOfAudioToFinalMs = marks?.let { m ->
+            val ended = m.activityEndedAtMs ?: return@let null
+            m.finalAtMs?.minus(ended)
+        },
+        // Provider prose can echo request content and can carry a URL; sanitizeError bounds it
+        // and the client has already redacted the API key out of the message before this point.
+        error = sanitizeError(failure?.message),
+    )
+}
+
+/**
  * Serializes callbacks even when the supplied executor is a pool.
  *
  * One instance is shared factory-wide by every session, so a single throwing listener callback

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
@@ -99,16 +99,15 @@ fun cloudLiveBenchmarkStage(
 ): CloudLiveStage {
     val marks = terminal?.timing ?: timing
     val failure = terminal as? CloudLiveTerminal.Failure
+    // One rule for all three durations: both ends must exist, or the answer is "didn't happen".
+    fun elapsed(from: Long?, to: Long?): Long? = if (from != null && to != null) to - from else null
     return CloudLiveStage(
         outcome = outcome.name,
         fellBackToBatch = outcome != CloudLiveOutcome.LIVE_DELIVERED,
         failureReason = failure?.reason?.name,
-        setupMs = marks?.let { m -> m.setupCompletedAtMs?.minus(m.connectStartedAtMs) },
-        firstInterimMs = marks?.let { m -> m.firstInterimAtMs?.minus(m.connectStartedAtMs) },
-        endOfAudioToFinalMs = marks?.let { m ->
-            val ended = m.activityEndedAtMs ?: return@let null
-            m.finalAtMs?.minus(ended)
-        },
+        setupMs = elapsed(marks?.connectStartedAtMs, marks?.setupCompletedAtMs),
+        firstInterimMs = elapsed(marks?.connectStartedAtMs, marks?.firstInterimAtMs),
+        endOfAudioToFinalMs = elapsed(marks?.activityEndedAtMs, marks?.finalAtMs),
         // Provider prose can echo request content and can carry a URL; sanitizeError bounds it
         // and the client has already redacted the API key out of the message before this point.
         error = sanitizeError(failure?.message),

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveWiring.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveWiring.kt
@@ -1,0 +1,79 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.util.Log
+
+/**
+ * Builds the cloud-live transcription factory for a host, or returns null (#233 Phase 1).
+ *
+ * The merged seam ([DictationRuntime]'s `cloudLiveFactory`) has been null in every shipped host
+ * since it landed, so no user could reach the live path at all. This object is the entire
+ * construction/gating layer that closes that gap: it decides whether live transcription is
+ * allowed *right now*, and if so builds a configured [GeminiCloudLiveTranscriptionClient]. It
+ * adds no behavior of its own -- interim delivery, terminal resolution, and the lossless batch
+ * fallback all already live in [DictationRuntime.beginCloudLiveAttempt] behind the null check.
+ *
+ * Three independent conditions must ALL hold, and each is read from its existing source rather
+ * than a new one, so this can never disagree with the rest of the app:
+ *
+ *  1. [CloudLiveToggle] is on -- the user's explicit, default-OFF opt-in.
+ *  2. Cloud transcription is actually selected, i.e. the same `use_local` pref
+ *     [DictationRuntime] itself branches on. Live is a *cloud* transcription strategy; offering
+ *     it to someone who has chosen on-device would silently contradict that choice.
+ *  3. A Gemini credential exists, from [ProviderCredentialStore] -- the exact source the batch
+ *     GEMINI branch uses.
+ *
+ * Returning null is always safe: the host is then constructed exactly as it was before this
+ * change, and dictation takes the unchanged batch path.
+ */
+object CloudLiveWiring {
+    private const val TAG = "PhoneWhisper"
+
+    /**
+     * The pure gate, split out from [factoryOrNull] so the three-condition policy is unit-testable
+     * without a Context, encrypted prefs, or any network object.
+     */
+    fun isLiveAllowed(
+        toggleEnabled: Boolean,
+        useLocalTranscription: Boolean,
+        geminiKey: String,
+    ): Boolean = toggleEnabled && !useLocalTranscription && geminiKey.isNotBlank()
+
+    /**
+     * A configured live factory, or null when live transcription is not allowed or cannot be
+     * built.
+     *
+     * Construction failure is deliberately swallowed into null rather than propagated: this runs
+     * inside the IME host's onCreate, where a thrown [IllegalArgumentException] from the client's
+     * validation would take the whole keyboard down instead of merely disabling an experimental
+     * extra. The failure is logged without the credential or any user text.
+     */
+    fun factoryOrNull(context: Context): CloudLiveTranscriptionSessionFactory? {
+        val prefs = context.getSharedPreferences("ramblr", Context.MODE_PRIVATE)
+        if (!CloudLiveToggle.isEnabled(prefs)) return null
+        // Read the existing cloud-vs-local gate exactly as DictationRuntime does; no new pref.
+        val useLocal = prefs.getBoolean("use_local", true)
+        val apiKey = ProviderCredentialStore.get(context, ProviderKind.GEMINI)
+        if (!isLiveAllowed(CloudLiveToggle.isEnabled(prefs), useLocal, apiKey)) return null
+
+        // Same terms the batch transcription path biases on (#26/#114), read from the same key.
+        // Truncated to the client's documented ceiling so an oversized personal list downgrades
+        // to fewer hints rather than rejecting the factory outright.
+        val vocabulary = VocabularyTerms
+            .parse(prefs.getString("custom_vocabulary_terms", VocabularyTerms.DEFAULT_SERIALIZED))
+            .take(GeminiCloudLiveTranscriptionClient.MAX_CUSTOM_VOCABULARY)
+
+        // languageCodes is left at the client default: the codebase has no configured language
+        // source anywhere (the batch Gemini client defaults it the same way), and inventing one
+        // here would be a new user-facing setting this phase does not own.
+        return try {
+            GeminiCloudLiveTranscriptionClient(
+                apiKey = apiKey,
+                customVocabulary = vocabulary,
+            )
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Cloud-live transcription unavailable: ${e.message}")
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveWiring.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveWiring.kt
@@ -50,11 +50,15 @@ object CloudLiveWiring {
      */
     fun factoryOrNull(context: Context): CloudLiveTranscriptionSessionFactory? {
         val prefs = context.getSharedPreferences("ramblr", Context.MODE_PRIVATE)
-        if (!CloudLiveToggle.isEnabled(prefs)) return null
+        // Cheap gate first: opting out must not pay for SecurePrefsFactory's keystore-backed
+        // credential read, which the vast majority of installs would otherwise do on every
+        // IME onCreate to learn they were never opted in.
+        val enabled = CloudLiveToggle.isEnabled(prefs)
+        if (!enabled) return null
         // Read the existing cloud-vs-local gate exactly as DictationRuntime does; no new pref.
         val useLocal = prefs.getBoolean("use_local", true)
         val apiKey = ProviderCredentialStore.get(context, ProviderKind.GEMINI)
-        if (!isLiveAllowed(CloudLiveToggle.isEnabled(prefs), useLocal, apiKey)) return null
+        if (!isLiveAllowed(enabled, useLocal, apiKey)) return null
 
         // Same terms the batch transcription path biases on (#26/#114), read from the same key.
         // Truncated to the client's documented ceiling so an oversized personal list downgrades

--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudProviderActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudProviderActivity.kt
@@ -48,6 +48,8 @@ class CloudProviderActivity : BaseSettingsActivity() {
     private lateinit var localFallbackRowSub: TextView
     private lateinit var cloudFallbackSwitch: MaterialSwitch
     private lateinit var cloudFallbackRowSub: TextView
+    private lateinit var cloudLiveSwitch: MaterialSwitch
+    private lateinit var cloudLiveRowSub: TextView
 
     /** Provider kinds a user can manually add here. LOCAL is the implicit floor (never a
      *  manually-added row). OMNIROUTE only appears once a base URL has been supplied via
@@ -186,6 +188,26 @@ class CloudProviderActivity : BaseSettingsActivity() {
             alpha = 0.6f
         })
 
+        root.addView(sectionHeader("Experimental"))
+
+        cloudLiveSwitch = MaterialSwitch(this).apply { isClickable = false }
+        val cloudLiveRow = settingsRow(
+            "Live cloud transcription", cloudLiveSubtitle(), cloudLiveSwitch
+        ) { onToggleCloudLive(!cloudLiveSwitch.isChecked) }
+        cloudLiveRowSub = cloudLiveRow.findViewWithTag("subtitle")
+        root.addView(cloudLiveRow)
+        root.addView(TextView(this).apply {
+            text = "Streams audio to Gemini while you speak, so text appears as you talk instead " +
+                "of after you stop. Ramblr keyboard only. Requires cloud transcription and a " +
+                "Gemini key — it does not change which provider transcribes you, or the order of " +
+                "the chain above. Unproven on real devices and roughly 1.8x the cost of the " +
+                "normal upload, so it is off until you turn it on. If a stream fails, the " +
+                "recording still finishes over the normal path."
+            textSize = 13f
+            setTextColor(attrColor(android.R.attr.textColorSecondary))
+            setPadding(dp(24), 0, dp(24), dp(12))
+        })
+
         setContentView(ScrollView(this).apply {
             setBackgroundColor(attrColor(android.R.attr.colorBackground))
             addView(root)
@@ -220,6 +242,9 @@ class CloudProviderActivity : BaseSettingsActivity() {
         localFallbackRowSub.text = localFallbackSubtitle()
         cloudFallbackSwitch.isChecked = DictationModeToggle.allowCloudFallback(this)
         cloudFallbackRowSub.text = cloudFallbackSubtitle()
+
+        cloudLiveSwitch.isChecked = CloudLiveToggle.isEnabled(this)
+        cloudLiveRowSub.text = cloudLiveSubtitle()
 
         refreshModeSelection()
     }
@@ -752,6 +777,24 @@ class CloudProviderActivity : BaseSettingsActivity() {
 
     private fun onToggleCloudFallback(enabled: Boolean) {
         DictationModeToggle.setAllowCloudFallback(this, enabled)
+        refresh()
+    }
+
+    // --- Experimental: live cloud transcription (#233 Phase 1) ---
+
+    /** Delegates to the pure [cloudLiveSubtitleText], reading the same three inputs
+     *  [CloudLiveWiring.factoryOrNull] gates on so the row and the wiring cannot disagree. */
+    private fun cloudLiveSubtitle(): String = cloudLiveSubtitleText(
+        enabled = CloudLiveToggle.isEnabled(this),
+        useLocalTranscription = prefs().getBoolean("use_local", true),
+        hasGeminiKey = ProviderCredentialStore.isConfigured(this, ProviderKind.GEMINI),
+    )
+
+    /** Persists intent only. The switch never edits `use_local`, the chain, or any credential --
+     *  turning it on while transcription is on-device leaves the row honestly saying so instead
+     *  of silently reconfiguring the user's providers behind the toggle. */
+    private fun onToggleCloudLive(enabled: Boolean) {
+        CloudLiveToggle.setEnabled(this, enabled)
         refresh()
     }
 

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
@@ -168,6 +168,11 @@ class DictationRuntime internal constructor(
         var token: Int = 0
         var claimed = false
         var finalWait: Runnable? = null
+        /** Newest [CloudLiveTiming] seen from any callback (#233 item 10). Main-thread only, same
+         *  as every other field here. Kept so a fallback that happens because NO terminal ever
+         *  arrived can still report that setup landed and interims flowed -- otherwise the most
+         *  interesting failure on a real device (mid-stream drop) would log nothing but nulls. */
+        var lastTiming: CloudLiveTiming? = null
     }
 
     @Volatile private var cloudLiveAttempt: CloudLiveAttempt? = null
@@ -544,7 +549,12 @@ class DictationRuntime internal constructor(
             attempt.session = factory.create(object : CloudLiveTranscriptionListener {
                 override fun onInterim(text: String, timing: CloudLiveTiming) {
                     handler.post {
-                        if (cloudLiveAttempt === attempt && sessionLease === lease &&
+                        if (cloudLiveAttempt !== attempt) return@post
+                        // #233 item 10: record the marks even when this interim isn't shown (a
+                        // claimed/stopped attempt still produced real setup + first-interim
+                        // timing, and that is exactly what the device trial needs to read back).
+                        attempt.lastTiming = timing
+                        if (sessionLease === lease &&
                             stateMachine.current() == RecordingStateMachine.State.RECORDING && !attempt.claimed) {
                             listener.onCloudLiveInterim(text)
                         }
@@ -555,6 +565,7 @@ class DictationRuntime internal constructor(
                     handler.post {
                         if (cloudLiveAttempt !== attempt || sessionLease !== lease || attempt.claimed) return@post
                         attempt.terminal = result
+                        attempt.lastTiming = result.timing
                         resolveCloudLiveAttempt(attempt)
                     }
                 }
@@ -881,7 +892,17 @@ class DictationRuntime internal constructor(
             if (!attempt.claimed && attempt.finalWait == null) {
                 val timeout = Runnable {
                     attempt.finalWait = null
-                    if (cloudLiveAttempt === attempt && !attempt.claimed) startCloudLiveBatchFallback(attempt)
+                    // No terminal ever arrived within the bounded wait -- the mid-stream drop /
+                    // wedged-socket case, which reports no CloudLiveFailureReason of its own
+                    // (#233 item 10). Distinguished from FALLBACK_FAILED so a device trial can
+                    // tell "the session told us it broke" from "the session went silent".
+                    if (cloudLiveAttempt === attempt && !attempt.claimed) {
+                        startCloudLiveBatchFallback(
+                            attempt,
+                            if (attempt.terminal == null) CloudLiveOutcome.FALLBACK_NO_TERMINAL
+                            else CloudLiveOutcome.FALLBACK_FAILED,
+                        )
+                    }
                 }
                 attempt.finalWait = timeout
                 handler.postDelayed(timeout, CLOUD_LIVE_FINAL_WAIT_MS)
@@ -899,7 +920,7 @@ class DictationRuntime internal constructor(
             is CloudLiveTerminal.Success -> {
                 if (terminal.text.isBlank() || result.pcmFile == null ||
                     isBelowMinimumDuration(result.pcmFile.length(), SAMPLE_RATE)) {
-                    startCloudLiveBatchFallback(attempt)
+                    startCloudLiveBatchFallback(attempt, CloudLiveOutcome.FALLBACK_UNUSABLE_FINAL)
                     return
                 }
                 attempt.claimed = true
@@ -909,13 +930,44 @@ class DictationRuntime internal constructor(
                 runCatching { attempt.session?.close() }
                 result.pcmFile.delete()
                 result.compressedFile?.delete()
+                logCloudLiveAttempt(attempt, CloudLiveOutcome.LIVE_DELIVERED)
                 thread { handleTranscriptionResult(terminal.text, attempt.token, attempt.lease) }
             }
-            is CloudLiveTerminal.Failure -> startCloudLiveBatchFallback(attempt)
+            is CloudLiveTerminal.Failure -> startCloudLiveBatchFallback(attempt, CloudLiveOutcome.FALLBACK_FAILED)
         }
     }
 
-    private fun startCloudLiveBatchFallback(attempt: CloudLiveAttempt) {
+    /**
+     * Writes this attempt's timing + outcome to the existing per-dictation [BenchmarkLogger] line
+     * (#233 Phase 1 item 10).
+     *
+     * The reason this exists at all: the live->batch fallback is lossless, so on a real device a
+     * live failure and a live success look identical from the outside -- the same text is
+     * delivered the same way either way. Without a durable record, nobody can tell whether live
+     * ever ran, which makes the device acceptance gate unfalsifiable.
+     *
+     * Correlated by [correlationIdFor] on the attempt's own token, i.e. the exact id the
+     * transcription/cleanup/pipeline lines for this same dictation already use -- no second id
+     * scheme. Emitted as its own JSONL line (not folded into another call site's line) because
+     * live resolution happens strictly before the batch/cleanup lines are written and a line is
+     * self-contained by design; a reader groups on correlationId, which is what that key is for.
+     *
+     * Length-only, like the rest of this log: durations, enum names and booleans, never the
+     * interim or final text. Failure-isolated -- [BenchmarkLogger.log] already wraps its I/O in
+     * runCatching on a daemon executor, and the extra runCatching here means even a malformed
+     * derivation can't take the delivery path down with it.
+     */
+    private fun logCloudLiveAttempt(attempt: CloudLiveAttempt, outcome: CloudLiveOutcome) {
+        runCatching {
+            BenchmarkLogger.log(
+                context = context,
+                correlationId = correlationIdFor(attempt.token),
+                cloudLive = cloudLiveBenchmarkStage(outcome, attempt.terminal, attempt.lastTiming),
+            )
+        }.onFailure { Log.w(TAG, "Couldn't record cloud-live benchmark timing", it) }
+    }
+
+    private fun startCloudLiveBatchFallback(attempt: CloudLiveAttempt, outcome: CloudLiveOutcome) {
         val result = attempt.recordingResult ?: return
         if (attempt.claimed || cloudLiveAttempt !== attempt || sessionLease !== attempt.lease) return
         attempt.claimed = true
@@ -923,6 +975,7 @@ class DictationRuntime internal constructor(
         attempt.finalWait = null
         cloudLiveAttempt = null
         runCatching { attempt.session?.close() }
+        logCloudLiveAttempt(attempt, outcome)
         onCloudLiveBatchFallback()
         thread { continueTranscription(result, attempt.token, attempt.lease) }
     }

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
@@ -295,8 +295,19 @@ class GeminiCloudLiveTranscriptionClient(
             }
 
             override fun onMessage(webSocket: WebSocket, text: String) = onText(text)
+
+            /**
+             * Gemini Live delivers its JSON events as binary frames as well as text
+             * ones; the frame opcode is not part of the protocol contract. Decode and
+             * parse them identically instead of treating binary as fatal. Malformed
+             * bytes still fail closed via [onText]'s JSON parse.
+             */
             override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
-                fail(CloudLiveFailureReason.PROTOCOL_ERROR, "Unexpected binary live transcription event")
+                if (bytes.size > MAX_INBOUND_BYTES) {
+                    fail(CloudLiveFailureReason.PROTOCOL_ERROR, "Live transcription message too large")
+                    return
+                }
+                onText(bytes.utf8())
             }
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 fail(CloudLiveFailureReason.NETWORK_ERROR, t.message ?: "Live transcription network failure")

--- a/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClient.kt
@@ -312,6 +312,18 @@ class GeminiCloudLiveTranscriptionClient(
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 fail(CloudLiveFailureReason.NETWORK_ERROR, t.message ?: "Live transcription network failure")
             }
+            /**
+             * OkHttp's default onClosing does not echo the close frame, so a
+             * server-initiated close never advances to onClosed -- verified: a
+             * 6s wait yields onClosing(1011) and nothing else. Handling only
+             * onClosed left a mid-stream server close with no terminal at all,
+             * stalling the session until the final timeout expired. Treat the
+             * close frame itself as the terminal.
+             */
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                if (!terminal.get()) fail(CloudLiveFailureReason.NETWORK_ERROR, "Live transcription connection closed")
+            }
+
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 if (!terminal.get()) fail(CloudLiveFailureReason.NETWORK_ERROR, "Live transcription connection closed")
             }

--- a/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
@@ -216,7 +216,11 @@ class RamblrImeService : InputMethodService() {
             runHistoryWrite = ImeHistoryWriteExecutor::execute,
             postToMain = { mainHandler.post(it) },
         )
-        createdRuntime = DictationRuntime(this, controller.listener)
+        // #233 Phase 1: the IME is the first (and only) host to reach the merged cloud-live seam.
+        // CloudLiveWiring returns null unless the user opted in, chose cloud transcription, and
+        // has a Gemini key -- so the default construction is byte-for-byte the previous behavior.
+        // Accessibility stays final-only in this phase and is intentionally not wired.
+        createdRuntime = DictationRuntime(this, controller.listener, cloudLiveFactory = CloudLiveWiring.factoryOrNull(this))
         panelController = controller
         runtime = createdRuntime
         controller.onEditorChanged(editorGeneration, editorIdentity, currentInputConnection)

--- a/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/SettingsSubtitles.kt
@@ -62,6 +62,28 @@ fun vocabularyMainRowSubtitleText(termCount: Int): String {
 }
 
 /**
+ * The Cloud screen's experimental "Live cloud transcription" row subtitle (#233 Phase 1).
+ *
+ * Mirrors [CloudLiveWiring.isLiveAllowed]'s three conditions so the row can never claim the
+ * feature is running when the wiring would in fact hand back null. When the switch is on but a
+ * precondition is missing, the subtitle names the specific missing piece rather than a generic
+ * "not configured" -- the toggle looks satisfied at that point, so the row is the only place the
+ * user can find out why nothing changed.
+ *
+ * Pure (no Context) so the on/blocked/off wording is unit-testable, like the rest of this file.
+ */
+fun cloudLiveSubtitleText(
+    enabled: Boolean,
+    useLocalTranscription: Boolean,
+    hasGeminiKey: Boolean,
+): String = when {
+    !enabled -> "Off — cloud transcription returns your text once you stop speaking"
+    useLocalTranscription -> "On, but transcription is set to on-device — needs cloud transcription above"
+    !hasGeminiKey -> "On, but no Gemini key is set — add a Gemini provider above"
+    else -> "On — the keyboard streams to Gemini as you speak. Experimental, costs more than batch"
+}
+
+/**
  * The Behavior screen's "Personal vocabulary" row subtitle: the term list itself, prefixed with
  * the #185 inert-setting warning when nothing in the current configuration applies the terms.
  * Extracted from BehaviorActivity's private `vocabularySummary` (#217) so it's unit-testable and

--- a/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveBenchmarkTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveBenchmarkTest.kt
@@ -1,0 +1,524 @@
+package com.trevornk.ramblr
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.os.Looper
+import java.io.File
+import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * #233 Phase 1 item 10: cloud-live timing + fallback reason must survive the dictation that
+ * produced them.
+ *
+ * These are not schema tests for their own sake. The live -> batch fallback is deliberately
+ * LOSSLESS -- a failed live attempt replays the preserved recording through the ordinary batch
+ * chain and the user gets the same text, delivered the same way. That makes a live failure
+ * completely invisible from the outside: on a real device there is no way to tell "live served
+ * this dictation" from "live silently died on every single utterance and batch covered for it".
+ * Everything below exists so that distinction is readable off `benchmark_log.jsonl` after the
+ * fact, which is the only reason a device trial can produce evidence at all.
+ *
+ * The privacy assertion is equally load-bearing: [BenchmarkLogger] is documented as length-only
+ * and the issue says "without transcript content", so the interim and final text are asserted
+ * absent against distinctive sentinel strings rather than merely "not obviously present".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class CloudLiveBenchmarkTest {
+
+    /** A sentinel that could never occur incidentally in JSON structure or an enum name, so an
+     *  "is the transcript in the log" assertion cannot pass by accident. */
+    private companion object {
+        const val SECRET_FINAL = "zqx-final-transcript-must-never-be-logged"
+        const val SECRET_INTERIM = "zqx-interim-transcript-must-never-be-logged"
+    }
+
+    private lateinit var app: Application
+    private lateinit var listener: RecordingListener
+    private lateinit var engines: MutableList<FakeRecordingEngine>
+    private lateinit var leaseRegistry: InMemoryDictationSessionLeaseRegistry
+    private lateinit var runtime: DictationRuntime
+    private lateinit var batchServer: MockWebServer
+
+    private class RecordingListener : RuntimeListener {
+        val delivered = mutableListOf<String>()
+        val interims = mutableListOf<String>()
+        override fun onRecordingStartRequested() = Unit
+        override fun onRecordingStartFailed() = Unit
+        override fun onRecordingStarted() = Unit
+        override fun onEnterTranscribingUi() = Unit
+        override fun onIdleUi() = Unit
+        override fun onStreamingTeardown() = Unit
+        override fun onStreamingPartial(text: String) = Unit
+        override fun onCloudLiveInterim(text: String) { interims += text }
+        override fun deliverText(
+            text: String,
+            rawText: String?,
+            paidFallbackGroup: CleanupStepGroup?,
+            cleanupError: String?,
+            feedbackDurationMs: Long,
+        ) { delivered += text }
+        override fun foregroundPackageName(): String? = null
+    }
+
+    @Before fun setUp() {
+        app = RuntimeEnvironment.getApplication()
+        shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+        listener = RecordingListener()
+        engines = mutableListOf()
+        leaseRegistry = InMemoryDictationSessionLeaseRegistry()
+        batchServer = MockWebServer().apply { start() }
+        // The log is app-private and append-only; Robolectric reuses filesDir across tests in a
+        // class, so start every case from a known-empty file rather than a leftover tail.
+        BenchmarkLogger.logFile(app).delete()
+    }
+
+    @After fun tearDown() {
+        batchServer.shutdown()
+    }
+
+    private fun idleMainLooper() = shadowOf(Looper.getMainLooper()).idle()
+
+    private fun realSizedPcm(): File = File.createTempFile("rec_", ".pcm", app.cacheDir).apply {
+        writeBytes(ByteArray(32_000)) // 1s of 16kHz mono 16-bit, comfortably over the #192 floor
+    }
+
+    private fun cloudLiveRuntime(factory: FakeCloudLiveFactory) {
+        runtime = DictationRuntime(app, listener, leaseRegistry, cloudLiveFactory = factory) {
+            cacheDir, stateMachine -> FakeRecordingEngine(cacheDir, stateMachine).also { engines += it }
+        }
+    }
+
+    /** Same batch stub DictationRuntimeTest uses, so a fallback case actually walks the real
+     *  batch chain and emits its own transcription line to correlate against. */
+    private fun stubBatchProvider(transcript: String) {
+        batchServer.enqueue(MockResponse().setBody(JSONObject().put("text", transcript).toString()))
+        val base = batchServer.url("/v1").toString().trimEnd('/')
+        ProviderChainStore.save(
+            app,
+            ProviderChain(listOf(ProviderChainEntry(ProviderKind.OPENAI, "gpt-5.4-mini", baseUrlOverride = base, transcriptionModel = "gpt-transcribe"))),
+        )
+        ProviderCredentialStore.set(app, ProviderKind.OPENAI, "test-batch-key")
+        app.getSharedPreferences("ramblr", Context.MODE_PRIVATE).edit().putBoolean("use_local", false).apply()
+        PostProcessingToggle.setEnabled(app, false)
+    }
+
+    /** [BenchmarkLogger] defers its append to a daemon executor, so a reader has to wait for it. */
+    private fun awaitCloudLiveLine(): JSONObject {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            idleMainLooper()
+            val line = logLines().firstOrNull { !it.isNull("cloudLive") }
+            if (line != null) return line
+            Thread.sleep(10)
+        }
+        throw AssertionError("no cloudLive benchmark line was written; file=${rawLog()}")
+    }
+
+    private fun rawLog(): String =
+        BenchmarkLogger.logFile(app).takeIf { it.exists() }?.readText().orEmpty()
+
+    private fun logLines(): List<JSONObject> =
+        rawLog().lineSequence().filter { it.isNotBlank() }.map { JSONObject(it) }.toList()
+
+    // --- the three durations item 10 names, on a live attempt that actually served the text ---
+
+    @Test
+    fun `a delivered live attempt records setup, first-interim and end-of-audio-to-final durations`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        session.interim(SECRET_INTERIM, CloudLiveTiming(connectStartedAtMs = 1_000, firstInterimAtMs = 1_400))
+        idleMainLooper()
+
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(
+            CloudLiveTerminal.Success(
+                SECRET_FINAL,
+                CloudLiveTiming(
+                    connectStartedAtMs = 1_000,
+                    socketOpenedAtMs = 1_050,
+                    setupCompletedAtMs = 1_180,
+                    firstInterimAtMs = 1_400,
+                    activityEndedAtMs = 5_000,
+                    finalAtMs = 5_320,
+                ),
+            ),
+        )
+        idleMainLooper()
+
+        val line = awaitCloudLiveLine()
+        val live = line.getJSONObject("cloudLive")
+        assertEquals("LIVE_DELIVERED", live.getString("outcome"))
+        assertFalse("live served this dictation, so nothing fell back", live.getBoolean("fellBackToBatch"))
+        assertTrue(live.isNull("failureReason"))
+        assertEquals(180L, live.getLong("setupMs"))
+        assertEquals(400L, live.getLong("firstInterimMs"))
+        assertEquals("the headline post-stop number", 320L, live.getLong("endOfAudioToFinalMs"))
+        assertTrue(live.isNull("error"))
+    }
+
+    // --- a failed attempt has to name the reason, or a device trial learns nothing ---
+
+    @Test
+    fun `a failed live attempt records the specific failure reason and marks the batch fallback`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        stubBatchProvider("batch covered for the failed live attempt")
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(
+            CloudLiveTerminal.Failure(
+                CloudLiveFailureReason.NETWORK_ERROR,
+                "socket closed mid-stream",
+                CloudLiveTiming(connectStartedAtMs = 2_000, setupCompletedAtMs = 2_090, activityEndedAtMs = 7_000),
+            ),
+        )
+        idleMainLooper()
+
+        val line = awaitCloudLiveLine()
+        val live = line.getJSONObject("cloudLive")
+        assertEquals("FALLBACK_FAILED", live.getString("outcome"))
+        assertTrue("the reader must be able to see batch delivered this text", live.getBoolean("fellBackToBatch"))
+        assertEquals("NETWORK_ERROR", live.getString("failureReason"))
+        assertEquals(90L, live.getLong("setupMs"))
+        assertTrue("no interim ever arrived", live.isNull("firstInterimMs"))
+        assertTrue("no final ever arrived", live.isNull("endOfAudioToFinalMs"))
+        assertEquals("socket closed mid-stream", live.getString("error"))
+    }
+
+    @Test
+    fun `a live attempt that never reports a terminal is distinguishable from one that failed`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        stubBatchProvider("batch covered for the silent live attempt")
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        // Setup landed and interims flowed, then the session simply went quiet -- the mid-stream
+        // drop shape, which reports no CloudLiveFailureReason of its own.
+        session.interim(SECRET_INTERIM, CloudLiveTiming(connectStartedAtMs = 3_000, setupCompletedAtMs = 3_120, firstInterimAtMs = 3_500))
+        idleMainLooper()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        idleMainLooper()
+        shadowOf(Looper.getMainLooper()).idleFor(2_501, TimeUnit.MILLISECONDS)
+
+        val live = awaitCloudLiveLine().getJSONObject("cloudLive")
+        assertEquals("FALLBACK_NO_TERMINAL", live.getString("outcome"))
+        assertTrue(live.getBoolean("fellBackToBatch"))
+        assertTrue("a silent session names no reason", live.isNull("failureReason"))
+        assertEquals("but the marks it did emit still survive", 120L, live.getLong("setupMs"))
+        assertEquals(500L, live.getLong("firstInterimMs"))
+    }
+
+    @Test
+    fun `a live success whose final is unusable is not reported as a live delivery`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        stubBatchProvider("batch covered for the blank live final")
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(CloudLiveTerminal.Success("   ", CloudLiveTiming(connectStartedAtMs = 1, activityEndedAtMs = 10, finalAtMs = 42)))
+        idleMainLooper()
+
+        val live = awaitCloudLiveLine().getJSONObject("cloudLive")
+        assertEquals("FALLBACK_UNUSABLE_FINAL", live.getString("outcome"))
+        assertTrue(live.getBoolean("fellBackToBatch"))
+        assertTrue("a blank final is not a session failure", live.isNull("failureReason"))
+        assertEquals(32L, live.getLong("endOfAudioToFinalMs"))
+    }
+
+    // --- the hard constraint: never any transcript content ---
+
+    @Test
+    fun `no interim or final transcript text ever reaches the benchmark log`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        session.interim(SECRET_INTERIM, CloudLiveTiming(connectStartedAtMs = 1_000, firstInterimAtMs = 1_100))
+        idleMainLooper()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(
+            CloudLiveTerminal.Success(
+                SECRET_FINAL,
+                CloudLiveTiming(connectStartedAtMs = 1_000, setupCompletedAtMs = 1_050, firstInterimAtMs = 1_100, activityEndedAtMs = 4_000, finalAtMs = 4_200),
+            ),
+        )
+        idleMainLooper()
+        awaitCloudLiveLine()
+
+        // The interim WAS shown to the user (so this isn't vacuous) and the final WAS delivered,
+        // yet neither may appear anywhere in the durable log.
+        assertTrue("the interim must actually have been surfaced", listener.interims.contains(SECRET_INTERIM))
+        val log = rawLog()
+        assertFalse("the final transcript leaked into benchmark_log.jsonl", log.contains(SECRET_FINAL))
+        assertFalse("an interim transcript leaked into benchmark_log.jsonl", log.contains(SECRET_INTERIM))
+    }
+
+    @Test
+    fun `a failure message that echoes the transcript is bounded by sanitizeError`() {
+        // A provider error envelope can quote the request that caused it. The stage must route
+        // through sanitizeError like every other error field: collapsed (JSONL is line-oriented,
+        // so an embedded newline would split one record into two unparseable fragments) and
+        // capped at MAX_ERROR_DETAIL_CHARS.
+        val stage = cloudLiveBenchmarkStage(
+            outcome = CloudLiveOutcome.FALLBACK_FAILED,
+            terminal = CloudLiveTerminal.Failure(
+                CloudLiveFailureReason.PROTOCOL_ERROR,
+                "rejected\n" + "x".repeat(MAX_ERROR_DETAIL_CHARS * 3),
+                CloudLiveTiming(connectStartedAtMs = 1),
+            ),
+            timing = null,
+        )
+        val error = requireNotNull(stage.error)
+        assertFalse("a newline would split the JSONL record", error.contains("\n"))
+        assertEquals(MAX_ERROR_DETAIL_CHARS + 3, error.length)
+        assertTrue(error.endsWith("..."))
+    }
+
+    // --- correlation with the dictation the live attempt belongs to ---
+
+    @Test
+    fun `the cloud-live line shares the dictation's existing correlationId with its batch line`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        stubBatchProvider("batch transcript")
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(CloudLiveTerminal.Failure(CloudLiveFailureReason.SETUP_TIMEOUT, "setup timed out", CloudLiveTiming(1)))
+        idleMainLooper()
+
+        val liveCorrelationId = awaitCloudLiveLine().getString("correlationId")
+        // The same dictation's batch transcription line must land under the identical id, which
+        // is the whole point of reusing correlationIdFor(token) rather than minting a new scheme.
+        val deadline = System.currentTimeMillis() + 5_000
+        var batchLine: JSONObject? = null
+        while (System.currentTimeMillis() < deadline && batchLine == null) {
+            idleMainLooper()
+            batchLine = logLines().firstOrNull { !it.isNull("transcription") }
+            Thread.sleep(10)
+        }
+        assertNotNull("the batch fallback must still have produced its own line", batchLine)
+        assertEquals(liveCorrelationId, batchLine!!.getString("correlationId"))
+        assertTrue("ids stay in the existing tok-<launch>-<token> shape", liveCorrelationId.startsWith("tok-"))
+    }
+
+    // --- backward compatibility: existing consumers must keep working ---
+
+    @Test
+    fun `a cloud-live line keeps every pre-existing key and an ordinary line keeps a null cloudLive`() {
+        val json = JSONObject(
+            BenchmarkLogger.buildLine(
+                timestamp = 1_700_000_000_000L,
+                correlationId = "tok-7",
+                transcription = BenchmarkStage("OPENAI", "gpt-4o-transcribe", 812L, success = true),
+                cleanup = null,
+                rawTextLength = 12,
+                cleanedTextLength = null,
+            ),
+        )
+        // Every consumer (BackupManager's ENTRY_BENCHMARK_LOG copy, DataLogsActivity's share,
+        // and the existing tests) reads these keys; an additive block must not disturb them.
+        assertEquals(1_700_000_000_000L, json.getLong("timestamp"))
+        assertEquals("tok-7", json.getString("correlationId"))
+        assertEquals(12, json.getInt("rawTextLength"))
+        assertTrue(json.isNull("cleanedTextLength"))
+        assertTrue(json.isNull("cleanup"))
+        assertTrue(json.isNull("pipeline"))
+        assertEquals("OPENAI", json.getJSONObject("transcription").getString("provider"))
+        assertTrue("a line with no live attempt still carries the key, as JSON null", json.isNull("cloudLive"))
+
+        val withLive = JSONObject(
+            BenchmarkLogger.buildLine(
+                timestamp = 2L,
+                correlationId = "tok-8",
+                transcription = null,
+                cleanup = null,
+                rawTextLength = null,
+                cleanedTextLength = null,
+                cloudLive = CloudLiveStage(
+                    outcome = CloudLiveOutcome.LIVE_DELIVERED.name,
+                    fellBackToBatch = false,
+                    setupMs = 180L,
+                    firstInterimMs = 400L,
+                    endOfAudioToFinalMs = 320L,
+                ),
+            ),
+        )
+        // Still a complete, self-contained record: the additive block never replaces the old keys.
+        assertEquals(2L, withLive.getLong("timestamp"))
+        assertTrue(withLive.isNull("transcription"))
+        assertTrue(withLive.isNull("cleanup"))
+        assertTrue(withLive.isNull("rawTextLength"))
+        assertTrue(withLive.isNull("cleanedTextLength"))
+        assertTrue(withLive.isNull("pipeline"))
+        assertEquals("LIVE_DELIVERED", withLive.getJSONObject("cloudLive").getString("outcome"))
+    }
+
+    // --- failure isolation: observability must never cost a delivery ---
+
+    @Test
+    fun `a benchmark log write failure does not break or block live delivery`() {
+        val factory = FakeCloudLiveFactory()
+        cloudLiveRuntime(factory)
+        // Make the append genuinely impossible: a directory where the log file should be. The
+        // logger's runCatching must swallow it, and the user must still get their text.
+        val logPath = BenchmarkLogger.logFile(app)
+        logPath.delete()
+        assertTrue(logPath.mkdirs())
+        val pcm = realSizedPcm()
+
+        runtime.onTap()
+        val session = factory.sessions.single()
+        runtime.onTap()
+        engines.single().finishAs(pcm, RecordingEngine.StopReason.USER)
+        session.complete(CloudLiveTerminal.Success(SECRET_FINAL, CloudLiveTiming(1, activityEndedAtMs = 2, finalAtMs = 3)))
+        idleMainLooper()
+
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline && listener.delivered.isEmpty()) {
+            idleMainLooper(); Thread.sleep(10)
+        }
+        assertEquals(listOf(SECRET_FINAL), listener.delivered)
+        assertEquals(RecordingStateMachine.State.IDLE, runtime.currentState())
+        logPath.delete()
+    }
+
+    // --- the pure derivation, independent of any host ---
+
+    @Test
+    fun `derivation reports a mark that never happened as null rather than a fabricated zero`() {
+        val stage = cloudLiveBenchmarkStage(
+            outcome = CloudLiveOutcome.FALLBACK_FAILED,
+            terminal = CloudLiveTerminal.Failure(
+                CloudLiveFailureReason.SETUP_TIMEOUT,
+                "setup timed out",
+                CloudLiveTiming(connectStartedAtMs = 500),
+            ),
+            timing = null,
+        )
+        assertNull("setup never completed; 0ms would be a lie", stage.setupMs)
+        assertNull(stage.firstInterimMs)
+        assertNull(stage.endOfAudioToFinalMs)
+        assertEquals("SETUP_TIMEOUT", stage.failureReason)
+        assertTrue(stage.fellBackToBatch)
+    }
+
+    @Test
+    fun `derivation falls back to the last seen interim timing when no terminal ever arrived`() {
+        val stage = cloudLiveBenchmarkStage(
+            outcome = CloudLiveOutcome.FALLBACK_NO_TERMINAL,
+            terminal = null,
+            timing = CloudLiveTiming(connectStartedAtMs = 100, setupCompletedAtMs = 260, firstInterimAtMs = 700),
+        )
+        assertEquals(160L, stage.setupMs)
+        assertEquals(600L, stage.firstInterimMs)
+        assertNull(stage.endOfAudioToFinalMs)
+        assertNull(stage.failureReason)
+        assertNull(stage.error)
+    }
+
+    @Test
+    fun `derivation degrades to outcome only when there are no marks at all`() {
+        val stage = cloudLiveBenchmarkStage(CloudLiveOutcome.FALLBACK_NO_TERMINAL, terminal = null, timing = null)
+        assertEquals("FALLBACK_NO_TERMINAL", stage.outcome)
+        assertTrue(stage.fellBackToBatch)
+        assertNull(stage.setupMs)
+        assertNull(stage.firstInterimMs)
+        assertNull(stage.endOfAudioToFinalMs)
+    }
+
+    /** Same narrow capture-boundary fake DictationRuntimeTest uses (its copy is private to that
+     *  class): start() performs the real engine's synchronous IDLE -> RECORDING claim, and
+     *  [finishAs] runs the same [RecorderHandoff] claim/discard decision the reader thread does,
+     *  so the runtime sees byte-identical state-machine traffic. */
+    private class FakeRecordingEngine(
+        cacheDir: File,
+        private val stateMachine: RecordingStateMachine,
+    ) : RecordingEngine(cacheDir, stateMachine) {
+        var onFinished: ((Result) -> Unit)? = null
+        var onChunk: ((ByteArray, Int) -> Unit)? = null
+
+        override fun start(onFinished: (Result) -> Unit, onChunk: (ByteArray, Int) -> Unit): Boolean {
+            if (!stateMachine.tryStartRecording()) return false
+            this.onFinished = onFinished
+            this.onChunk = onChunk
+            return true
+        }
+
+        override fun awaitTeardown(timeoutMs: Long): Boolean = true
+
+        override fun isReaderTeardownPending(): Boolean = false
+
+        fun finishAs(pcmFile: File?, stopReason: StopReason, superseded: Boolean = false) {
+            if (RecorderHandoff.shouldClaimTranscribing(superseded)) stateMachine.tryStartTranscribing()
+            val discarded = RecorderHandoff.discarded(superseded, stateMachine.current())
+            onFinished!!(
+                Result(
+                    pcmFile = if (!discarded) pcmFile else null,
+                    bytesRecorded = pcmFile?.length() ?: 0L,
+                    discarded = discarded,
+                    stopReason = stopReason,
+                )
+            )
+        }
+    }
+
+    private class FakeCloudLiveFactory : CloudLiveTranscriptionSessionFactory {
+        val sessions = mutableListOf<FakeCloudLiveSession>()
+        override fun create(listener: CloudLiveTranscriptionListener): CloudLiveTranscriptionSession =
+            FakeCloudLiveSession(listener).also(sessions::add)
+    }
+
+    private class FakeCloudLiveSession(
+        private val listener: CloudLiveTranscriptionListener,
+    ) : CloudLiveTranscriptionSession {
+        override fun connect() = Unit
+        override fun startActivity(): Boolean = true
+        override fun sendPcm(buffer: ByteArray, length: Int): Boolean = true
+        override fun endActivity(): Boolean = true
+        override fun cancel() = Unit
+        override fun close() = Unit
+        fun interim(text: String, timing: CloudLiveTiming) = listener.onInterim(text, timing)
+        fun complete(result: CloudLiveTerminal) = listener.onTerminal(result)
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveToggleTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveToggleTest.kt
@@ -1,0 +1,35 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CloudLiveToggleTest {
+
+    private val prefs = FakeStringPrefs()
+
+    @Test fun `defaults to off when never set`() {
+        assertFalse(CloudLiveToggle.isEnabled(prefs))
+    }
+
+    /** The default is the whole point of the phase: live is experimental and costs ~1.8x batch,
+     *  so a regression flipping this constant to true is a shipped behavior change. */
+    @Test fun `the declared default constant is false`() {
+        assertEquals(false, CloudLiveToggle.DEFAULT)
+    }
+
+    @Test fun `setEnabled persists and is read back`() {
+        CloudLiveToggle.setEnabled(prefs, true)
+        assertTrue(CloudLiveToggle.isEnabled(prefs))
+        CloudLiveToggle.setEnabled(prefs, false)
+        assertFalse(CloudLiveToggle.isEnabled(prefs))
+    }
+
+    @Test fun `writes under its own key without disturbing the cloud transcription gate`() {
+        prefs.edit().putBoolean("use_local", true).apply()
+        CloudLiveToggle.setEnabled(prefs, true)
+        assertEquals(true, prefs.getBoolean(CloudLiveToggle.KEY, false))
+        assertTrue("live toggle must not touch use_local", prefs.getBoolean("use_local", false))
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveWiringTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveWiringTest.kt
@@ -1,0 +1,167 @@
+package com.trevornk.ramblr
+
+import android.app.Application
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * The #233 Phase 1 gate: [CloudLiveWiring] is the only thing standing between a user and the
+ * merged cloud-live seam, so every one of its three conditions is asserted independently and in
+ * combination. Nothing here touches the network -- a factory is only ever *constructed*, and
+ * [CloudLiveTranscriptionSessionFactory.create] opens no socket until `connect()` is called.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class CloudLiveWiringTest {
+
+    private lateinit var app: Application
+
+    @Before fun setUp() {
+        app = RuntimeEnvironment.getApplication()
+        // SecurePrefsFactory caches its EncryptedSharedPreferences per name for the whole process,
+        // so a credential written by an earlier test survives Robolectric's per-test app reset.
+        // Clear both stores explicitly rather than relying on a fresh-install starting state.
+        prefs().edit().clear().apply()
+        ProviderKind.values().forEach { ProviderCredentialStore.clear(app, it) }
+    }
+
+    private fun prefs() = app.getSharedPreferences("ramblr", Context.MODE_PRIVATE)
+
+    private fun setUseLocal(useLocal: Boolean) {
+        prefs().edit().putBoolean("use_local", useLocal).apply()
+    }
+
+    /** All three conditions satisfied: opted in, cloud transcription selected, Gemini key set. */
+    private fun configureFullyEnabled() {
+        CloudLiveToggle.setEnabled(app, true)
+        setUseLocal(false)
+        ProviderCredentialStore.set(app, ProviderKind.GEMINI, "test-gemini-key")
+    }
+
+    // --- factoryOrNull: the three gating conditions ---
+
+    @Test fun `null on a default install where nothing has been opted into`() {
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `null when the toggle is off even with cloud selected and a key present`() {
+        configureFullyEnabled()
+        CloudLiveToggle.setEnabled(app, false)
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `null when the toggle is on but transcription is on-device`() {
+        configureFullyEnabled()
+        setUseLocal(true)
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    /** use_local is absent, not false, on a fresh install -- the default must read as local. */
+    @Test fun `null when the toggle is on and use_local has never been written`() {
+        CloudLiveToggle.setEnabled(app, true)
+        ProviderCredentialStore.set(app, ProviderKind.GEMINI, "test-gemini-key")
+        prefs().edit().remove("use_local").apply()
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `null when opted in and cloud selected but the Gemini credential is blank`() {
+        configureFullyEnabled()
+        ProviderCredentialStore.set(app, ProviderKind.GEMINI, "")
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `null when opted in and cloud selected but the Gemini credential was cleared`() {
+        configureFullyEnabled()
+        ProviderCredentialStore.clear(app, ProviderKind.GEMINI)
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    /** A key for some *other* provider is not a Gemini key -- live is Gemini-only in Phase 1. */
+    @Test fun `null when only a non-Gemini credential is configured`() {
+        CloudLiveToggle.setEnabled(app, true)
+        setUseLocal(false)
+        ProviderCredentialStore.set(app, ProviderKind.OPENAI, "test-openai-key")
+        assertNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `non-null only when all three conditions hold`() {
+        configureFullyEnabled()
+        assertNotNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `the constructed factory produces a session`() {
+        configureFullyEnabled()
+        val factory = CloudLiveWiring.factoryOrNull(app)
+        assertNotNull(factory)
+        val session = factory!!.create(object : CloudLiveTranscriptionListener {
+            override fun onInterim(text: String, timing: CloudLiveTiming) = Unit
+            override fun onTerminal(result: CloudLiveTerminal) = Unit
+        })
+        assertNotNull(session)
+        // Never connected, so this opens nothing; close stays idempotent per the seam's contract.
+        session.close()
+        session.close()
+    }
+
+    @Test fun `the factory is built against the production Gemini live client`() {
+        configureFullyEnabled()
+        val factory = CloudLiveWiring.factoryOrNull(app)
+        assertTrue(factory is GeminiCloudLiveTranscriptionClient)
+        // Production endpoint only -- the test-endpoint escape hatch must never be wired on.
+        assertFalse((factory as GeminiCloudLiveTranscriptionClient).allowTestEndpoint)
+    }
+
+    /** An oversized personal vocabulary must degrade to fewer hints, not fail the whole factory
+     *  (the client rejects more than MAX_CUSTOM_VOCABULARY terms outright). */
+    @Test fun `an oversized custom vocabulary is truncated rather than disabling live`() {
+        configureFullyEnabled()
+        val terms = (1..GeminiCloudLiveTranscriptionClient.MAX_CUSTOM_VOCABULARY + 50).map { "term-$it" }
+        prefs().edit().putString("custom_vocabulary_terms", VocabularyTerms.serialize(terms)).apply()
+        assertNotNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    @Test fun `an empty custom vocabulary still yields a factory`() {
+        configureFullyEnabled()
+        prefs().edit().putString("custom_vocabulary_terms", "").apply()
+        assertNotNull(CloudLiveWiring.factoryOrNull(app))
+    }
+
+    // --- isLiveAllowed: the pure policy ---
+
+    @Test fun `isLiveAllowed requires all three inputs`() {
+        assertTrue(CloudLiveWiring.isLiveAllowed(true, useLocalTranscription = false, geminiKey = "k"))
+        assertFalse(CloudLiveWiring.isLiveAllowed(false, useLocalTranscription = false, geminiKey = "k"))
+        assertFalse(CloudLiveWiring.isLiveAllowed(true, useLocalTranscription = true, geminiKey = "k"))
+        assertFalse(CloudLiveWiring.isLiveAllowed(true, useLocalTranscription = false, geminiKey = ""))
+        assertFalse(CloudLiveWiring.isLiveAllowed(true, useLocalTranscription = false, geminiKey = "   "))
+    }
+
+    // --- the settings row's wording tracks the same gate ---
+
+    @Test fun `the subtitle names the specific blocker instead of a generic message`() {
+        assertTrue(cloudLiveSubtitleText(false, useLocalTranscription = false, hasGeminiKey = true).startsWith("Off"))
+        assertTrue(cloudLiveSubtitleText(true, useLocalTranscription = true, hasGeminiKey = true).contains("on-device"))
+        assertTrue(cloudLiveSubtitleText(true, useLocalTranscription = false, hasGeminiKey = false).contains("Gemini key"))
+        assertTrue(cloudLiveSubtitleText(true, useLocalTranscription = false, hasGeminiKey = true).startsWith("On —"))
+    }
+
+    /** The row must not claim live is running in any state where the wiring would return null. */
+    @Test fun `the subtitle only reads as fully on when isLiveAllowed agrees`() {
+        val states = listOf(true, false)
+        for (enabled in states) for (useLocal in states) for (hasKey in states) {
+            val subtitle = cloudLiveSubtitleText(enabled, useLocal, hasKey)
+            val allowed = CloudLiveWiring.isLiveAllowed(enabled, useLocal, if (hasKey) "k" else "")
+            assertEquals("enabled=$enabled useLocal=$useLocal hasKey=$hasKey", allowed, subtitle.startsWith("On —"))
+        }
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
@@ -10,6 +10,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
@@ -326,8 +327,52 @@ class GeminiCloudLiveTranscriptionClientTest {
         allowTestEndpoint = true,
     )
 
-    private fun scriptedSocket(vararg events: String, delayMs: Long = 0): ServerScript {
-        val script = ServerScript(events.toList(), delayMs)
+    /**
+     * Regression: Gemini Live delivers its JSON events as binary frames. Treating
+     * binary as a protocol violation killed every real session before
+     * setupComplete, so live transcription always fell back to batch. Every other
+     * test in this class drives the String overload, which is why the field defect
+     * survived a green suite.
+     */
+    @Test fun `binary json frames parse identically to text frames`() {
+        val listener = RecordingListener()
+        val socket = scriptedSocket(
+            "{\"setupComplete\":{}}",
+            "{\"serverContent\":{\"interimInputTranscription\":{\"text\":\"hel\"}}}",
+            "{\"serverContent\":{\"inputTranscription\":{\"text\":\"hello\"}}}",
+            binary = true,
+        )
+        val session = factory().create(listener)
+        session.connect(); session.startActivity(); session.endActivity()
+
+        assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+        Thread.sleep(50)
+        assertEquals(listOf("hel"), listener.interims)
+        val success = listener.result as CloudLiveTerminal.Success
+        assertEquals("hello", success.text)
+        assertEquals(1, listener.terminals)
+        assertTrue(success.timing.setupCompletedAtMs != null)
+        socket.awaitMessages()
+    }
+
+    @Test fun `oversized binary frame fails closed without decoding`() {
+        val listener = RecordingListener()
+        scriptedSocket(
+            "{\"setupComplete\":{}}",
+            "{\"pad\":\"" + "x".repeat(GeminiCloudLiveTranscriptionClient.MAX_INBOUND_BYTES + 1) + "\"}",
+            binary = true,
+        )
+        val session = factory().create(listener)
+        session.connect(); session.startActivity(); session.endActivity()
+
+        assertTrue(listener.done.await(5, TimeUnit.SECONDS))
+        val failure = listener.result as CloudLiveTerminal.Failure
+        assertEquals(CloudLiveFailureReason.PROTOCOL_ERROR, failure.reason)
+        assertEquals(1, listener.terminals)
+    }
+
+    private fun scriptedSocket(vararg events: String, delayMs: Long = 0, binary: Boolean = false): ServerScript {
+        val script = ServerScript(events.toList(), delayMs, binary)
         server.enqueue(MockResponse().withWebSocketUpgrade(script))
         return script
     }
@@ -338,12 +383,18 @@ class GeminiCloudLiveTranscriptionClientTest {
         }
     }
 
-    private class ServerScript(private val events: List<String>, private val delayMs: Long) : ClosingWebSocketListener() {
+    private class ServerScript(
+        private val events: List<String>,
+        private val delayMs: Long,
+        private val binary: Boolean = false,
+    ) : ClosingWebSocketListener() {
         private val received = CountDownLatch(1)
         override fun onOpen(webSocket: WebSocket, response: Response) {
             Thread {
                 if (delayMs > 0) Thread.sleep(delayMs)
-                events.forEach { webSocket.send(it) }
+                events.forEach { event ->
+                    if (binary) webSocket.send(event.encodeUtf8()) else webSocket.send(event)
+                }
             }.start()
         }
         override fun onMessage(webSocket: WebSocket, text: String) { received.countDown() }

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
@@ -371,6 +371,46 @@ class GeminiCloudLiveTranscriptionClientTest {
         assertEquals(1, listener.terminals)
     }
 
+    /**
+     * The real mid-stream drop: setup succeeded, interims were flowing, then the
+     * server closes the socket without ever sending a final. This is the
+     * FALLBACK_NO_TERMINAL case, and the one path where a stale interim could
+     * leak out as if it were an authoritative final.
+     *
+     * The server-initiated close arrives as onClosing, and OkHttp's default
+     * onClosing does not echo the close frame, so onClosed never follows
+     * (measured: 6s yields onClosing(1011) alone). Handling only onClosed left
+     * this with no terminal at all until the final timeout expired. Must fail
+     * closed: NETWORK_ERROR, exactly one terminal, no interim promoted.
+     */
+    @Test fun `mid stream server close fails closed without promoting an interim`() {
+        val listener = RecordingListener()
+        server.enqueue(MockResponse().withWebSocketUpgrade(object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                Thread {
+                    webSocket.send("{\"setupComplete\":{}}")
+                    webSocket.send("{\"serverContent\":{\"interimInputTranscription\":{\"text\":\"partial words\"}}}")
+                    Thread.sleep(50)
+                    webSocket.close(1011, "server gone")
+                }.start()
+            }
+        }))
+        // Long final timeout: if the timeout were what rescued this, the test
+        // would take 30s. It must terminate from the close itself, in well under that.
+        val session = factory(finalTimeoutMs = 30_000).create(listener)
+        val started = System.currentTimeMillis()
+        session.connect(); session.startActivity()
+
+        assertTrue(listener.done.await(10, TimeUnit.SECONDS))
+        val elapsed = System.currentTimeMillis() - started
+        assertTrue("terminal came from the close, not the final timeout (took ${elapsed}ms)", elapsed < 10_000)
+        Thread.sleep(50)
+        val failure = listener.result as CloudLiveTerminal.Failure
+        assertEquals(CloudLiveFailureReason.NETWORK_ERROR, failure.reason)
+        assertEquals(1, listener.terminals)
+        assertEquals("an interim must never be promoted to a final", listOf("partial words"), listener.interims)
+    }
+
     private fun scriptedSocket(vararg events: String, delayMs: Long = 0, binary: Boolean = false): ServerScript {
         val script = ServerScript(events.toList(), delayMs, binary)
         server.enqueue(MockResponse().withWebSocketUpgrade(script))


### PR DESCRIPTION
Closes the gap left by #234: the cloud-live client and `DictationRuntime`'s live/fallback path are merged, but `cloudLiveFactory` is null in every shipped host, so **no user can reach any of it**. This is the construction/gating layer plus the settings switch that makes it reachable for the first time.

## What is gated, and how

`CloudLiveWiring.factoryOrNull(context)` is the single decision point. It returns `null` unless **all three** hold:

1. **`CloudLiveToggle` is on** — the user's explicit opt-in, **`DEFAULT = false`**.
2. **Cloud transcription is actually selected** — the existing `use_local` pref that `DictationRuntime` itself branches on. Not a new gate.
3. **A Gemini credential exists** — `ProviderCredentialStore.get(context, ProviderKind.GEMINI)` is non-blank, the same source the batch GEMINI branch reads.

Returning `null` reproduces the previous construction byte-for-byte, so **a default install sees no behavior change at all**.

## Default is OFF, deliberately

Live streams audio for the whole recording rather than uploading one file at the end: roughly **1.8x batch pricing**, and unproven. It has to be a thing the user reaches for, never a thing that happens to them. `CloudLiveToggleTest` asserts the default constant directly so a regression flipping it is a failing test, not a silent shipped change.

## Scope

- **IME host only.** `RamblrImeService` is the one wiring site. **`WhisperAccessibilityService.kt` is not modified** — Phase 1 is IME-first and accessibility remains final-only.
- **`DictationRuntime.kt` is not modified.** The live path, interim callbacks, terminal resolution, and lossless batch fallback all already exist behind the null check; this only supplies a non-null factory. The merged `CloudLiveTranscription.kt` / `GeminiCloudLiveTranscriptionClient.kt` are likewise untouched.
- No change to the shipped transcription default, the provider catalog, the provider chain, `ProviderChainMigration`, or any picker. The switch persists intent only — it never edits `use_local`, the chain, or a credential.

## Settings UI

New "Experimental" section at the bottom of the Cloud screen, below the chain and the per-feature overrides since it changes neither. `cloudLiveSubtitleText` mirrors `isLiveAllowed`'s three conditions, so the row can never claim live is running where the wiring would return null; when the switch is on but a precondition is missing it names the specific blocker instead of a generic "not configured". A property test walks all eight input combinations and asserts the "On —" wording appears exactly when the gate agrees.

## Decisions worth a reviewer's eye

- **Language codes left at the client default.** I checked — there is no configured language source anywhere in the codebase (the batch Gemini client defaults it the same way). Inventing one would be a new user-facing setting this phase does not own.
- **Oversized vocabulary truncates rather than fails.** The client rejects more than `MAX_CUSTOM_VOCABULARY` terms outright; a user with a huge personal list should get fewer hints, not silently lose live entirely.
- **Construction failure is swallowed into `null`, not thrown.** This runs in the IME's `onCreate`, where a validation `IllegalArgumentException` would take the whole keyboard down instead of disabling an experimental extra. The log line carries neither the credential nor any transcript text.
- **Inline Kotlin strings, not `strings.xml`.** Every other row on this screen is inline; `strings.xml` here holds only manifest/IME/accessibility strings.

## Verification

- `./gradlew testGithubDebugUnitTest --rerun-tasks` — **green: 163 suites, 1716 tests, 0 failures, 0 errors, 0 skipped** (counts read from the JUnit XML). 19 of those are new: `CloudLiveWiringTest` (15), `CloudLiveToggleTest` (4).
- `./gradlew assembleGithubDebug --rerun-tasks` — BUILD SUCCESSFUL.
- No test makes a real network call; the factory is only ever constructed, and a session opens no socket until `connect()`.

## Not done yet

**No device validation has been performed.** Nothing in this PR has run on real hardware — no live session has been established against the real Gemini endpoint, and latency, interim cadence, battery, and flaky-network behavior are all unmeasured. That is precisely why the toggle ships off. On-device validation is the next step before this is recommended to anyone.

---

## Update: #233 Phase 1 item 10 is now implemented (commit `8a6a648`)

Item 10 — *"benchmark timing fields for connection setup, first interim, end-of-audio to final, and fallback reason without transcript content"* — was the one Phase 1 item still missing, and it blocked the device trial rather than merely trimming it.

**Why it blocked the trial.** The live → batch fallback is deliberately **lossless**: a failed live attempt replays the preserved recording through the ordinary batch chain and the user gets the same text, delivered the same way. That is correct product behavior, but it makes a live failure *invisible*. On a phone there was no way to tell "live served this dictation" from "live silently died on every single utterance and batch quietly covered for it" — so the acceptance gate (post-stop latency, setup timing, interim behavior, mid-stream network-drop fallback) had no evidence trail to read afterwards and was unfalsifiable. `CloudLiveTiming` was already populated end-to-end by the client and then **discarded** at `DictationRuntime`'s listener boundary.

### What now gets logged

An optional `cloudLive` block on the existing `benchmark_log.jsonl` line — **not** a parallel log file — so a live attempt correlates with its own dictation's `transcription`/`cleanup`/`pipeline` lines via the `correlationId` already threaded through the runtime (`correlationIdFor(token)`; no second id scheme). Same additive `JSONObject.NULL` convention `pipeline` (#115) and `error` (#138) established, so `BackupManager` (`ENTRY_BENCHMARK_LOG`), `DataLogsActivity` and every existing consumer keep parsing unchanged lines byte-identically.

Real emitted lines (from `CloudLiveBenchmarkTest`, fake data):

```json
{"timestamp":1787942932516,"correlationId":"tok-1787942932510-1","transcription":null,"cleanup":null,"rawTextLength":null,"cleanedTextLength":null,"pipeline":null,"cloudLive":{"outcome":"LIVE_DELIVERED","fellBackToBatch":false,"failureReason":null,"setupMs":180,"firstInterimMs":400,"endOfAudioToFinalMs":320,"error":null}}
{"timestamp":1787942932382,"correlationId":"tok-1787942932367-1","transcription":null,"cleanup":null,"rawTextLength":null,"cleanedTextLength":null,"pipeline":null,"cloudLive":{"outcome":"FALLBACK_FAILED","fellBackToBatch":true,"failureReason":"NETWORK_ERROR","setupMs":90,"firstInterimMs":null,"endOfAudioToFinalMs":null,"error":"socket closed mid-stream"}}
```

- `setupMs` — `connectStarted → setupCompleted`
- `firstInterimMs` — `connectStarted → firstInterim`
- `endOfAudioToFinalMs` — `activityEnded → final`, the headline post-stop number the feature exists to reduce
- `fellBackToBatch` + `failureReason` — the single pair that answers "did live actually serve this text, or did batch?"

All **derived durations**, never wall-clock absolutes, matching `PipelineStage`'s "directly comparable elapsed ms" convention. A mark that never happened logs `null`, never a fabricated `0` — "never happened" and "happened instantly" are different findings.

### Decisions worth a reviewer's eye

- **New `CloudLiveOutcome` enum, deliberately finer-grained than `CloudLiveTerminal`'s two cases.** `FALLBACK_NO_TERMINAL` (the session went silent, names no `CloudLiveFailureReason`) is the mid-stream-drop shape and has to be distinguishable from `FALLBACK_FAILED` (the session told us it broke). A live `Success` whose final is blank or whose recording is under the #192 floor is `FALLBACK_UNUSABLE_FINAL` — a live success that still lost the recording to batch, which would otherwise be misread as a live delivery.
- **`attempt.lastTiming` retains the newest marks from any callback.** Without it, the most interesting real-device failure (drop after setup + interims) would log nothing but nulls; now it still reports that setup landed at 120ms and interims flowed at 500ms before the session went quiet.
- **Extended the existing shape rather than adding a log file.** A JSONL line is self-contained by design and `correlationId` is exactly the grouping key for this; a second file would need its own rotation, its own `BackupManager` entry, its own share action, and would still have to be joined on the same id.

### Hard constraints held

- **Zero transcript content.** Durations, enum names and booleans only — never the interim text, never the final. A test asserts this explicitly against distinctive sentinel strings, with the interim proven to have actually reached the user first so the assertion isn't vacuous. The session's failure message routes through `sanitizeError` (`MAX_ERROR_DETAIL_CHARS`, whitespace collapsed so an embedded newline can't split a JSONL record); the client already redacts the API key out of that message upstream.
- **No behavior change.** The fallback decision, delivery path, and timing semantics are identical — this only observes paths that already existed. `startCloudLiveBatchFallback` gained a parameter; its logic is unchanged.
- **Failure-isolated.** The logging call is `runCatching`-wrapped on top of `BenchmarkLogger`'s own daemon-executor `runCatching`, and a test makes the append genuinely impossible (a directory where the file belongs) and asserts the text is still delivered.
- **`WhisperAccessibilityService.kt` not modified.** `CloudLiveToggle.DEFAULT` still `false`. No change to the shipped default, provider catalog, chain, or any picker.

### Verification

`./gradlew testGithubDebugUnitTest assembleGithubDebug --rerun-tasks` — **green: 164 suites, 1728 tests, 0 failures, 0 errors, 0 skipped** (counts read from the JUnit XML). Exactly the previous 163/1716 plus the 12 new tests in `CloudLiveBenchmarkTest`. `BUILD SUCCESSFUL`, APK produced.

**Still no device validation.** This PR makes a device trial *legible*; it does not constitute one.
