### PR TITLE
Rename CloudLiveOutcome FALLBACK_* to BATCH_SERVED_*

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/CloudLiveTranscription.kt
@@ -64,19 +64,49 @@ sealed class CloudLiveTerminal {
  * (#233 Phase 1 item 10). Deliberately finer-grained than [CloudLiveTerminal]'s two cases,
  * because the two ways a *successful* live session still loses the recording to batch are
  * exactly the ones a device trial has to be able to tell apart afterwards.
+ *
+ * Every non-[LIVE_DELIVERED] constant is named `BATCH_SERVED_*` on purpose: in all of them the
+ * user still received their full text, because the lossless recording is preserved for batch
+ * precisely so a live failure is never a lost dictation. Only the *live leg* failed. The earlier
+ * names (`FALLBACK_FAILED` and friends) read like the fallback itself broke, which is the
+ * opposite of what they record, and that is a bad way to label the one line in the telemetry a
+ * reader most needs to interpret correctly during an incident.
  */
 enum class CloudLiveOutcome {
     /** Live text was authoritative and went down the normal delivery path. */
     LIVE_DELIVERED,
     /** The session reported [CloudLiveTerminal.Success], but the final was unusable (blank, or
      *  the preserved recording was below the minimum-duration floor), so batch served it. */
-    FALLBACK_UNUSABLE_FINAL,
-    /** The session reported [CloudLiveTerminal.Failure]; see [CloudLiveStage.failureReason]. */
-    FALLBACK_FAILED,
+    BATCH_SERVED_UNUSABLE_FINAL,
+    /** The live session reported [CloudLiveTerminal.Failure] and batch served the text instead;
+     *  see [CloudLiveStage.failureReason] for why live died. */
+    BATCH_SERVED_LIVE_FAILED,
     /** No terminal callback arrived at all before the runtime's bounded final wait expired --
      *  the mid-stream-drop / wedged-socket case, which produces no [CloudLiveFailureReason]
-     *  because the session never got far enough to report one. */
-    FALLBACK_NO_TERMINAL,
+     *  because the session never got far enough to report one. Batch served the text. */
+    BATCH_SERVED_NO_TERMINAL,
+    ;
+
+    /**
+     * The pre-rename spelling of this constant, or null when the name never changed.
+     *
+     * Kept because device trials already on disk (the Fold #233 trial among them) recorded the
+     * old names, and telemetry you cannot read historically is telemetry you cannot trust. The
+     * reader maps old to new through this rather than hardcoding a second copy of the mapping.
+     */
+    val legacyName: String?
+        get() = when (this) {
+            LIVE_DELIVERED -> null
+            BATCH_SERVED_UNUSABLE_FINAL -> "FALLBACK_UNUSABLE_FINAL"
+            BATCH_SERVED_LIVE_FAILED -> "FALLBACK_FAILED"
+            BATCH_SERVED_NO_TERMINAL -> "FALLBACK_NO_TERMINAL"
+        }
+
+    companion object {
+        /** Resolves either the current or the pre-rename spelling, so old logs still parse. */
+        fun fromLogName(name: String): CloudLiveOutcome? =
+            entries.firstOrNull { it.name == name || it.legacyName == name }
+    }
 }
 
 /**
@@ -85,7 +115,7 @@ enum class CloudLiveOutcome {
  * Pure and free of Android/[android.content.Context] so the whole "what does a device trial
  * actually see" question is unit-testable without a device. [timing] is the best marks known to
  * the runtime -- a terminal's own timing when there is one, otherwise the last interim's, which
- * is what makes [CloudLiveOutcome.FALLBACK_NO_TERMINAL] still able to report that setup landed
+ * is what makes [CloudLiveOutcome.BATCH_SERVED_NO_TERMINAL] still able to report that setup landed
  * and interims flowed before the session went quiet.
  *
  * Durations are simple subtractions of the marks the session already recorded; a mark that was

--- a/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/DictationRuntime.kt
@@ -894,13 +894,13 @@ class DictationRuntime internal constructor(
                     attempt.finalWait = null
                     // No terminal ever arrived within the bounded wait -- the mid-stream drop /
                     // wedged-socket case, which reports no CloudLiveFailureReason of its own
-                    // (#233 item 10). Distinguished from FALLBACK_FAILED so a device trial can
-                    // tell "the session told us it broke" from "the session went silent".
+                    // (#233 item 10). Distinguished from BATCH_SERVED_LIVE_FAILED so a device
+                    // trial can tell "the session told us it broke" from "it went silent".
                     if (cloudLiveAttempt === attempt && !attempt.claimed) {
                         startCloudLiveBatchFallback(
                             attempt,
-                            if (attempt.terminal == null) CloudLiveOutcome.FALLBACK_NO_TERMINAL
-                            else CloudLiveOutcome.FALLBACK_FAILED,
+                            if (attempt.terminal == null) CloudLiveOutcome.BATCH_SERVED_NO_TERMINAL
+                            else CloudLiveOutcome.BATCH_SERVED_LIVE_FAILED,
                         )
                     }
                 }
@@ -920,7 +920,7 @@ class DictationRuntime internal constructor(
             is CloudLiveTerminal.Success -> {
                 if (terminal.text.isBlank() || result.pcmFile == null ||
                     isBelowMinimumDuration(result.pcmFile.length(), SAMPLE_RATE)) {
-                    startCloudLiveBatchFallback(attempt, CloudLiveOutcome.FALLBACK_UNUSABLE_FINAL)
+                    startCloudLiveBatchFallback(attempt, CloudLiveOutcome.BATCH_SERVED_UNUSABLE_FINAL)
                     return
                 }
                 attempt.claimed = true
@@ -933,7 +933,7 @@ class DictationRuntime internal constructor(
                 logCloudLiveAttempt(attempt, CloudLiveOutcome.LIVE_DELIVERED)
                 thread { handleTranscriptionResult(terminal.text, attempt.token, attempt.lease) }
             }
-            is CloudLiveTerminal.Failure -> startCloudLiveBatchFallback(attempt, CloudLiveOutcome.FALLBACK_FAILED)
+            is CloudLiveTerminal.Failure -> startCloudLiveBatchFallback(attempt, CloudLiveOutcome.BATCH_SERVED_LIVE_FAILED)
         }
     }
 

--- a/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveBenchmarkTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/CloudLiveBenchmarkTest.kt
@@ -203,7 +203,7 @@ class CloudLiveBenchmarkTest {
 
         val line = awaitCloudLiveLine()
         val live = line.getJSONObject("cloudLive")
-        assertEquals("FALLBACK_FAILED", live.getString("outcome"))
+        assertEquals("BATCH_SERVED_LIVE_FAILED", live.getString("outcome"))
         assertTrue("the reader must be able to see batch delivered this text", live.getBoolean("fellBackToBatch"))
         assertEquals("NETWORK_ERROR", live.getString("failureReason"))
         assertEquals(90L, live.getLong("setupMs"))
@@ -231,7 +231,7 @@ class CloudLiveBenchmarkTest {
         shadowOf(Looper.getMainLooper()).idleFor(2_501, TimeUnit.MILLISECONDS)
 
         val live = awaitCloudLiveLine().getJSONObject("cloudLive")
-        assertEquals("FALLBACK_NO_TERMINAL", live.getString("outcome"))
+        assertEquals("BATCH_SERVED_NO_TERMINAL", live.getString("outcome"))
         assertTrue(live.getBoolean("fellBackToBatch"))
         assertTrue("a silent session names no reason", live.isNull("failureReason"))
         assertEquals("but the marks it did emit still survive", 120L, live.getLong("setupMs"))
@@ -253,7 +253,7 @@ class CloudLiveBenchmarkTest {
         idleMainLooper()
 
         val live = awaitCloudLiveLine().getJSONObject("cloudLive")
-        assertEquals("FALLBACK_UNUSABLE_FINAL", live.getString("outcome"))
+        assertEquals("BATCH_SERVED_UNUSABLE_FINAL", live.getString("outcome"))
         assertTrue(live.getBoolean("fellBackToBatch"))
         assertTrue("a blank final is not a session failure", live.isNull("failureReason"))
         assertEquals(32L, live.getLong("endOfAudioToFinalMs"))
@@ -297,7 +297,7 @@ class CloudLiveBenchmarkTest {
         // so an embedded newline would split one record into two unparseable fragments) and
         // capped at MAX_ERROR_DETAIL_CHARS.
         val stage = cloudLiveBenchmarkStage(
-            outcome = CloudLiveOutcome.FALLBACK_FAILED,
+            outcome = CloudLiveOutcome.BATCH_SERVED_LIVE_FAILED,
             terminal = CloudLiveTerminal.Failure(
                 CloudLiveFailureReason.PROTOCOL_ERROR,
                 "rejected\n" + "x".repeat(MAX_ERROR_DETAIL_CHARS * 3),
@@ -428,7 +428,7 @@ class CloudLiveBenchmarkTest {
     @Test
     fun `derivation reports a mark that never happened as null rather than a fabricated zero`() {
         val stage = cloudLiveBenchmarkStage(
-            outcome = CloudLiveOutcome.FALLBACK_FAILED,
+            outcome = CloudLiveOutcome.BATCH_SERVED_LIVE_FAILED,
             terminal = CloudLiveTerminal.Failure(
                 CloudLiveFailureReason.SETUP_TIMEOUT,
                 "setup timed out",
@@ -446,7 +446,7 @@ class CloudLiveBenchmarkTest {
     @Test
     fun `derivation falls back to the last seen interim timing when no terminal ever arrived`() {
         val stage = cloudLiveBenchmarkStage(
-            outcome = CloudLiveOutcome.FALLBACK_NO_TERMINAL,
+            outcome = CloudLiveOutcome.BATCH_SERVED_NO_TERMINAL,
             terminal = null,
             timing = CloudLiveTiming(connectStartedAtMs = 100, setupCompletedAtMs = 260, firstInterimAtMs = 700),
         )
@@ -459,12 +459,53 @@ class CloudLiveBenchmarkTest {
 
     @Test
     fun `derivation degrades to outcome only when there are no marks at all`() {
-        val stage = cloudLiveBenchmarkStage(CloudLiveOutcome.FALLBACK_NO_TERMINAL, terminal = null, timing = null)
-        assertEquals("FALLBACK_NO_TERMINAL", stage.outcome)
+        val stage = cloudLiveBenchmarkStage(CloudLiveOutcome.BATCH_SERVED_NO_TERMINAL, terminal = null, timing = null)
+        assertEquals("BATCH_SERVED_NO_TERMINAL", stage.outcome)
         assertTrue(stage.fellBackToBatch)
         assertNull(stage.setupMs)
         assertNull(stage.firstInterimMs)
         assertNull(stage.endOfAudioToFinalMs)
+    }
+
+    @Test
+    fun `pre-rename outcome names still resolve so historical trial logs stay readable`() {
+        // Device trials that ran before the FALLBACK_* -> BATCH_SERVED_* rename wrote the old
+        // spellings into benchmark_log.jsonl. Those logs are the only record of what the
+        // hardware actually did, so the mapping is load-bearing, not cosmetic.
+        assertEquals(
+            CloudLiveOutcome.BATCH_SERVED_LIVE_FAILED,
+            CloudLiveOutcome.fromLogName("FALLBACK_FAILED"),
+        )
+        assertEquals(
+            CloudLiveOutcome.BATCH_SERVED_NO_TERMINAL,
+            CloudLiveOutcome.fromLogName("FALLBACK_NO_TERMINAL"),
+        )
+        assertEquals(
+            CloudLiveOutcome.BATCH_SERVED_UNUSABLE_FINAL,
+            CloudLiveOutcome.fromLogName("FALLBACK_UNUSABLE_FINAL"),
+        )
+        // Current spellings resolve to themselves, and LIVE_DELIVERED never had an alias.
+        for (outcome in CloudLiveOutcome.entries) {
+            assertEquals(outcome, CloudLiveOutcome.fromLogName(outcome.name))
+        }
+        assertNull(CloudLiveOutcome.LIVE_DELIVERED.legacyName)
+        assertNull(CloudLiveOutcome.fromLogName("NOT_AN_OUTCOME"))
+    }
+
+    @Test
+    fun `every batch-served outcome reports falling back and live-delivered does not`() {
+        // The invariant the name change is meant to make obvious: BATCH_SERVED_* means the user
+        // still got their text, via batch. Only LIVE_DELIVERED skipped the fallback entirely.
+        for (outcome in CloudLiveOutcome.entries) {
+            val stage = cloudLiveBenchmarkStage(outcome, terminal = null, timing = null)
+            val expected = outcome != CloudLiveOutcome.LIVE_DELIVERED
+            assertEquals(
+                "$outcome should report fellBackToBatch=$expected",
+                expected,
+                stage.fellBackToBatch,
+            )
+            assertEquals(expected, outcome.name.startsWith("BATCH_SERVED_"))
+        }
     }
 
     /** Same narrow capture-boundary fake DictationRuntimeTest uses (its copy is private to that

--- a/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/GeminiCloudLiveTranscriptionClientTest.kt
@@ -374,7 +374,7 @@ class GeminiCloudLiveTranscriptionClientTest {
     /**
      * The real mid-stream drop: setup succeeded, interims were flowing, then the
      * server closes the socket without ever sending a final. This is the
-     * FALLBACK_NO_TERMINAL case, and the one path where a stale interim could
+     * BATCH_SERVED_NO_TERMINAL case, and the one path where a stale interim could
      * leak out as if it were an authoritative final.
      *
      * The server-initiated close arrives as onClosing, and OkHttp's default


### PR DESCRIPTION
`FALLBACK_FAILED` does not mean the fallback failed. It means the **live leg** failed and batch served the dictation — the user still received their complete text, transcribed from the preserved lossless recording. The name says the opposite of what it records, on the one telemetry line most likely to be read during an incident.

The 2026-08-29 Fold trial produced exactly that line. A real mid-dictation network drop logged:

```json
{"outcome": "FALLBACK_FAILED", "failureReason": "NETWORK_ERROR",
 "error": "Software caused connection abort", "fellBackToBatch": true}
```

That is gate 4 **passing** — same `correlationId` shows batch delivered 225 raw / 229 cleaned characters two seconds later. It reads like a failure.

## Change

| old | new |
|---|---|
| `FALLBACK_FAILED` | `BATCH_SERVED_LIVE_FAILED` |
| `FALLBACK_NO_TERMINAL` | `BATCH_SERVED_NO_TERMINAL` |
| `FALLBACK_UNUSABLE_FINAL` | `BATCH_SERVED_UNUSABLE_FINAL` |

`LIVE_DELIVERED` is unchanged. Behavior is unchanged — only the serialized outcome string differs.

## Backward compatibility

The outcome string is already written to `benchmark_log.jsonl` on both devices, and those logs are the only record of what the hardware actually did. `CloudLiveOutcome.fromLogName()` and `read-cloudlive.py`'s `LEGACY_OUTCOMES` resolve both spellings, so historical trial data stays readable. A rename that silently orphaned existing device evidence would cost more than the clearer name is worth.

Verified against the untouched Fold log — same bytes on disk, now reported correctly:

```
outcomes:
  LIVE_DELIVERED: 5
  BATCH_SERVED_LIVE_FAILED: 1
why live failed (text was still delivered by batch):
  NETWORK_ERROR: 1
live-delivered=5  batch-served=1 (batch-served still delivered the user's full text)
```

## Tests

165 suites / 1747 tests / 0 failures (+2 new): one pinning the legacy-name mapping, one asserting the invariant the rename encodes — `fellBackToBatch` is true for exactly the `BATCH_SERVED_*` constants.

Runbook docs updated (untracked `.hermes/`) to state plainly that `BATCH_SERVED_*` is not a lost dictation.