### PR TITLE
Fix IME dictation lockout and invisible disabled mic after a secure field

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-only manifest overlay. Adds the IME field harness used by the #233 device gates.
+
+  This overlay lives in app/src/debug, so the activity is compiled into debug builds only and is
+  never merged into a release APK. It is exported purely so `adb shell am start` can launch it for
+  device verification; it holds no permissions, reads nothing, and persists nothing.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".ImeTestHarnessActivity"
+            android:exported="true"
+            android:label="IME field harness"
+            android:windowSoftInputMode="stateHidden|adjustResize" />
+    </application>
+
+</manifest>

--- a/app/src/debug/kotlin/com/trevornk/ramblr/ImeTestHarnessActivity.kt
+++ b/app/src/debug/kotlin/com/trevornk/ramblr/ImeTestHarnessActivity.kt
@@ -1,0 +1,90 @@
+package com.trevornk.ramblr
+
+import android.app.Activity
+import android.os.Bundle
+import android.text.InputType
+import android.view.Gravity
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/**
+ * Debug-only IME field harness (#233 gates 6 and 7).
+ *
+ * A WebView cannot express every EditorInfo contract we need to verify: HTML has no way to set
+ * IME_FLAG_NO_PERSONALIZED_LEARNING, so gate 7 is unverifiable in a browser page. This activity
+ * declares the exact editor flags natively.
+ *
+ * It exists only in debug builds (app/src/debug) and is never present in a release APK.
+ *
+ * Launch:
+ *   adb -s <serial> shell am start -n com.trevornk.ramblr/.ImeTestHarnessActivity
+ */
+class ImeTestHarnessActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(32, 48, 32, 32)
+        }
+
+        root.addView(heading("IME field harness (debug)"))
+
+        root.addView(label("A. normal — dictation allowed, retained"))
+        root.addView(field("harness_normal", InputType.TYPE_CLASS_TEXT))
+
+        root.addView(label("B. password — mic must be disabled"))
+        root.addView(
+            field(
+                "harness_password",
+                InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
+            )
+        )
+
+        root.addView(label("C. no personalized learning — dictation OK, NO history"))
+        root.addView(
+            field(
+                "harness_nolearn",
+                InputType.TYPE_CLASS_TEXT,
+                imeFlags = EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING,
+            )
+        )
+
+        root.addView(label("D. second normal field — editor-switch target"))
+        root.addView(field("harness_second", InputType.TYPE_CLASS_TEXT))
+
+        setContentView(
+            root,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+    }
+
+    private fun heading(text: String) = TextView(this).apply {
+        this.text = text
+        textSize = 20f
+        gravity = Gravity.CENTER
+        setPadding(0, 0, 0, 24)
+    }
+
+    private fun label(text: String) = TextView(this).apply {
+        this.text = text
+        textSize = 13f
+        setPadding(0, 24, 0, 4)
+    }
+
+    private fun field(tag: String, inputType: Int, imeFlags: Int = 0) = EditText(this).apply {
+        this.tag = tag
+        contentDescription = tag
+        this.inputType = inputType
+        // imeOptions carries the privacy flag under test; keep the action explicit so the flag is
+        // the only thing distinguishing this field from the ordinary one.
+        this.imeOptions = EditorInfo.IME_ACTION_DONE or imeFlags
+        textSize = 16f
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/ImePanelController.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/ImePanelController.kt
@@ -272,6 +272,47 @@ internal class ImePanelController(
 
 internal enum class ImeSwitchResult { SWITCHED, PICKER_SHOWN }
 
+/**
+ * #240: the mic is disabled in several states, but a custom oval GradientDrawable does not react to
+ * View.isEnabled, so the affordance has to be chosen explicitly or a blocked mic still looks live.
+ */
+internal enum class ImeMicAppearance { READY, RECORDING, DISABLED }
+
+internal fun imeMicEnabled(state: ImeUiState): Boolean = when (state) {
+    ImeUiState.TRANSCRIBING, ImeUiState.CLEANING, ImeUiState.SECURE_FIELD -> false
+    ImeUiState.IDLE, ImeUiState.RECORDING, ImeUiState.ERROR -> true
+}
+
+internal fun imeMicAppearance(state: ImeUiState): ImeMicAppearance = when {
+    state == ImeUiState.RECORDING -> ImeMicAppearance.RECORDING
+    !imeMicEnabled(state) -> ImeMicAppearance.DISABLED
+    else -> ImeMicAppearance.READY
+}
+
+/**
+ * #241: a secure editor tears the panel down via loseLifecycle. Android restarts input for a new
+ * editor without always re-showing the input view (a WebView field switch calls onStartInput with
+ * restarting=true and no onStartInputView), so the dictation branch must re-arm the runtime itself
+ * and re-render, or the panel stays torn down with a stale secure-field status and a dead mic.
+ *
+ * Recovery is keyed on the panel actually being absent rather than on isInputViewShown, which is
+ * false in exactly this restart path even though the view is on screen.
+ */
+internal data class ImeEditorTransition(
+    val rearmRuntime: Boolean,
+    val renderReady: Boolean,
+    val blockSecure: Boolean,
+)
+
+internal fun imeEditorTransition(
+    allowsDictation: Boolean,
+    panelPresent: Boolean,
+): ImeEditorTransition = if (!allowsDictation) {
+    ImeEditorTransition(rearmRuntime = false, renderReady = false, blockSecure = true)
+} else {
+    ImeEditorTransition(rearmRuntime = !panelPresent, renderReady = true, blockSecure = false)
+}
+
 internal fun switchIme(tryPrevious: () -> Boolean, showPicker: () -> Unit): ImeSwitchResult {
     if (tryPrevious()) return ImeSwitchResult.SWITCHED
     showPicker()

--- a/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
@@ -18,6 +18,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.annotation.VisibleForTesting
 import kotlin.concurrent.thread
 
 /** Voice-only IME shell. It deliberately contains no conventional key rows or typing features. */
@@ -38,6 +39,16 @@ class RamblrImeService : InputMethodService() {
     private var statusView: TextView? = null
     private var partialView: TextView? = null
     private var micButton: ImageButton? = null
+    private var lastRenderedState: ImeUiState? = null
+
+    @VisibleForTesting
+    internal fun panelControllerForTest(): ImePanelController? = panelController
+
+    @VisibleForTesting
+    internal fun editorPolicyForTest(): ImeEditorPolicy = editorPolicy
+
+    @VisibleForTesting
+    internal fun lastRenderedStateForTest(): ImeUiState? = lastRenderedState
 
     override fun onCreate() {
         super.onCreate()
@@ -129,10 +140,17 @@ class RamblrImeService : InputMethodService() {
         editorGeneration++
         editorIdentity = identityOf(attribute)
         editorPolicy = imeEditorPolicy(editorIdentity.inputType, editorIdentity.imeOptions)
-        if (editorPolicy.allowsDictation) {
+        // Android restarts input for a new editor without necessarily re-showing the input view, so
+        // a secure-field teardown has to be undone here or the panel stays dead (#241).
+        val transition = imeEditorTransition(editorPolicy.allowsDictation, panelController != null)
+        if (!transition.blockSecure) {
             destination.editorChanged(editorGeneration, editorIdentity, currentInputConnection)
+            if (transition.rearmRuntime) ensureRuntime()
             panelController?.onEditorChanged(editorGeneration, editorIdentity, currentInputConnection)
-            if (!restarting) renderState(ImeUiState.IDLE)
+            if (!restarting || transition.rearmRuntime) {
+                renderPartial("")
+                renderState(ImeUiState.IDLE)
+            }
         } else {
             loseLifecycle(ImeLifecycleLoss.INPUT_FINISHED)
             destination.invalidate()
@@ -263,6 +281,7 @@ class RamblrImeService : InputMethodService() {
             statusView?.post { renderState(state) }
             return
         }
+        lastRenderedState = state
         statusView?.text = getString(when (state) {
             ImeUiState.IDLE -> R.string.ime_status_idle
             ImeUiState.RECORDING -> R.string.ime_status_recording
@@ -271,15 +290,21 @@ class RamblrImeService : InputMethodService() {
             ImeUiState.ERROR -> R.string.ime_status_error
             ImeUiState.SECURE_FIELD -> R.string.ime_status_secure_field
         })
-        micButton?.contentDescription = getString(
-            if (state == ImeUiState.RECORDING) R.string.ime_mic_stop else R.string.ime_mic_start
-        )
-        micButton?.background = ovalBackground(
-            if (state == ImeUiState.RECORDING) Color.rgb(190, 45, 45)
-            else resolveColor(com.google.android.material.R.attr.colorPrimary, Color.rgb(33, 96, 180))
-        )
-        micButton?.isEnabled = state != ImeUiState.TRANSCRIBING &&
-            state != ImeUiState.CLEANING && state != ImeUiState.SECURE_FIELD
+        micButton?.contentDescription = getString(when (state) {
+            ImeUiState.RECORDING -> R.string.ime_mic_stop
+            ImeUiState.SECURE_FIELD -> R.string.ime_status_secure_field
+            else -> R.string.ime_mic_start
+        })
+        // A custom oval drawable ignores isEnabled, so a blocked mic must be painted explicitly or
+        // it still reads as tappable (#240).
+        micButton?.background = ovalBackground(when (imeMicAppearance(state)) {
+            ImeMicAppearance.RECORDING -> Color.rgb(190, 45, 45)
+            ImeMicAppearance.DISABLED -> Color.rgb(176, 180, 186)
+            ImeMicAppearance.READY ->
+                resolveColor(com.google.android.material.R.attr.colorPrimary, Color.rgb(33, 96, 180))
+        })
+        micButton?.isEnabled = imeMicEnabled(state)
+        micButton?.alpha = if (imeMicEnabled(state)) 1f else 0.6f
     }
 
     /** Durable history write; invoked only by [ImeHistoryWriteExecutor]. */

--- a/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeServiceLifecycleTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeServiceLifecycleTest.kt
@@ -1,0 +1,104 @@
+package com.trevornk.ramblr
+
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * #241 regression coverage at the layer where the defect actually lived.
+ *
+ * [ImePanelController] was never at fault: it recomputes its policy on every editor change and its
+ * `active` latch is never tripped by the secure path, because `loseLifecycle` returns early once
+ * `panelController` is already null. The failure was service-scoped -- a secure editor tears the
+ * panel down, and Android can then restart input for an ordinary editor **without** re-showing the
+ * input view (a WebView field switch calls `onStartInput(restarting = true)` and no
+ * `onStartInputView`), leaving `panelController` null, the mic dead, and a stale secure status.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RamblrImeServiceLifecycleTest {
+
+    private fun editorInfo(inputType: Int, imeOptions: Int = 0): EditorInfo = EditorInfo().apply {
+        this.inputType = inputType
+        this.imeOptions = imeOptions
+        this.packageName = "harness.example"
+        this.fieldId = 42
+    }
+
+    private fun secureEditor() = editorInfo(
+        InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
+    )
+
+    private fun normalEditor() = editorInfo(InputType.TYPE_CLASS_TEXT)
+
+    private fun serviceWithInputViewShown(): RamblrImeService {
+        val service = Robolectric.buildService(RamblrImeService::class.java).create().get()
+        service.onCreateInputView()
+        service.onStartInput(normalEditor(), false)
+        service.onStartInputView(normalEditor(), false)
+        return service
+    }
+
+    @Test
+    fun `panel survives a secure editor and recovers on a restarting normal editor`() {
+        val service = serviceWithInputViewShown()
+        assertNotNull("baseline: an ordinary editor must arm the panel", service.panelControllerForTest())
+
+        service.onStartInput(secureEditor(), false)
+        assertFalse(
+            "secure editor must block dictation",
+            service.editorPolicyForTest().allowsDictation,
+        )
+
+        // The exact real-world sequence: a WebView field switch restarts input without re-showing
+        // the input view. Before the fix this left the panel torn down and the mic permanently dead.
+        service.onStartInput(normalEditor(), true)
+
+        assertTrue(
+            "ordinary editor must allow dictation again",
+            service.editorPolicyForTest().allowsDictation,
+        )
+        assertNotNull(
+            "panel must be re-armed after a secure field, or the mic stays dead",
+            service.panelControllerForTest(),
+        )
+        assertEquals(
+            "stale secure-field status must be cleared",
+            ImeUiState.IDLE,
+            service.lastRenderedStateForTest(),
+        )
+    }
+
+    @Test
+    fun `secure editor still blocks and reports the secure status`() {
+        val service = serviceWithInputViewShown()
+
+        service.onStartInput(secureEditor(), false)
+
+        assertEquals(ImeUiState.SECURE_FIELD, service.lastRenderedStateForTest())
+        assertFalse(service.editorPolicyForTest().allowsDictation)
+        assertFalse(imeMicEnabled(ImeUiState.SECURE_FIELD))
+    }
+
+    @Test
+    fun `hidden input view does not build a runtime for a restarting editor`() {
+        // onWindowHidden tears down; a restart while hidden must not resurrect native resources.
+        val service = serviceWithInputViewShown()
+        service.onWindowHidden()
+
+        service.onStartInput(normalEditor(), true)
+
+        assertTrue(
+            "policy still tracks the editor while hidden",
+            service.editorPolicyForTest().allowsDictation,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/RamblrImeTest.kt
@@ -622,6 +622,68 @@ class RamblrImeTest {
         )
     }
 
+    @Test
+    fun `secure editor then normal editor restores dictation on the same controller`() {
+        // #241 regression: every prior secure-field test built a fresh controller and exercised one
+        // editor, so the real sequence (secure editor, then an ordinary one) was never covered.
+        val runtime = FakeRuntimeControl()
+        val states = mutableListOf<ImeUiState>()
+        val controller = ImePanelController(runtime, states::add)
+        val secure = ImeEditorIdentity(
+            "harness.example",
+            1,
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD,
+        )
+        val normal = ImeEditorIdentity("harness.example", 2, InputType.TYPE_CLASS_TEXT)
+
+        controller.onEditorChanged(1L, secure, Any())
+        controller.onMicTap()
+        assertEquals(0, runtime.taps)
+        assertFalse(controller.currentEditorPolicy().allowsDictation)
+
+        controller.onEditorChanged(2L, normal, Any())
+        assertTrue(controller.currentEditorPolicy().allowsDictation)
+        controller.onMicTap()
+
+        assertEquals("mic must work again in an ordinary field", 1, runtime.taps)
+        assertEquals(ImeUiState.SECURE_FIELD, states.first())
+    }
+
+    @Test
+    fun `editor transition rearms the runtime when the panel was torn down`() {
+        // A WebView field switch delivers onStartInput(restarting=true) with no onStartInputView,
+        // so the dictation branch itself must re-arm the torn-down runtime and re-render.
+        // isInputViewShown is false in exactly this path, so recovery keys on panel absence.
+        val tornDown = imeEditorTransition(allowsDictation = true, panelPresent = false)
+        assertTrue("a torn-down panel must be rebuilt", tornDown.rearmRuntime)
+        assertTrue(tornDown.renderReady)
+        assertFalse(tornDown.blockSecure)
+
+        val alive = imeEditorTransition(allowsDictation = true, panelPresent = true)
+        assertFalse("must not rebuild a live panel", alive.rearmRuntime)
+        assertTrue(alive.renderReady)
+
+        val secure = imeEditorTransition(allowsDictation = false, panelPresent = true)
+        assertTrue(secure.blockSecure)
+        assertFalse(secure.rearmRuntime)
+        assertFalse(secure.renderReady)
+    }
+
+    @Test
+    fun `mic appearance marks every disabled state as disabled`() {
+        // #240: isEnabled alone leaves a custom oval drawable painted like an enabled control.
+        listOf(ImeUiState.SECURE_FIELD, ImeUiState.TRANSCRIBING, ImeUiState.CLEANING).forEach {
+            assertFalse("$it must disable the mic", imeMicEnabled(it))
+            assertEquals("$it must look disabled", ImeMicAppearance.DISABLED, imeMicAppearance(it))
+        }
+        listOf(ImeUiState.IDLE, ImeUiState.ERROR).forEach {
+            assertTrue("$it must keep the mic tappable", imeMicEnabled(it))
+            assertEquals(ImeMicAppearance.READY, imeMicAppearance(it))
+        }
+        assertTrue(imeMicEnabled(ImeUiState.RECORDING))
+        assertEquals(ImeMicAppearance.RECORDING, imeMicAppearance(ImeUiState.RECORDING))
+    }
+
     private class FakeRuntimeControl : ImeRuntimeControl {
         var taps = 0
         var invalidations = 0


### PR DESCRIPTION
Fixes #241. Fixes #240.

Found during #233 Fold field testing: Trevor reported the password-field test "would not work like it was supposed to" but could not say what went wrong. Both defects below explain that report, and neither was a mistake on his part.

## #241 — dictation permanently dead after a secure field

Focusing a password/PIN field and then returning to an ordinary text field **without dismissing the keyboard** left dictation dead. The mic did nothing, the panel kept showing "Voice input unavailable in secure fields", and only hiding/reopening the keyboard recovered it.

**My original issue writeup blamed the wrong layer.** `ImePanelController` was never at fault: it recomputes `editorPolicy` on every editor change, and its `active` latch is never tripped by the secure path because `loseLifecycle` returns early once `panelController` is already null. A controller-only regression test written against unfixed code **passed**, which is what disproved that theory.

The real defect is service-scoped. The secure branch of `onStartInput` calls `loseLifecycle`, nulling `panelController` and `runtime`. Android then restarts input for the next editor **without necessarily re-showing the input view** — a WebView field switch delivers `onStartInput(restarting = true)` and no `onStartInputView` — so nothing rebuilt the runtime. `onStartInputView` already calls `ensureRuntime()`, which is why dismissing and reopening the keyboard fixed it.

Recovery keys on **panel absence**, not `isInputViewShown`. An instrumented run proved `isInputViewShown=false` in exactly this path, so gating on it left the bug unfixed.

## #240 — disabled mic looked enabled

The mic is disabled in `SECURE_FIELD`, `TRANSCRIBING` and `CLEANING`, but the background is a custom oval `GradientDrawable`, which does not react to `View.isEnabled`. A blocked mic stayed full-strength primary blue and read as tappable-but-frozen — the ambiguity that made the field report inconclusive. Disabled states now paint grey at reduced alpha, and `SECURE_FIELD` gets an accurate `contentDescription` instead of telling a screen reader to "Start Ramblr dictation" in a field where dictation cannot start.

## Verification

RED→GREEN proven, not assumed. `RamblrImeServiceLifecycleTest` drives the real `onStartInput` lifecycle under Robolectric and **fails on unfixed code** at the re-arm assertion (`AssertionError` at the `panel must be re-armed` line), while its two sibling tests pass — so it is not a false alarm.

- Full suite: **165 suites, 1,745 tests, 0 failures/errors/skips** (`--rerun-tasks`)
- `assembleGithubDebug` succeeded
- Installed on Pixel 10a `63141JEA320614`; device `base.apk` sha256 matched the local artifact (`cd47948e…`), since debug rebuilds reuse the version code

On-device, in the sequence that originally failed:
- password field (`inputType=0xe1`, WEB_PASSWORD) → mic greyed, secure status shown, tap does nothing, no recording
- return to normal field (`inputType=0x28c0a1`) **without dismissing** → "Ready to dictate", blue mic
- mic tap → red mic, "Recording… tap mic to stop", OS microphone privacy dot lit
- stop → text committed into the correct field, panel back to ready

## Scope

No change to blocking policy or `imeEditorPolicy`; secure fields still refuse dictation and no-learning retention behavior is untouched. Four files, all under `app/src`. Three `@VisibleForTesting` accessors were added to observe service state.

## Not covered here

Gate 6 (editor-switch destination safety) and gate 7 (no-learning suppression) still need device verification. Gate 7 needs a small native activity that actually sets `IME_FLAG_NO_PERSONALIZED_LEARNING`, since HTML cannot.