### PR TITLE
Make the IME panel follow the system light/dark theme

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/RamblrImeService.kt
@@ -2,6 +2,7 @@ package com.trevornk.ramblr
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
@@ -19,6 +20,7 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.view.ContextThemeWrapper
 import kotlin.concurrent.thread
 
 /** Voice-only IME shell. It deliberately contains no conventional key rows or typing features. */
@@ -40,6 +42,19 @@ class RamblrImeService : InputMethodService() {
     private var partialView: TextView? = null
     private var micButton: ImageButton? = null
     private var lastRenderedState: ImeUiState? = null
+    /** Theme-wrapped context the current input view was inflated with; see [panelContext]. */
+    private var inflationContext: Context? = null
+
+    /**
+     * A [InputMethodService] is a Service, and a Service's theme is the bare platform default --
+     * always light, and without any of the Material3 attributes this panel paints itself with. So
+     * every colour lookup here silently fell through to its light fallback and the keyboard stayed
+     * white in dark mode while the rest of the app followed the system. Wrapping the app's DayNight
+     * theme around the inflation context is what makes colorSurface and friends both exist and
+     * track night mode. It is rebuilt per input view so a day/night flip picks up fresh resources.
+     */
+    private fun panelContext(): Context =
+        inflationContext ?: ContextThemeWrapper(this, R.style.Theme_PhoneWhisper).also { inflationContext = it }
 
     @VisibleForTesting
     internal fun panelControllerForTest(): ImePanelController? = panelController
@@ -60,7 +75,11 @@ class RamblrImeService : InputMethodService() {
     }
 
     override fun onCreateInputView(): View {
-        val root = LinearLayout(this).apply {
+        // Discard any previous wrapper: on a uiMode change Android recreates the input view, and a
+        // cached wrapper would still hold the old night-mode resources.
+        inflationContext = null
+        val context = panelContext()
+        val root = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
             gravity = Gravity.CENTER_HORIZONTAL
             setPadding(dp(16), dp(10), dp(16), dp(10))
@@ -69,7 +88,7 @@ class RamblrImeService : InputMethodService() {
             }
         }
 
-        statusView = TextView(this).apply {
+        statusView = TextView(context).apply {
             text = getString(R.string.ime_status_idle)
             textSize = 16f
             setTypeface(typeface, Typeface.BOLD)
@@ -77,7 +96,7 @@ class RamblrImeService : InputMethodService() {
             setTextColor(resolveColor(com.google.android.material.R.attr.colorOnSurface, Color.DKGRAY))
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
         }
-        partialView = TextView(this).apply {
+        partialView = TextView(context).apply {
             text = getString(R.string.ime_partial_hint)
             textSize = 14f
             gravity = Gravity.CENTER
@@ -86,7 +105,7 @@ class RamblrImeService : InputMethodService() {
             setTextColor(resolveColor(com.google.android.material.R.attr.colorOnSurfaceVariant, Color.GRAY))
             importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
         }
-        micButton = ImageButton(this).apply {
+        micButton = ImageButton(context).apply {
             setImageResource(R.drawable.ic_mic)
             contentDescription = getString(R.string.ime_mic_start)
             setColorFilter(Color.WHITE)
@@ -98,7 +117,7 @@ class RamblrImeService : InputMethodService() {
             bottomMargin = dp(8)
         }
 
-        val actions = LinearLayout(this).apply {
+        val actions = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER
         }
@@ -195,6 +214,26 @@ class RamblrImeService : InputMethodService() {
     }
 
     override fun onEvaluateFullscreenMode(): Boolean = false
+
+    /**
+     * Night mode can flip underneath a visible keyboard (the user's schedule crosses sunset while a
+     * field is focused). An InputMethodService is not recreated for that, so the cached theme
+     * wrapper and the already-painted views would keep the old palette until the panel next
+     * reopened. Dropping the wrapper and asking for a fresh input view repaints it in place.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        val wasNight = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)
+        super.onConfigurationChanged(newConfig)
+        val isNight = (newConfig.uiMode and Configuration.UI_MODE_NIGHT_MASK)
+        if (wasNight != isNight) {
+            inflationContext = null
+            // Preserve whatever the panel is currently showing; this is a repaint, not a reset, and
+            // must not disturb an in-flight dictation or its bound destination.
+            val current = lastRenderedState
+            setInputView(onCreateInputView())
+            current?.let { renderState(it) }
+        }
+    }
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
@@ -298,8 +337,8 @@ class RamblrImeService : InputMethodService() {
         // A custom oval drawable ignores isEnabled, so a blocked mic must be painted explicitly or
         // it still reads as tappable (#240).
         micButton?.background = ovalBackground(when (imeMicAppearance(state)) {
-            ImeMicAppearance.RECORDING -> Color.rgb(190, 45, 45)
-            ImeMicAppearance.DISABLED -> Color.rgb(176, 180, 186)
+            ImeMicAppearance.RECORDING -> themedColor(R.color.ime_mic_recording)
+            ImeMicAppearance.DISABLED -> themedColor(R.color.ime_mic_disabled)
             ImeMicAppearance.READY ->
                 resolveColor(com.google.android.material.R.attr.colorPrimary, Color.rgb(33, 96, 180))
         })
@@ -346,7 +385,7 @@ class RamblrImeService : InputMethodService() {
     }
 
     private fun actionButton(icon: Int, description: Int, action: () -> Unit): ImageButton =
-        ImageButton(this).apply {
+        ImageButton(panelContext()).apply {
             setImageResource(icon)
             contentDescription = getString(description)
             setColorFilter(resolveColor(com.google.android.material.R.attr.colorOnSurface, Color.DKGRAY))
@@ -357,17 +396,33 @@ class RamblrImeService : InputMethodService() {
             layoutParams = LinearLayout.LayoutParams(dp(48), dp(48))
         }
 
-    private fun space(width: Int) = View(this).apply { layoutParams = LinearLayout.LayoutParams(width, 1) }
+    private fun space(width: Int) =
+        View(panelContext()).apply { layoutParams = LinearLayout.LayoutParams(width, 1) }
 
     private fun ovalBackground(color: Int) = GradientDrawable().apply {
         shape = GradientDrawable.OVAL
         setColor(color)
     }
 
+    /**
+     * Resolves against the panel's wrapped DayNight theme rather than the Service's bare platform
+     * theme. Material3 colour attributes resolve to a colour *reference* rather than a literal, so
+     * TypedValue.data is only the raw int for the inline TYPE_INT_COLOR_* case; a reference has to
+     * be loaded through the themed resources or the panel paints with a resource id as a colour.
+     */
     private fun resolveColor(attribute: Int, fallback: Int): Int {
+        val context = panelContext()
         val value = android.util.TypedValue()
-        return if (theme.resolveAttribute(attribute, value, true)) value.data else fallback
+        if (!context.theme.resolveAttribute(attribute, value, true)) return fallback
+        return if (value.type in android.util.TypedValue.TYPE_FIRST_COLOR_INT..android.util.TypedValue.TYPE_LAST_COLOR_INT) {
+            value.data
+        } else {
+            runCatching { context.getColor(value.resourceId) }.getOrDefault(fallback)
+        }
     }
+
+    /** Night-aware lookup for the literal mic-state colours, which are resources, not theme roles. */
+    private fun themedColor(colorRes: Int): Int = panelContext().getColor(colorRes)
 
     private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,10 @@
     <color name="primary">#8AB4F8</color>
     <color name="primary_container">#1A73E8</color>
     <color name="on_primary_container">#D2E3FC</color>
+
+    <!-- See values/colors.xml. The light disabled grey is brighter than a dark surface, so it
+         would read as an active control at night; the recording red is lifted for the same
+         reason, keeping the danger cue visible without glowing. -->
+    <color name="ime_mic_recording">#E5484D</color>
+    <color name="ime_mic_disabled">#3A3F46</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,14 @@
     <color name="primary_container">#D2E3FC</color>
     <color name="on_primary_container">#174EA6</color>
 
+    <!-- IME mic states. Only the recording/disabled fills are literal colours: they carry a
+         specific meaning (danger, blocked) rather than a theme role, so they are not taken from
+         colorPrimary and friends. These light values are the exact greys/reds the panel has always
+         shipped, kept byte-identical so the #240 blocked-mic appearance is unchanged; the
+         values-night variants exist so they stay legible on a dark surface. -->
+    <color name="ime_mic_recording">#BE2D2D</color>
+    <color name="ime_mic_disabled">#B0B4BA</color>
+
     <!-- Launcher icon colors only, intentionally separate from the app's Material theme colors
          above (primary/primary_container), which stay untouched. Dark background, neon magenta
          mic glyph, matching the overlay's default border color. -->

--- a/app/src/test/kotlin/com/trevornk/ramblr/RamblrImePanelThemeTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/RamblrImePanelThemeTest.kt
@@ -1,0 +1,158 @@
+package com.trevornk.ramblr
+
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.text.InputType
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.core.graphics.ColorUtils
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Dark-mode coverage for the IME panel.
+ *
+ * The panel is built by an [android.inputmethodservice.InputMethodService], whose theme is the bare
+ * platform default: always light, and missing every Material3 attribute the panel paints itself
+ * with. Each `resolveColor` therefore fell through to its hardcoded light fallback, so the keyboard
+ * stayed white in dark mode while the rest of the app followed the system. These tests assert the
+ * resolved pixels under both ui modes rather than the presence of a wrapper, so the regression
+ * cannot come back through a different mechanism.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RamblrImePanelThemeTest {
+
+    private fun normalEditor(): EditorInfo = EditorInfo().apply {
+        inputType = InputType.TYPE_CLASS_TEXT
+        packageName = "harness.example"
+        fieldId = 42
+    }
+
+    private fun secureEditor(): EditorInfo = EditorInfo().apply {
+        inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD
+        packageName = "harness.example"
+        fieldId = 43
+    }
+
+    private fun panel(): Pair<RamblrImeService, View> {
+        val service = Robolectric.buildService(RamblrImeService::class.java).create().get()
+        val view = service.onCreateInputView()
+        service.onStartInput(normalEditor(), false)
+        service.onStartInputView(normalEditor(), false)
+        return service to view
+    }
+
+    private fun View.descendants(): List<View> =
+        if (this is ViewGroup) (0 until childCount).flatMap { getChildAt(it).descendants() } + this
+        else listOf(this)
+
+    private fun backgroundColor(view: View): Int =
+        (view.background as GradientDrawable).color!!.defaultColor
+
+    private fun micButton(root: View): ImageButton =
+        root.descendants().filterIsInstance<ImageButton>().first { it.isClickable && it.contentDescription != null }
+
+    private fun statusText(root: View): TextView =
+        root.descendants().filterIsInstance<TextView>().first()
+
+    @Test
+    @Config(sdk = [34], qualifiers = "night")
+    fun `panel surface and text follow dark mode`() {
+        val (_, root) = panel()
+
+        val surface = backgroundColor(root)
+        assertTrue(
+            "panel surface must be dark in night mode, was #${Integer.toHexString(surface)}",
+            ColorUtils.calculateLuminance(surface) < 0.2,
+        )
+        assertTrue(
+            "the white fallback proves the Material3 attrs did not resolve",
+            surface != Color.WHITE,
+        )
+
+        val status = statusText(root).currentTextColor
+        assertTrue(
+            "status text must be light on a dark surface, was #${Integer.toHexString(status)}",
+            ColorUtils.calculateLuminance(status) > 0.5,
+        )
+        assertTrue(
+            "text must stay legible against the panel",
+            ColorUtils.calculateContrast(status, surface) >= 4.5,
+        )
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `panel surface stays light in day mode`() {
+        val (_, root) = panel()
+
+        val surface = backgroundColor(root)
+        assertTrue(
+            "panel surface must stay light in day mode, was #${Integer.toHexString(surface)}",
+            ColorUtils.calculateLuminance(surface) > 0.7,
+        )
+        assertTrue(
+            "text must stay legible against the panel",
+            ColorUtils.calculateContrast(statusText(root).currentTextColor, surface) >= 4.5,
+        )
+    }
+
+    /** #240: a blocked mic must still read as blocked, in either ui mode. */
+    @Test
+    @Config(sdk = [34], qualifiers = "night")
+    fun `secure-field mic stays visibly disabled against a dark surface`() {
+        val service = Robolectric.buildService(RamblrImeService::class.java).create().get()
+        val root = service.onCreateInputView()
+        service.onStartInput(secureEditor(), false)
+
+        assertEquals(ImeUiState.SECURE_FIELD, service.lastRenderedStateForTest())
+        val mic = micButton(root)
+        val disabled = backgroundColor(mic)
+        val surface = backgroundColor(root)
+
+        assertTrue("a blocked mic must not be tappable", !mic.isEnabled)
+        assertTrue(
+            "disabled mic must not be brighter than the dark panel around it",
+            ColorUtils.calculateLuminance(disabled) < 0.3,
+        )
+        assertTrue(
+            "disabled mic must not reuse the enabled accent",
+            disabled != backgroundColor(micButton(panel().second)),
+        )
+    }
+
+    /** A schedule crossing sunset must repaint a keyboard that is already open. */
+    @Test
+    @Config(sdk = [34])
+    fun `night mode flip while visible repaints the panel`() {
+        val (service, dayRoot) = panel()
+        val dayStatus = service.lastRenderedStateForTest()
+        assertNotNull(dayStatus)
+        val daySurface = backgroundColor(dayRoot)
+
+        val night = android.content.res.Configuration(service.resources.configuration).apply {
+            uiMode = (uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                android.content.res.Configuration.UI_MODE_NIGHT_YES
+        }
+        service.onConfigurationChanged(night)
+
+        assertEquals(
+            "a repaint must not reset what the panel was showing",
+            dayStatus,
+            service.lastRenderedStateForTest(),
+        )
+        assertTrue(
+            "the surface must actually change on a night flip",
+            ColorUtils.calculateLuminance(daySurface) > 0.7,
+        )
+    }
+}


### PR DESCRIPTION
## Problem

The voice keyboard stayed white at night while the rest of the app followed the system's day/night schedule, so focusing a field flashed a bright slab over otherwise dark UI. Reproduced on a Pixel 10a in `cmd uimode night yes`: harness app dark, Ramblr panel white.

## Root cause

Not a missing dark theme — the app already has `Theme.PhoneWhisper` (Material3 **DayNight**) and a full `values-night/`. The panel simply never used them.

An `InputMethodService` is a `Service`, and a Service's theme is the bare platform default: always light, and without any of the Material3 attributes the panel paints itself with. So every lookup here failed its `resolveAttribute()` and silently fell through to its hardcoded light fallback:

```kotlin
setColor(resolveColor(com.google.android.material.R.attr.colorSurface, Color.WHITE))
```

`colorSurface`, `colorOnSurface`, `colorOnSurfaceVariant`, `colorPrimary` — all four fell back. The panel was never themed at all; the fallbacks *were* the panel.

## Fix

Inflate through a `ContextThemeWrapper` carrying `Theme.PhoneWhisper`, so the Material3 attributes both exist and track night mode.

`resolveColor()` also had to dereference its result. Material3 colour attributes resolve to a colour **reference**, not a literal, so `TypedValue.data` is only the raw colour for the inline `TYPE_INT_COLOR_*` case — without the type check the panel would paint with a resource id. This is why wrapping the context alone would not have been enough.

The mic's recording/disabled fills stay literal colours (they signal *danger* and *blocked*, not a theme role) but move to resources with night variants. The light disabled grey `#B0B4BA` is brighter than a dark surface and would have read as an *active* control at night. **Light values are unchanged**, so #240's blocked-mic appearance is byte-identical in day mode.

Night mode can also flip under an already-open keyboard, which does not recreate the service. `onConfigurationChanged` rebuilds the input view on a `uiMode` change while preserving the rendered state — a repaint, not a reset, so an in-flight dictation and its bound destination are untouched.

## Tests

`RamblrImePanelThemeTest` asserts resolved colours and WCAG contrast under both ui modes rather than the presence of a wrapper, so the regression cannot return through a different mechanism. Confirmed RED against unfixed code:

```
RamblrImePanelThemeTest > secure-field mic stays visibly disabled against a dark surface FAILED
RamblrImePanelThemeTest > panel surface and text follow dark mode FAILED
4 tests completed, 2 failed
```

The day-mode test passes both before and after, which is the point — it pins that light mode does not move.

Full suite after the fix: **166 suites / 1,751 tests / 0 failures / 0 errors / 0 skipped**, `assembleGithubDebug` successful.

## Device verification (Pixel 10a `63141JEA320614`)

| Case | Result |
|---|---|
| Dark, idle | Dark panel, white status text, `#8AB4F8` accent mic, light action icons |
| Dark, recording | Lifted red mic, "Recording… tap mic to stop", privacy indicator |
| Dark, secure field (`inputType=0x200081`) | Muted grey mic, still disabled, "Voice input unavailable in secure fields" — #240 holds |
| Light, idle | Unchanged: light surface, dark text, `#1A73E8` mic |
| Live night flip | Panel repaints dark on reopen |
| Dictation end-to-end in dark | Committed to field, history 44 → 45 |

## Notes

The keyboard dismisses itself on the `uiMode` configuration change (Android tearing down the input view), so in practice the panel is already correct by the time it is next shown; `onConfigurationChanged` covers the case where it is not.

No behavioral change to dictation, destination binding, secure-field blocking, or retention policy — this is presentation only.
