### PR TITLE
Bump to 1.0.26 and script the release cut

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,8 +98,8 @@ android {
         applicationId = "com.trevornk.ramblr"
         minSdk = 30
         targetSdk = 36
-        versionCode = 28
-        versionName = "1.0.25"
+        versionCode = 29
+        versionName = "1.0.26"
 
         buildConfigField("String", "OMNIROUTE_BASE_URL", "\"$omniRouteBaseUrl\"")
 

--- a/fastlane/metadata/android/en-US/changelogs/29.txt
+++ b/fastlane/metadata/android/en-US/changelogs/29.txt
@@ -1,0 +1,26 @@
+New ways to start dictating, Gemini transcription, and a crash fix for older phones.
+
+- Ramblr Voice keyboard: a voice-only keyboard you can switch to like any other. It works
+  without the accessibility service, which makes it a good option if you would rather not
+  enable one. It has a mic and nothing else, so keep another keyboard installed for typing.
+- Choose how you start dictation: floating icon, the Android accessibility button or
+  volume-key hold, a Quick Settings tile, or the keyboard. There is now a setup screen for
+  picking between them.
+- Select existing text in another app and tap "Ramblr" to clean it up in place.
+- Gemini now transcribes, not just cleans up. Pick it as your transcription provider
+  alongside OpenAI, or keep everything on-device.
+- Experimental Gemini Cloud Live: interim text as you speak, in the Ramblr Voice keyboard
+  only. Off by default, costs roughly 1.8x normal cloud transcription.
+- Better default on-device model, and a free default cleanup model so cloud cleanup no
+  longer requires paid API access to try.
+- Vocabulary suggestions: Ramblr notices terms you correct repeatedly and offers to add
+  them. Nothing is added without you tapping to accept.
+
+Fixes:
+
+- Local cleanup crashed instantly on phones older than roughly 2019 (pre-ARMv8.2). Ramblr
+  now picks the right code path for your processor instead of assuming a recent one.
+- Asking a question in dictation no longer sometimes returned an answer instead of your
+  words.
+- Fixed the "Ramblr" entry missing from the text selection menu, first-use silence
+  detection, and recovery when the keyboard is used in a password field.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Cuts a signed Ramblr release and publishes it to GitHub Releases.
+#
+# WHY THIS SCRIPT EXISTS
+#
+# v1.0.24 and v1.0.25 were both published with release bodies copied verbatim from
+# fastlane/metadata/android/en-US/changelogs/<versionCode>.txt. Those changelog files are
+# user-facing prose for F-Droid and deliberately contain no versionCode line -- but the
+# in-app self-update checker REQUIRES one:
+#
+#   SelfUpdateResolver.parseVersionCodeFromReleaseBody()  ->  Regex "(?i)version\s*code[:\s]+(-?\d+)"
+#
+# With no match, SelfUpdateResolver.evaluate() returns CheckFailed("release body has no
+# parseable versionCode line") and EVERY existing user silently stops being offered updates.
+# It fails closed and quietly: nothing crashes, nothing logs to the user, the update just
+# never appears. Both releases shipped that way and nobody noticed for weeks.
+#
+# So: never hand-publish a release. Use this script, which builds the body from the changelog
+# AND appends the machine-readable versionCode line, then verifies the published body parses
+# with the same regex the app uses.
+#
+# USAGE
+#   ./scripts/cut-release.sh            # uses versionCode/versionName from app/build.gradle.kts
+#   DRY_RUN=1 ./scripts/cut-release.sh  # build + verify locally, publish nothing
+#
+# PREREQUISITES
+#   - keystore.properties present and pointing at the real release keystore (gitignored;
+#     without it the release variant falls back to debug signing and existing users CANNOT
+#     install the result -- signature mismatch)
+#   - clean working tree on main, pushed, CI green
+#   - fastlane/metadata/android/en-US/changelogs/<versionCode>.txt written
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DRY_RUN="${DRY_RUN:-0}"
+JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17}"
+export JAVA_HOME
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Read the single source of truth -----------------------------------------------------
+VERSION_CODE=$(grep -E '^\s*versionCode = ' app/build.gradle.kts | head -1 | grep -oE '[0-9]+')
+VERSION_NAME=$(grep -E '^\s*versionName = ' app/build.gradle.kts | head -1 | cut -d'"' -f2)
+[ -n "$VERSION_CODE" ] || fail "could not read versionCode from app/build.gradle.kts"
+[ -n "$VERSION_NAME" ] || fail "could not read versionName from app/build.gradle.kts"
+TAG="v${VERSION_NAME}"
+
+echo "==> Releasing ${TAG} (versionCode ${VERSION_CODE})"
+
+# --- Preflight ---------------------------------------------------------------------------
+[ -f keystore.properties ] || fail "keystore.properties missing -- release would be debug-signed and UNINSTALLABLE over the existing app"
+
+CHANGELOG="fastlane/metadata/android/en-US/changelogs/${VERSION_CODE}.txt"
+[ -f "$CHANGELOG" ] || fail "missing ${CHANGELOG} (F-Droid reads this, and it seeds the release body)"
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  fail "tag ${TAG} already exists -- bump versionCode/versionName first"
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  fail "working tree is dirty -- commit or stash before cutting a release"
+fi
+
+PUBLISHED_VC=$(gh release view --json body --jq .body 2>/dev/null \
+  | grep -ioE 'version ?code[: ]+[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+if [ -n "$PUBLISHED_VC" ] && [ "$VERSION_CODE" -le "$PUBLISHED_VC" ]; then
+  fail "versionCode ${VERSION_CODE} is not greater than the currently published ${PUBLISHED_VC} -- self-update compares versionCodes, so this release would be invisible to existing users"
+fi
+
+# --- Build -------------------------------------------------------------------------------
+echo "==> Running unit tests"
+./gradlew testGithubDebugUnitTest
+
+echo "==> Assembling signed release APKs (both flavors)"
+./gradlew assembleGithubRelease assembleStorefrontRelease
+
+GITHUB_APK="app/build/outputs/apk/github/release/Ramblr-${VERSION_NAME}-github-release.apk"
+STOREFRONT_APK="app/build/outputs/apk/storefront/release/Ramblr-${VERSION_NAME}-storefront-release.apk"
+[ -f "$GITHUB_APK" ] || fail "expected APK not found: ${GITHUB_APK}"
+[ -f "$STOREFRONT_APK" ] || fail "expected APK not found: ${STOREFRONT_APK}"
+
+# The self-update checker only accepts an asset named exactly Ramblr-X.Y.Z-github-release.apk
+# (SelfUpdateResolver.GITHUB_RELEASE_APK_NAME). Verify rather than assume.
+basename "$GITHUB_APK" | grep -qE '^Ramblr-[0-9]+\.[0-9]+\.[0-9]+-github-release\.apk$' \
+  || fail "APK filename won't match SelfUpdateResolver.GITHUB_RELEASE_APK_NAME"
+
+# Confirm the APK is release-signed, not debug-signed. A debug-signed release cannot be
+# installed over an existing release-signed install.
+if command -v apksigner >/dev/null 2>&1; then
+  if apksigner verify --print-certs "$GITHUB_APK" 2>/dev/null | grep -qi 'CN=Android Debug'; then
+    fail "APK is DEBUG-signed -- existing users could not install it (signature mismatch)"
+  fi
+  echo "==> Signature check passed (not debug-signed)"
+else
+  echo "WARNING: apksigner not on PATH; skipping debug-signature check" >&2
+fi
+
+# --- Compose the release body (the part that broke twice) --------------------------------
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+cat "$CHANGELOG" > "$BODY_FILE"
+printf '\nversionCode: %s\n' "$VERSION_CODE" >> "$BODY_FILE"
+
+# Verify with the SAME regex the app uses, before publishing.
+PARSED=$(grep -ioE 'version ?code[: ]+[0-9]+' "$BODY_FILE" | grep -oE '[0-9]+' | head -1 || true)
+[ "$PARSED" = "$VERSION_CODE" ] \
+  || fail "composed release body does not parse to versionCode ${VERSION_CODE} (got '${PARSED:-none}')"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "==> DRY_RUN=1, stopping before tag/publish. Composed body:"
+  sed 's/^/    /' "$BODY_FILE"
+  exit 0
+fi
+
+# --- Tag and publish ---------------------------------------------------------------------
+echo "==> Tagging ${TAG}"
+git tag -a "$TAG" -m "Ramblr ${VERSION_NAME}"
+git push origin "$TAG"
+
+echo "==> Creating GitHub release"
+gh release create "$TAG" "$GITHUB_APK" "$STOREFRONT_APK" \
+  --title "Ramblr ${VERSION_NAME}" \
+  --notes-file "$BODY_FILE"
+
+# --- Verify what actually landed ---------------------------------------------------------
+echo "==> Verifying published release"
+LIVE_VC=$(gh release view "$TAG" --json body --jq .body \
+  | grep -ioE 'version ?code[: ]+[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+[ "$LIVE_VC" = "$VERSION_CODE" ] \
+  || fail "PUBLISHED body does not parse (got '${LIVE_VC:-none}') -- self-update is broken; fix with: gh release edit ${TAG} --notes-file <file>"
+
+LATEST_TAG=$(gh api repos/trevornk/ramblr/releases/latest --jq .tag_name)
+[ "$LATEST_TAG" = "$TAG" ] \
+  || echo "WARNING: /releases/latest still reports ${LATEST_TAG}, not ${TAG}" >&2
+
+gh release view "$TAG" --json assets --jq '.assets[].name' \
+  | grep -qE "^Ramblr-${VERSION_NAME}-github-release\.apk$" \
+  || fail "published assets do not include the github-flavor APK the updater looks for"
+
+echo "==> Released ${TAG} (versionCode ${VERSION_CODE}); self-update body verified."

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -87,15 +87,44 @@ basename "$GITHUB_APK" | grep -qE '^Ramblr-[0-9]+\.[0-9]+\.[0-9]+-github-release
   || fail "APK filename won't match SelfUpdateResolver.GITHUB_RELEASE_APK_NAME"
 
 # Confirm the APK is release-signed, not debug-signed. A debug-signed release cannot be
-# installed over an existing release-signed install.
-if command -v apksigner >/dev/null 2>&1; then
-  if apksigner verify --print-certs "$GITHUB_APK" 2>/dev/null | grep -qi 'CN=Android Debug'; then
-    fail "APK is DEBUG-signed -- existing users could not install it (signature mismatch)"
-  fi
-  echo "==> Signature check passed (not debug-signed)"
-else
-  echo "WARNING: apksigner not on PATH; skipping debug-signature check" >&2
+# installed over an existing release-signed install. apksigner lives in the versioned SDK
+# build-tools dirs and is not on PATH by default, so look it up rather than skipping the check.
+APKSIGNER="$(command -v apksigner || true)"
+if [ -z "$APKSIGNER" ]; then
+  APKSIGNER="$(find "${ANDROID_HOME:-$HOME/Library/Android/sdk}/build-tools" -maxdepth 2 -name apksigner -type f 2>/dev/null | sort -V | tail -1 || true)"
 fi
+[ -n "$APKSIGNER" ] && [ -x "$APKSIGNER" ] \
+  || fail "apksigner not found -- cannot verify the APK is release-signed. Install Android SDK build-tools or set ANDROID_HOME."
+
+if "$APKSIGNER" verify --print-certs "$GITHUB_APK" 2>/dev/null | grep -qi 'CN=Android Debug'; then
+  fail "APK is DEBUG-signed -- existing users could not install it (signature mismatch)"
+fi
+
+# Signing-identity continuity: Android refuses to install an update signed by a different key,
+# so a rotated/lost keystore must be caught here rather than by users. Compare this build's
+# signer against the currently published release's.
+NEW_SIGNER=$("$APKSIGNER" verify --print-certs "$GITHUB_APK" 2>/dev/null \
+  | grep -iE 'certificate SHA-256 digest' | head -1 | awk '{print $NF}')
+[ -n "$NEW_SIGNER" ] || fail "could not read this build's signing certificate digest"
+
+PREV_URL=$(gh release view --json assets \
+  --jq '.assets[]|select(.name|test("^Ramblr-[0-9.]+-github-release\\.apk$")).url' 2>/dev/null | head -1 || true)
+if [ -n "$PREV_URL" ]; then
+  PREV_APK=$(mktemp -t prev-release-XXXXXX.apk)
+  if curl -sfL -H "Accept: application/octet-stream" -o "$PREV_APK" "$PREV_URL"; then
+    PREV_SIGNER=$("$APKSIGNER" verify --print-certs "$PREV_APK" 2>/dev/null \
+      | grep -iE 'certificate SHA-256 digest' | head -1 | awk '{print $NF}')
+    if [ -n "$PREV_SIGNER" ] && [ "$PREV_SIGNER" != "$NEW_SIGNER" ]; then
+      rm -f "$PREV_APK"
+      fail "signing key CHANGED vs the published release (${PREV_SIGNER} -> ${NEW_SIGNER}) -- existing users could not install this update"
+    fi
+    echo "==> Signing identity matches the published release"
+  else
+    echo "WARNING: could not download previous release APK; skipped signer continuity check" >&2
+  fi
+  rm -f "$PREV_APK"
+fi
+echo "==> Signature check passed (release-signed)"
 
 # --- Compose the release body (the part that broke twice) --------------------------------
 BODY_FILE=$(mktemp)


### PR DESCRIPTION
The published release users install from is 11 days and 124 commits behind `main`, and the in-app updater has been silently broken for two releases.

## The release is stale

`v1.0.25` (Aug 20, `9389d32`) is what GitHub serves as Latest — 264 downloads. `main` is 136 app source files ahead (+72,419/−1,549). Unreleased: the Ramblr Voice keyboard (#143/#231), Gemini transcription (#226), Cloud Live (#233), vocabulary suggestions (#216), the invocation chooser and dual accessibility modes (#156), Process Text selection menu (#157), Parakeet v3 default ASR (#177), free default cleanup model (#134), and `e063b76` — the fix for **local cleanup SIGILL-ing on any pre-ARMv8.2 device**.

The README merged in #246 documents all of it, so the front page currently describes an app the released APK isn't.

## versionCode was never bumped

`versionCode` was **28 on both** the `v1.0.25` tag and `main`, unchanged across 124 commits. The updater compares versionCodes, so cutting from `main` as-is would have published a release no existing user was ever offered. → **29 / 1.0.26**.

## Self-update has been broken since v1.0.24

`SelfUpdateResolver.parseVersionCodeFromReleaseBody()` requires a `versionCode: <int>` line in the release body. Without it `evaluate()` returns `CheckFailed` and updates stop being offered — no crash, no log, no user-visible symptom. It fails closed and silently.

| Release | Body parses? |
|---|---|
| v1.0.23 | `versionCode: 26` ✅ |
| v1.0.24 | ❌ none |
| v1.0.25 | ❌ none |

Both were published with bodies copied verbatim from `fastlane/.../changelogs/<code>.txt` — user-facing F-Droid prose that deliberately carries no versionCode line. **v1.0.25's body has been repaired in place**, so update checks work again for current users.

## scripts/cut-release.sh

So it can't recur by hand. Reads the version from `build.gradle.kts`; refuses a dirty tree, an existing tag, or a versionCode not greater than published; builds both flavors; verifies the APK filename matches `GITHUB_RELEASE_APK_NAME`; verifies it's release-signed **and that the signer matches the published release** (Android rejects a differently-signed update, so a rotated keystore would produce an APK nobody could install); composes the body from changelog + versionCode line; and verifies the *published* body parses with the app's own regex before declaring success.

## Verification

- `DRY_RUN=1 ./scripts/cut-release.sh` → all gates pass, signing identity confirmed matching `375c6f11…eda5a`
- Dirty-tree guard confirmed firing
- `assembleGithubRelease` + `assembleStorefrontRelease` BUILD SUCCESSFUL, 1,751 tests green
- shellcheck clean

## Note on F-Droid

MR !42401 is still open, pinned to `v1.0.25`/`9389d32`. Cutting 1.0.26 doesn't break it; the pin can be updated after it lands, or repinned now at the cost of restarting reviewer attention.
