### PR TITLE
Surface the voice keyboard in Invocation settings and fix readiness drift

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.view.inputmethod.InputMethodManager
 import android.widget.ScrollView
 import android.widget.TextView
 import com.google.android.material.materialswitch.MaterialSwitch
@@ -49,6 +50,8 @@ class InvocationActivity : BaseSettingsActivity() {
     private lateinit var systemButtonRowSub: TextView
     private lateinit var volumeKeysRowSub: TextView
     private lateinit var advancedTierRowSub: TextView
+    private lateinit var voiceKeyboardSectionSub: TextView
+    private lateinit var voiceKeyboardRowSub: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -75,6 +78,28 @@ class InvocationActivity : BaseSettingsActivity() {
         }
         systemModeCardSub = systemCard.findViewWithTag("subtitle")
         root.addView(systemCard)
+
+        // --- Voice keyboard (#238): deliberately its OWN section, not a third mode card.
+        // The two cards above are mutually exclusive because they select which accessibility
+        // *component* is PM-enabled (flagRequestAccessibilityButton is static-XML-only, so the
+        // OS classification TOGGLE vs INVISIBLE_TOGGLE is fixed per component). The IME is a
+        // separate OS registration in enabled_input_methods and coexists with either -- both
+        // run simultaneously on a real device. Putting it in the exclusive selector would
+        // encode a mutual exclusivity that does not exist.
+        root.addView(sectionHeader("Voice keyboard"))
+        voiceKeyboardSectionSub = TextView(this).apply {
+            textSize = 13f
+            alpha = 0.7f
+            setPadding(dp(24), 0, dp(24), dp(8))
+            text = "Checking..."
+        }
+        root.addView(voiceKeyboardSectionSub)
+
+        val voiceKeyboardRow = settingsRow("Ramblr keyboard", "Checking...") {
+            onVoiceKeyboardRowTapped()
+        }
+        voiceKeyboardRowSub = voiceKeyboardRow.findViewWithTag("subtitle")
+        root.addView(voiceKeyboardRow)
 
         root.addView(sectionHeader("How to start dictation"))
 
@@ -194,6 +219,82 @@ class InvocationActivity : BaseSettingsActivity() {
             directControl = direct,
         )
         advancedTierRowSub.text = invocationAdvancedTierSubtitleText(granted = direct)
+
+        // Read live from the OS every refresh -- nothing about the keyboard is persisted by
+        // Ramblr, so onResume after a trip to system settings always reflects reality.
+        val keyboardStatus = voiceKeyboardStatus()
+        voiceKeyboardSectionSub.text = invocationVoiceKeyboardSectionSubtitleText(keyboardStatus)
+        voiceKeyboardRowSub.text = invocationVoiceKeyboardSubtitleText(keyboardStatus)
+    }
+
+    // --- #238 voice keyboard --------------------------------------------------------------
+
+    /**
+     * The keyboard's live OS state. Enablement comes from the InputMethodManager's enabled list
+     * and default-ness from Settings.Secure.DEFAULT_INPUT_METHOD, which is a component string
+     * that must be parsed rather than string-compared -- the OS may store either flatten form.
+     */
+    private fun voiceKeyboardStatus(): VoiceKeyboardStatus {
+        val manager = getSystemService(InputMethodManager::class.java)
+        val enabled = manager?.enabledInputMethodList?.any {
+            it.packageName == packageName && it.serviceName == RamblrImeService::class.java.name
+        } == true
+        val default = Settings.Secure.getString(contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        val isDefault = default != null && componentEquals(
+            default,
+            ComponentName(this, RamblrImeService::class.java).flattenToString(),
+        )
+        return resolveVoiceKeyboardStatus(isEnabled = enabled, isDefault = isDefault)
+    }
+
+    /**
+     * Enabling an IME and choosing it as the default live on two different system screens, and
+     * neither is something an app may do for the user -- so this routes to the correct one for
+     * the current state rather than pretending there is one action.
+     */
+    private fun onVoiceKeyboardRowTapped() {
+        val (title, message, positive) = when (voiceKeyboardStatus()) {
+            VoiceKeyboardStatus.DISABLED -> Triple(
+                "Turn on the Ramblr keyboard?",
+                "Android needs you to enable it yourself.\n\n" +
+                    "On the next screen, find \u201cRamblr Voice\u201d in the on-screen keyboard " +
+                    "list and turn it on. Keep your usual keyboard enabled too \u2014 you can " +
+                    "switch between them any time.\n\n" +
+                    "The keyboard works alongside your invocation mode; turning it on does " +
+                    "not change anything above.",
+                "Open keyboard settings",
+            )
+            VoiceKeyboardStatus.ENABLED_NOT_DEFAULT -> Triple(
+                "Switch to the Ramblr keyboard?",
+                "The Ramblr keyboard is on, but another keyboard is still your default, " +
+                    "so it won't open on its own.\n\n" +
+                    "Pick \u201cRamblr Voice\u201d in the switcher to use it now. Your other " +
+                    "keyboard stays enabled.",
+                "Show keyboard switcher",
+            )
+            VoiceKeyboardStatus.DEFAULT -> Triple(
+                "Ramblr keyboard is your default",
+                "It opens automatically in text fields.\n\n" +
+                    "To go back to another keyboard, use the keyboard switcher or Android's " +
+                    "on-screen keyboard settings.",
+                "Open keyboard settings",
+            )
+        }
+        android.app.AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(positive) { _, _ ->
+                // showInputMethodPicker is the OS-sanctioned way to change the active IME; an
+                // app cannot set DEFAULT_INPUT_METHOD itself (WRITE_SECURE_SETTINGS, and even
+                // then it is the user's choice to make).
+                if (voiceKeyboardStatus() == VoiceKeyboardStatus.ENABLED_NOT_DEFAULT) {
+                    getSystemService(InputMethodManager::class.java)?.showInputMethodPicker()
+                } else {
+                    startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+                }
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
     }
 
     // --- Mode switching -------------------------------------------------------------------

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -271,6 +271,69 @@ fun invocationQsTileSubtitleText(canRequestAdd: Boolean): String =
     if (canRequestAdd) "Dictate from the Quick Settings panel — tap to add the tile"
     else "Dictate from the Quick Settings panel — tap for setup steps"
 
+// --- #238 voice-keyboard status -------------------------------------------------------------
+
+/**
+ * The voice keyboard's OS state, which is NOT part of [InvocationMode].
+ *
+ * [InvocationMode] is a strict either/or over a single bit -- which of the two accessibility
+ * *components* is PM-enabled -- because `flagRequestAccessibilityButton` is static-XML-only and
+ * decides the OS's TOGGLE vs INVISIBLE_TOGGLE classification. The IME is a wholly separate OS
+ * registration in `enabled_input_methods` and coexists with either accessibility mode (verified
+ * on device: the Ramblr a11y service and the Ramblr IME run simultaneously). Modelling the
+ * keyboard as a third [InvocationMode] would encode a mutual exclusivity that does not exist.
+ *
+ * All three states are read live from the OS. Nothing here is persisted, so this cannot drift
+ * out of sync with system settings the way a stored setup-mode string can.
+ */
+enum class VoiceKeyboardStatus {
+    /** Not in `enabled_input_methods`: the OS will never show it in the keyboard switcher. */
+    DISABLED,
+
+    /** Enabled and selectable, but another IME is the default -- reachable via the switcher. */
+    ENABLED_NOT_DEFAULT,
+
+    /** Enabled and the current default: it opens automatically in editable fields. */
+    DEFAULT,
+}
+
+/**
+ * Resolve the keyboard's state from the two OS facts that define it. [isDefault] implies
+ * [isEnabled] on a well-behaved system, but the two settings are separate rows and a device in
+ * a strange state must not be reported as DEFAULT while the OS would refuse to show it -- so
+ * enablement is checked first and wins.
+ */
+fun resolveVoiceKeyboardStatus(isEnabled: Boolean, isDefault: Boolean): VoiceKeyboardStatus = when {
+    !isEnabled -> VoiceKeyboardStatus.DISABLED
+    isDefault -> VoiceKeyboardStatus.DEFAULT
+    else -> VoiceKeyboardStatus.ENABLED_NOT_DEFAULT
+}
+
+/**
+ * The "Voice keyboard" row subtitle. Each state names the concrete next action, because the
+ * enable and default steps live on two different system screens and the distinction is exactly
+ * what a user cannot otherwise see.
+ */
+fun invocationVoiceKeyboardSubtitleText(status: VoiceKeyboardStatus): String = when (status) {
+    VoiceKeyboardStatus.DISABLED ->
+        "Off — tap to turn the Ramblr keyboard on in system settings"
+    VoiceKeyboardStatus.ENABLED_NOT_DEFAULT ->
+        "On, but not your default keyboard — switch to it from the keyboard switcher, " +
+            "or tap to make it the default"
+    VoiceKeyboardStatus.DEFAULT ->
+        "On — your default keyboard, opens automatically in text fields"
+}
+
+/**
+ * Section-header text spelling out the coexistence, since the keyboard sits directly below two
+ * cards that ARE mutually exclusive and would otherwise read as a third option in that set.
+ */
+fun invocationVoiceKeyboardSectionSubtitleText(status: VoiceKeyboardStatus): String =
+    if (status == VoiceKeyboardStatus.DISABLED)
+        "A dictation keyboard you can switch to in any text field. Independent of the mode above."
+    else
+        "A dictation keyboard you can switch to in any text field. Works alongside the mode above."
+
 /** The advanced tier's row subtitle: granted state is feature-detected, never assumed. */
 fun invocationAdvancedTierSubtitleText(granted: Boolean): String =
     if (granted) "Active — shortcut changes apply in-app, without the system Settings round-trip"

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.trevornk.ramblr
 
 import android.Manifest
+import android.content.ComponentName
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -37,6 +38,7 @@ class MainActivity : BaseSettingsActivity() {
     private lateinit var cloudRowSub: TextView
     private lateinit var vocabularyRowSub: TextView
     private lateinit var invocationRowSub: TextView
+    private lateinit var voiceKeyboardRowSub: TextView
     private lateinit var serviceKilledBanner: View
 
     // First-run wizard state (#6). Tracked in-memory so a dialog already on screen is never
@@ -149,13 +151,17 @@ class MainActivity : BaseSettingsActivity() {
         root.addView(invocationRow)
 
         // Supported, user-initiated IME activation only. Android owns the enable switch; Ramblr
-        // neither writes Secure settings nor auto-selects itself.
-        root.addView(settingsRow(
-            "Enable voice keyboard",
-            "Enable Ramblr Voice in Android settings, then select it with the keyboard switch",
-        ) {
-            startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
-        })
+        // neither writes Secure settings nor auto-selects itself. The subtitle was previously
+        // hardcoded to the "not set up yet" instruction, so on a device where the keyboard was
+        // already enabled and default it still read "Enable Ramblr Voice ... then select it" --
+        // telling the user to do something already done (#238). It now reports live state, and
+        // the row routes into Invocation settings where the keyboard has its own section rather
+        // than duplicating that surface here.
+        val voiceKeyboardRow = settingsRow("Voice keyboard", "Checking...") {
+            startActivity(Intent(this, InvocationActivity::class.java))
+        }
+        voiceKeyboardRowSub = voiceKeyboardRow.findViewWithTag("subtitle")
+        root.addView(voiceKeyboardRow)
 
         root.addView(settingsRow("Advanced", AdvancedActivity.subtitle(this)) {
             startActivity(Intent(this, AdvancedActivity::class.java))
@@ -295,6 +301,7 @@ class MainActivity : BaseSettingsActivity() {
         cloudRowSub.text = CloudProviderActivity.subtitle(this)
         vocabularyRowSub.text = vocabularyMainRowSubtitleText(VocabularyEditor.terms(this).size)
         invocationRowSub.text = InvocationActivity.subtitle(this)
+        voiceKeyboardRowSub.text = invocationVoiceKeyboardSubtitleText(voiceKeyboardStatus())
         serviceKilledBanner.visibility =
             if (InvocationGuardRail.shouldShowBanner(this)) View.VISIBLE else View.GONE
 
@@ -335,6 +342,21 @@ class MainActivity : BaseSettingsActivity() {
         return manager.enabledInputMethodList.any {
             it.packageName == packageName && it.serviceName == RamblrImeService::class.java.name
         }
+    }
+
+    /**
+     * The keyboard's live OS state (#238). Default-ness is compared with [componentEquals], not
+     * string equality: the OS stores DEFAULT_INPUT_METHOD in whichever flatten form it likes and
+     * a real device uses the short one, so a plain compare reports "not default" on the very
+     * device where it is.
+     */
+    private fun voiceKeyboardStatus(): VoiceKeyboardStatus {
+        val default = Settings.Secure.getString(contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+        val isDefault = default != null && componentEquals(
+            default,
+            ComponentName(this, RamblrImeService::class.java).flattenToString(),
+        )
+        return resolveVoiceKeyboardStatus(isEnabled = isVoiceKeyboardEnabled(), isDefault = isDefault)
     }
 
     // --- #156 guard rail: "Ramblr was turned off by the system shortcut switch" banner ---

--- a/app/src/main/kotlin/com/trevornk/ramblr/OnboardingWizard.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/OnboardingWizard.kt
@@ -47,6 +47,19 @@ object OnboardingWizard {
      * fully-configured Cleanup (previously `postReady = !usePostProcessing || hasApiKey` in
      * MainActivity.refresh(), which also mis-scored a fully-working on-device Cleanup choice as
      * "not ready" just because no cloud key was ever entered).
+     *
+     * Invocation readiness asks whether ANY invocation route is live, not whether the one picked
+     * during setup is (#238). [setupMode] is a stored string written once at first run, while
+     * [accessibilityEnabled] and [imeEnabled] are read live from the OS every refresh, so gating
+     * on the stored value lets them drift apart: disable the IME after a keyboard setup and the
+     * app reports "not ready" while a working accessibility service sits right there. The two
+     * routes are independent OS registrations -- an accessibility component in
+     * `enabled_accessibility_services` and an IME in `enabled_input_methods` -- and coexist, so
+     * either one being live means the user can actually dictate. This is the same class of bug
+     * as the Cleanup mis-scoring above: a stored preference standing in for observable state.
+     *
+     * [setupMode] is retained for the wizard's own step sequencing; it is deliberately not an
+     * input here.
      */
     fun isSetupComplete(
         audioGranted: Boolean,
@@ -58,10 +71,7 @@ object OnboardingWizard {
         imeEnabled: Boolean = false,
     ): Boolean {
         val transcriptionReady = if (transcriptionLocal) hasLocalModel else hasApiKey
-        val invocationReady = when (setupMode) {
-            OnboardingSetupMode.FLOATING_BUTTON -> accessibilityEnabled
-            OnboardingSetupMode.VOICE_KEYBOARD -> imeEnabled
-        }
+        val invocationReady = accessibilityEnabled || imeEnabled
         return audioGranted && invocationReady && transcriptionReady
     }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -381,6 +381,87 @@ class InvocationMethodsTest {
         assertTrue(invocationQsTileSubtitleText(canRequestAdd = false).contains("tap for setup steps"))
     }
 
+    // --- #238 voice-keyboard status ---------------------------------------------------------
+
+    @Test fun `voice keyboard status distinguishes disabled, enabled, and default`() {
+        assertEquals(
+            VoiceKeyboardStatus.DISABLED,
+            resolveVoiceKeyboardStatus(isEnabled = false, isDefault = false),
+        )
+        assertEquals(
+            VoiceKeyboardStatus.ENABLED_NOT_DEFAULT,
+            resolveVoiceKeyboardStatus(isEnabled = true, isDefault = false),
+        )
+        assertEquals(
+            VoiceKeyboardStatus.DEFAULT,
+            resolveVoiceKeyboardStatus(isEnabled = true, isDefault = true),
+        )
+    }
+
+    /**
+     * A device claiming "default" while the IME is not enabled is incoherent -- the OS would not
+     * show it. Enablement wins so the UI never tells the user a keyboard is in use that the
+     * system will not present.
+     */
+    @Test fun `voice keyboard status refuses to report default when not enabled`() {
+        assertEquals(
+            VoiceKeyboardStatus.DISABLED,
+            resolveVoiceKeyboardStatus(isEnabled = false, isDefault = true),
+        )
+    }
+
+    @Test fun `voice keyboard subtitle names the next action for each state`() {
+        assertTrue(
+            invocationVoiceKeyboardSubtitleText(VoiceKeyboardStatus.DISABLED)
+                .contains("tap to turn the Ramblr keyboard on"),
+        )
+        // The enabled-not-default case is the one users cannot otherwise diagnose: the keyboard
+        // is on but nothing appears to happen, because another IME is still the default.
+        val enabled = invocationVoiceKeyboardSubtitleText(VoiceKeyboardStatus.ENABLED_NOT_DEFAULT)
+        assertTrue(enabled.contains("not your default keyboard"))
+        assertTrue(enabled.contains("keyboard switcher"))
+        assertTrue(
+            invocationVoiceKeyboardSubtitleText(VoiceKeyboardStatus.DEFAULT)
+                .contains("opens automatically"),
+        )
+    }
+
+    /**
+     * The section sits under two mutually exclusive mode cards, so its subtitle must state the
+     * coexistence in every state or it reads as a third option in that set.
+     */
+    @Test fun `voice keyboard section subtitle always states independence from the mode cards`() {
+        VoiceKeyboardStatus.entries.forEach { status ->
+            val text = invocationVoiceKeyboardSectionSubtitleText(status)
+            assertTrue(
+                "status $status must not read as a third mode option",
+                text.contains("Independent of the mode above") || text.contains("Works alongside the mode above"),
+            )
+        }
+    }
+
+    /**
+     * DEFAULT_INPUT_METHOD is a component string whose flatten form is the OS's choice, and a
+     * real device stores the SHORT form: a Pixel 10a reports
+     * "com.trevornk.ramblr/.RamblrImeService" while ComponentName.flattenToString() produces the
+     * long form. A plain string compare would report "not default" on the very device where the
+     * keyboard IS the default, so the comparison must normalize -- this pins the real value.
+     */
+    @Test fun `default ime comparison matches the short flatten form a real device stores`() {
+        val stored = "com.trevornk.ramblr/.RamblrImeService"
+        val flattened = "com.trevornk.ramblr/com.trevornk.ramblr.RamblrImeService"
+        assertTrue(componentEquals(stored, flattened))
+        assertEquals(
+            VoiceKeyboardStatus.DEFAULT,
+            resolveVoiceKeyboardStatus(isEnabled = true, isDefault = componentEquals(stored, flattened)),
+        )
+        // A different IME being default must not read as ours.
+        assertFalse(componentEquals(
+            "com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME",
+            flattened,
+        ))
+    }
+
     @Test fun `advanced tier subtitle reflects the feature-detected grant`() {
         assertTrue(invocationAdvancedTierSubtitleText(granted = true).startsWith("Active"))
         assertTrue(invocationAdvancedTierSubtitleText(granted = false).contains("adb"))

--- a/app/src/test/kotlin/com/trevornk/ramblr/OnboardingWizardTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/OnboardingWizardTest.kt
@@ -68,12 +68,74 @@ class OnboardingWizardTest {
         ))
     }
 
-    @Test fun `floating button setup still requires accessibility`() {
-        assertFalse(OnboardingWizard.isSetupComplete(
+    /**
+     * #238 drift: setupMode is a stored string, but the invocation surfaces it gates are live OS
+     * state. A user who set up via the keyboard and later disabled the IME -- or enabled the
+     * accessibility service instead -- still has a stored mode of VOICE_KEYBOARD. Gating
+     * readiness on the stale string alone reports "not ready" while a working invocation route
+     * is active. Readiness must follow what the OS actually reports, not what was chosen once.
+     */
+    @Test fun `ready when accessibility works even though setup chose the keyboard`() {
+        assertTrue(OnboardingWizard.isSetupComplete(
+            audioGranted = true,
+            setupMode = OnboardingSetupMode.VOICE_KEYBOARD,
+            accessibilityEnabled = true,
+            imeEnabled = false,
+            transcriptionLocal = true,
+            hasLocalModel = true,
+            hasApiKey = false,
+        ))
+    }
+
+    /** The mirror image: set up via the floating button, later enabled the keyboard instead. */
+    @Test fun `ready when the keyboard works even though setup chose the floating button`() {
+        assertTrue(OnboardingWizard.isSetupComplete(
             audioGranted = true,
             setupMode = OnboardingSetupMode.FLOATING_BUTTON,
             accessibilityEnabled = false,
             imeEnabled = true,
+            transcriptionLocal = true,
+            hasLocalModel = true,
+            hasApiKey = false,
+        ))
+    }
+
+    /** Neither route available is still not ready, whatever the stored mode says. */
+    @Test fun `not ready when no invocation route is available in either mode`() {
+        assertFalse(OnboardingWizard.isSetupComplete(
+            audioGranted = true,
+            setupMode = OnboardingSetupMode.VOICE_KEYBOARD,
+            accessibilityEnabled = false,
+            imeEnabled = false,
+            transcriptionLocal = true,
+            hasLocalModel = true,
+            hasApiKey = false,
+        ))
+        assertFalse(OnboardingWizard.isSetupComplete(
+            audioGranted = true,
+            setupMode = OnboardingSetupMode.FLOATING_BUTTON,
+            accessibilityEnabled = false,
+            imeEnabled = false,
+            transcriptionLocal = true,
+            hasLocalModel = true,
+            hasApiKey = false,
+        ))
+    }
+
+    /**
+     * Superseded by #238. This previously asserted that floating-button setup with the IME
+     * enabled and accessibility off was "not ready" -- the stored-mode-is-truth model. But that
+     * describes a user whose Ramblr keyboard is on and working: they can dictate, so reporting
+     * "not ready" was the drift bug itself. Readiness now follows live OS state, and the real
+     * intent of this case -- that the floating button genuinely needs the accessibility service
+     * -- is preserved by checking it with NO other route available.
+     */
+    @Test fun `floating button setup still requires accessibility when no other route is live`() {
+        assertFalse(OnboardingWizard.isSetupComplete(
+            audioGranted = true,
+            setupMode = OnboardingSetupMode.FLOATING_BUTTON,
+            accessibilityEnabled = false,
+            imeEnabled = false,
             transcriptionLocal = true,
             hasLocalModel = true,
             hasApiKey = false,

--- a/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeTest.kt
@@ -76,8 +76,12 @@ class RamblrImeTest {
             repoRoot(),
             "app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt",
         ).readText()
-        assertTrue(main.contains("Enable voice keyboard"))
-        assertTrue(main.contains("Settings.ACTION_INPUT_METHOD_SETTINGS"))
+        // #238: the row's title changed from "Enable voice keyboard" to "Voice keyboard" and its
+        // subtitle is now derived from live OS state instead of a hardcoded instruction that
+        // told users to enable a keyboard already enabled. The load-bearing part of this guard
+        // is the assertFalse pair below -- Ramblr must never enable or select itself as the IME.
+        assertTrue(main.contains("\"Voice keyboard\""))
+        assertTrue(main.contains("invocationVoiceKeyboardSubtitleText(voiceKeyboardStatus())"))
         assertTrue(main.contains("OnboardingSetupMode.VOICE_KEYBOARD"))
         assertTrue(main.contains("KEY_ONBOARDING_SETUP_MODE"))
         assertTrue(main.contains("showOnboardingVoiceKeyboardStep()"))


### PR DESCRIPTION
Closes #238.

## The mode-space mismatch

Setup offered floating icon vs voice keyboard. Invocation settings offered floating icon vs system controls, with zero keyboard references. Choose the voice keyboard during setup and there was no way to see or change that choice afterwards.

## Why the keyboard is not a third mode card

`InvocationMode` is a strict either/or over a single bit — `resolveInvocationMode(systemComponentPmEnabled)` — deciding which of two *accessibility components* is PM-enabled. The two components exist separately only because `flagRequestAccessibilityButton` is static-XML-only yet fixes the OS's TOGGLE vs INVISIBLE_TOGGLE classification, and exactly one may be enabled at a time.

The IME is a wholly separate OS registration in `enabled_input_methods` and coexists with either mode. Verified on hardware — a Pixel 10a currently runs the Ramblr accessibility service and the Ramblr IME as default keyboard simultaneously:

```
enabled_accessibility_services: com.trevornk.ramblr/...WhisperAccessibilityService
default_input_method:          com.trevornk.ramblr/.RamblrImeService
```

Adding it to the exclusive selector would encode a mutual exclusivity that does not exist, so it gets its own section and the section subtitle states the independence in every state.

## Three live states, not two

Enabling an IME and making it the default are separate system screens, so the row distinguishes disabled, enabled-but-not-default, and default. The middle state is the one users cannot otherwise diagnose: the keyboard is on, but another IME is still the default, so nothing appears to happen. Each state routes to the screen that can actually fix it.

Default-ness uses `componentEquals`, not string equality. A real device stores the **short** flatten form — the 10a reports `com.trevornk.ramblr/.RamblrImeService` — while `ComponentName.flattenToString()` produces the long form, so a plain compare would report "not default" on the very device where it is. Pinned by test with the real device value.

## The readiness drift bug

`isSetupComplete` gated invocation readiness on the stored `setupMode` string while reading accessibility and IME state live from the OS on every refresh. Those drift apart:

| stored setupMode | accessibility | IME | old verdict | actual |
|---|---|---|---|---|
| `VOICE_KEYBOARD` | on | off | not ready | can dictate |
| `FLOATING_BUTTON` | off | on | not ready | can dictate |

Readiness now asks whether *any* invocation route is live. This is the same class of bug the function's own docstring already condemns — a stored preference standing in for observable state, exactly like the Cleanup mis-scoring it describes.

One existing test asserted the old model (floating setup + IME enabled + accessibility off = not ready). That describes a user whose keyboard is on and working, so the assertion encoded the bug. Rewritten to check the floating button's genuine requirement with no other route live; both drift cases were proven RED before the fix.

## Verification

- 164 suites / 1,738 tests / 0 failures (main is at 1,731; +7 added here)
- `compileGithubDebugKotlin` clean
- No changes outside the five source files; no protected paths touched

Device verification of the new section still to come.
