### PR TITLE
Prune orphaned staged update APKs and surface deferred installs

### DIFF
--- a/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateInstallGate.kt
+++ b/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateInstallGate.kt
@@ -96,4 +96,45 @@ object SelfUpdateInstallGate {
      */
     fun shouldAttemptManualInstallNow(recordingState: RecordingStateMachine.State?): Boolean =
         recordingState == null || recordingState == RecordingStateMachine.State.IDLE
+
+    /** Matches the staged-APK file names produced by [SelfUpdateInstallWorker.apkFilePath]
+     *  (`ramblr-update-<versionCode>.apk`) and captures the versionCode. Deliberately anchored and
+     *  digits-only so it can never match an unrelated file that happens to live in the same
+     *  directory -- an unrecognized name is left alone rather than deleted. */
+    private val STAGED_APK_NAME = Regex("""^ramblr-update-(\d+)\.apk$""")
+
+    /**
+     * Which of [presentFileNames] (the current contents of `filesDir/self_update/`) are orphaned
+     * staged APKs safe to delete, given the versionCode this pipeline is currently working toward
+     * ([currentTargetVersionCode], or null when no update is pending at all).
+     *
+     * Staged APKs are keyed by versionCode ([SelfUpdateInstallWorker.apkFilePath]), and every
+     * delete in the worker only ever touches *its own* target's file: the `.part` temp on a
+     * failed download, `dest` before a rename, and `apkFile` after a successful install. Nothing
+     * has ever deleted a staged file belonging to a *different* versionCode, so each time the
+     * update target moved (26 -> 29) the previous download was abandoned on disk permanently --
+     * app-private storage the user can neither see nor clear from Android's Files app. This is
+     * the pure half of fixing that; [SelfUpdateInstallWorker.pruneStagedApks] does the I/O.
+     *
+     * Rules, in order:
+     *  - Names that aren't recognizable staged APKs are never returned. Deleting an unrecognized
+     *    file in a directory this code doesn't exclusively own would be overreach, and failing
+     *    closed costs nothing.
+     *  - `.part` temp files are left to the download path's own cleanup, which already handles
+     *    them on every failure branch and knows whether one is mid-write. A concurrent download
+     *    writing `ramblr-update-29.apk.part` must not have it deleted out from under it.
+     *  - When [currentTargetVersionCode] is null (no update pending -- e.g. the check now says
+     *    UpToDate because the update was installed, or the release was pulled), every staged APK
+     *    is orphaned: there is no longer any version this pipeline intends to install.
+     *  - Otherwise every staged APK except the current target's is orphaned. Both older and newer
+     *    versionCodes qualify: a staged build the pipeline is no longer working toward will never
+     *    be installed by it, regardless of which direction it differs in.
+     */
+    fun orphanedStagedApks(
+        presentFileNames: Collection<String>,
+        currentTargetVersionCode: Int?,
+    ): List<String> = presentFileNames.filter { name ->
+        val versionCode = STAGED_APK_NAME.matchEntire(name)?.groupValues?.get(1)?.toIntOrNull()
+        versionCode != null && versionCode != currentTargetVersionCode
+    }
 }

--- a/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateInstallWorker.kt
+++ b/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateInstallWorker.kt
@@ -3,6 +3,7 @@ package com.trevornk.ramblr
 import android.app.Notification
 import android.content.Context
 import android.content.pm.ServiceInfo
+import android.util.Log
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
@@ -25,17 +26,28 @@ import java.util.concurrent.TimeUnit
  * retryable failure classification -- but this Worker additionally gates its own final step (the
  * actual install) on [SelfUpdateInstallGate], which [ModelDownloadWorker] has no equivalent of.
  *
- * NOT wired to any trigger yet: [enqueue] is a plain public entry point for Part 5's periodic
- * checker to call once it exists (see the `// TODO(Part 5)` in [SelfUpdatePrefs.setAutoInstallEnabled]).
- * Nothing in this codebase calls [enqueue] today.
+ * Triggered by [SelfUpdateCheckWorker]'s periodic tick (via [SelfUpdateCheckDecision.shouldAutoInstall]),
+ * by [SelfUpdatePrefs.setAutoInstallEnabled] when auto-install is switched on with an update already
+ * cached, and by [enqueueManual] from the Settings row / notification action.
  */
 class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(ctx, params) {
 
     override fun doWork(): Result {
         val update = SelfUpdateChecker.cachedResult(applicationContext) as? UpdateCheckResult.UpdateAvailable
-            ?: return Result.failure(errorData("No cached UpdateAvailable result"))
+            ?: run {
+                // No update pending: nothing to install, but any previously-staged APK is now
+                // orphaned (the update landed, or the release was pulled). Reclaim it before
+                // bailing -- this is the path that fires once an update has actually installed.
+                pruneStagedApks(applicationContext, currentTargetVersionCode = null)
+                return Result.failure(errorData("No cached UpdateAvailable result"))
+            }
 
         SelfUpdateNotifications.ensureChannel(applicationContext)
+
+        // Drop staged APKs for every version except the one we're working toward now. Runs on
+        // every attempt (before the resume-skip below, so a re-download can't be tricked by a
+        // stale neighbour) and is cheap: a directory listing plus zero or more deletes.
+        pruneStagedApks(applicationContext, currentTargetVersionCode = update.versionCode)
 
         val apkFile = apkFile(applicationContext, update.versionCode)
 
@@ -141,8 +153,14 @@ class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(c
         }
         if (!allowedFirst) {
             // Not a failure -- just not a good moment. Keep the verified file on disk so the next
-            // periodic retry (Part 5) doesn't need to re-download. No failure notification either:
-            // this is expected, routine "try again later" behavior, not something to alarm about.
+            // periodic retry doesn't need to re-download. Not a failure notification either: this
+            // is routine "try again later" behavior. It IS surfaced though (postInstallDeferred,
+            // not postInstallFailure) -- a downloaded update waiting on quiet hours used to be
+            // completely invisible, which made a working deferral look like a broken updater.
+            SelfUpdateNotifications.postInstallDeferred(
+                applicationContext, update,
+                SelfUpdateStatusFormatter.deferredReason(isDictating = isDictating(recordingStateFirst)),
+            )
             return Result.retry()
         }
 
@@ -160,6 +178,10 @@ class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(c
             SelfUpdateInstallGate.shouldAttemptInstallNow(SelfUpdateInstallGate.isWithinQuietHours(currentHour()), recordingStateSecond)
         }
         if (!allowedSecond) {
+            SelfUpdateNotifications.postInstallDeferred(
+                applicationContext, update,
+                SelfUpdateStatusFormatter.deferredReason(isDictating = isDictating(recordingStateSecond)),
+            )
             return Result.retry()
         }
 
@@ -187,6 +209,13 @@ class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(c
 
     private fun currentHour(): Int = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
 
+    /** Whether [state] represents an active dictation, using the same semantics as
+     *  [SelfUpdateInstallGate.shouldAttemptInstallNow]: null (accessibility service not connected)
+     *  and IDLE both mean "not dictating". Kept in lockstep with the gate so the reason shown to
+     *  the user can never contradict the decision that was actually made. */
+    private fun isDictating(state: RecordingStateMachine.State?): Boolean =
+        !(state == null || state == RecordingStateMachine.State.IDLE)
+
     /** Mirrors [ModelDownloadWorker.postForeground]'s never-fail-doWork contract exactly: a
      *  missing POST_NOTIFICATIONS grant must not block the download/install itself. */
     private fun postForeground(notification: Notification) {
@@ -206,6 +235,7 @@ class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(c
 
     companion object {
         private const val KEY_ERROR = "error"
+        private const val TAG = "SelfUpdateInstall"
 
         /** Stable notification id for this Worker's own foreground-progress notification, kept
          *  out of [SelfUpdateNotifications.notificationId]'s per-version id space (that's for the
@@ -249,6 +279,57 @@ class SelfUpdateInstallWorker(ctx: Context, params: WorkerParameters) : Worker(c
             File(filesDir, "self_update/ramblr-update-$versionCode.apk")
 
         fun apkFile(ctx: Context, versionCode: Int): File = apkFilePath(ctx.filesDir, versionCode)
+
+        /** The directory [apkFilePath] stages into. */
+        fun stagingDir(filesDir: File): File = File(filesDir, "self_update")
+
+        /**
+         * Deletes staged APKs that [SelfUpdateInstallGate.orphanedStagedApks] judges orphaned
+         * relative to [currentTargetVersionCode] (null = no update pending, so all of them).
+         *
+         * Exists because staged APKs are keyed by versionCode and the worker's own deletes only
+         * ever touch the current target's file -- so a moved update target used to abandon the
+         * previous download on disk forever (observed: a 57 MB `ramblr-update-26.apk` left for 18
+         * days alongside the live `-29`, 113 MB total, in storage the user cannot see or clear).
+         *
+         * Never throws: reclaiming disk is best-effort housekeeping and must not be able to fail
+         * an install that would otherwise succeed. A delete that loses a race with something else
+         * removing the same file is equally fine -- the file is gone either way, which is the
+         * whole point. Returns the number actually deleted, for logging and tests.
+         *
+         * Takes a plain [filesDir] rather than a [Context] for the same reason [apkFilePath] is
+         * split from [apkFile] (and [ModelDownloader.modelDirPath] from [ModelDownloader.modelDir]):
+         * so the real deletion behavior is directly unit-testable against a real filesystem without
+         * a live Android Context. Deliberately free of `android.util.Log` for the same reason --
+         * this project has no Robolectric (see DownloadNotificationsTest's kdoc) and does not set
+         * `unitTests.returnDefaultValues`, so touching an Android API here would make the whole
+         * function untestable on the JVM. It returns the deleted names and lets the
+         * [Context]-taking overload do the logging.
+         */
+        fun pruneStagedApks(filesDir: File, currentTargetVersionCode: Int?): List<String> {
+            val dir = stagingDir(filesDir)
+            val present = try {
+                dir.list()?.toList() ?: return emptyList()
+            } catch (_: SecurityException) {
+                return emptyList()
+            }
+            val deleted = mutableListOf<String>()
+            for (name in SelfUpdateInstallGate.orphanedStagedApks(present, currentTargetVersionCode)) {
+                val ok = try {
+                    File(dir, name).delete()
+                } catch (_: SecurityException) {
+                    false
+                }
+                if (ok) deleted += name
+            }
+            return deleted
+        }
+
+        fun pruneStagedApks(ctx: Context, currentTargetVersionCode: Int?): List<String> {
+            val deleted = pruneStagedApks(ctx.filesDir, currentTargetVersionCode)
+            for (name in deleted) Log.i(TAG, "Pruned orphaned staged update APK: $name")
+            return deleted
+        }
 
         fun workName(): String = "self-update-install"
 

--- a/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateNotifications.kt
+++ b/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateNotifications.kt
@@ -115,6 +115,38 @@ object SelfUpdateNotifications {
             .setOnlyAlertOnce(true)
             .build()
 
+    /** Posted when a fully downloaded, checksum-verified update is staged on disk but the install
+     *  gate deferred it (outside quiet hours, or dictation in progress -- see
+     *  [SelfUpdateInstallGate]). Distinct from [postInstallFailure]: nothing has gone wrong, the
+     *  bytes are ready and waiting for a safe moment.
+     *
+     *  This exists because a deferral was previously invisible. The only notification a user saw
+     *  was "Update available / Tap to view the release on GitHub", which understates reality once
+     *  the APK is already downloaded, and a deferred install could then sit for hours (the
+     *  default quiet-hours window is 1am-5am) with no indication of what it was waiting for. The
+     *  "Install now" action is the same manual, quiet-hours-free path as the Settings row, so a
+     *  user who doesn't want to wait for the overnight window has a one-tap way out.
+     *
+     *  Shares [INSTALL_PROGRESS_NOTIFICATION_ID] with the progress and failure notifications: all
+     *  three are states of the same single install attempt, so replacing rather than stacking is
+     *  correct -- the download-progress notification becoming "waiting" is the accurate story.
+     *  Never throws, mirrors [postUpdateAvailable]. */
+    fun postInstallDeferred(ctx: Context, update: UpdateCheckResult.UpdateAvailable, reason: String) {
+        ensureChannel(ctx)
+        val notification = NotificationCompat.Builder(ctx, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_mic)
+            .setContentTitle("Update v${update.versionName} ready to install")
+            .setContentText(reason)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(reason))
+            .addAction(0, "Install now", installActionPendingIntent(ctx, update))
+            .setAutoCancel(true)
+            .build()
+        try {
+            NotificationManagerCompat.from(ctx).notify(INSTALL_PROGRESS_NOTIFICATION_ID, notification)
+        } catch (_: SecurityException) {
+        }
+    }
+
     /** Posted when the download or install fails outright (checksum mismatch, terminal I/O
      *  failure, or a [PackageInstaller] failure) -- never posted for a gate deferral (quiet-hours
      *  miss / dictation in progress), which is routine "try again later" behavior, not a failure

--- a/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateStatusFormatter.kt
+++ b/app/src/github/kotlin/com/trevornk/ramblr/SelfUpdateStatusFormatter.kt
@@ -48,4 +48,42 @@ object SelfUpdateStatusFormatter {
         val status = statusLine(result)
         return "$checked · $running · $status"
     }
+
+    /**
+     * Why a staged, checksum-verified update isn't installing yet, in user-facing terms. Drives
+     * [SelfUpdateNotifications.postInstallDeferred].
+     *
+     * The two deferral causes are reported separately because the remedies differ: an in-progress
+     * dictation clears itself within seconds, whereas a quiet-hours wait can be hours away and is
+     * the case where a user most plausibly wants the "Install now" action instead. Dictation is
+     * checked first -- when both apply it's the more immediate and more surprising of the two, and
+     * telling someone mid-dictation to wait until 1am would be actively misleading.
+     *
+     * [quietHoursStartHour]/[quietHoursEndHour] are passed in rather than read from
+     * [SelfUpdateInstallGate]'s constants so the copy stays correct if the window ever becomes
+     * configurable, and so every phrasing is directly testable.
+     */
+    fun deferredReason(
+        isDictating: Boolean,
+        quietHoursStartHour: Int = SelfUpdateInstallGate.QUIET_HOURS_START_HOUR,
+        quietHoursEndHour: Int = SelfUpdateInstallGate.QUIET_HOURS_END_HOUR,
+    ): String = if (isDictating) {
+        "Downloaded. Waiting until dictation finishes."
+    } else {
+        "Downloaded. Will install overnight, between " +
+            "${formatHour(quietHoursStartHour)} and ${formatHour(quietHoursEndHour)}."
+    }
+
+    /** 24h hour-of-day to a 12h clock phrase ("1am", "12pm"), matching how the rest of the app's
+     *  user-facing copy reads. Only whole hours occur here: the quiet-hours window is defined in
+     *  whole hour-of-day units ([SelfUpdateInstallGate.isWithinQuietHours]). */
+    fun formatHour(hour: Int): String {
+        val normalized = ((hour % 24) + 24) % 24
+        val suffix = if (normalized < 12) "am" else "pm"
+        val twelve = when (normalized % 12) {
+            0 -> 12
+            else -> normalized % 12
+        }
+        return "$twelve$suffix"
+    }
 }

--- a/app/src/testGithub/kotlin/com/trevornk/ramblr/SelfUpdateInstallGateTest.kt
+++ b/app/src/testGithub/kotlin/com/trevornk/ramblr/SelfUpdateInstallGateTest.kt
@@ -158,6 +158,176 @@ class SelfUpdateInstallGateTest {
         assertEquals(SelfUpdateInstallWorker.workName(), SelfUpdateInstallWorker.workName())
     }
 
+    // -- orphanedStagedApks: the staged-APK leak fixed in #249 --
+    //
+    // Regression context: staged APKs are keyed by versionCode and every delete in the worker
+    // only ever touched the current target's own file, so a moved update target abandoned the
+    // previous download permanently. Observed on a real device as a 57 MB ramblr-update-26.apk
+    // left for 18 days next to the live -29, 113 MB total, in storage the user cannot clear.
+
+    @Test fun `staged apk for a different versionCode is orphaned`() {
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("ramblr-update-26.apk", "ramblr-update-29.apk"),
+            currentTargetVersionCode = 29,
+        )
+        assertEquals(listOf("ramblr-update-26.apk"), orphans)
+    }
+
+    @Test fun `the current target's staged apk is never orphaned`() {
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("ramblr-update-29.apk"),
+            currentTargetVersionCode = 29,
+        )
+        assertTrue(orphans.isEmpty())
+    }
+
+    @Test fun `every staged apk is orphaned when no update is pending`() {
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("ramblr-update-26.apk", "ramblr-update-29.apk"),
+            currentTargetVersionCode = null,
+        )
+        assertEquals(listOf("ramblr-update-26.apk", "ramblr-update-29.apk"), orphans)
+    }
+
+    @Test fun `a newer staged versionCode than the target is also orphaned`() {
+        // Target can move backwards (a release pulled/yanked, cache refreshed to an older one).
+        // A staged build the pipeline is no longer working toward will never be installed by it.
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("ramblr-update-30.apk"),
+            currentTargetVersionCode = 29,
+        )
+        assertEquals(listOf("ramblr-update-30.apk"), orphans)
+    }
+
+    @Test fun `unrecognized file names are never deleted`() {
+        // Fails closed: this code does not exclusively own the directory, so anything that isn't
+        // unmistakably a staged APK is left alone.
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("notes.txt", "ramblr-update-.apk", "ramblr-update-abc.apk", "update-29.apk", ""),
+            currentTargetVersionCode = 29,
+        )
+        assertTrue("expected no matches, got $orphans", orphans.isEmpty())
+    }
+
+    @Test fun `part files are left to the download path's own cleanup`() {
+        // A concurrent download writing ramblr-update-29.apk.part must not have it deleted out
+        // from under it; the download path already cleans .part up on every failure branch.
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(
+            listOf("ramblr-update-26.apk.part", "ramblr-update-29.apk.part"),
+            currentTargetVersionCode = 29,
+        )
+        assertTrue("expected .part files to be skipped, got $orphans", orphans.isEmpty())
+    }
+
+    @Test fun `an empty directory yields no orphans`() {
+        assertTrue(SelfUpdateInstallGate.orphanedStagedApks(emptyList(), 29).isEmpty())
+        assertTrue(SelfUpdateInstallGate.orphanedStagedApks(emptyList(), null).isEmpty())
+    }
+
+    @Test fun `orphan detection round-trips with the real apkFilePath naming`() {
+        // Guards against the regex and the path builder drifting apart: if apkFilePath's naming
+        // ever changes, this fails rather than silently pruning nothing forever.
+        val filesDir = java.io.File(System.getProperty("java.io.tmpdir"), "self-update-test-files")
+        val staleName = SelfUpdateInstallWorker.apkFilePath(filesDir, 26).name
+        val currentName = SelfUpdateInstallWorker.apkFilePath(filesDir, 29).name
+        val orphans = SelfUpdateInstallGate.orphanedStagedApks(listOf(staleName, currentName), 29)
+        assertEquals(listOf(staleName), orphans)
+    }
+
+    @Test fun `staging dir is where apkFilePath actually writes`() {
+        val filesDir = java.io.File(System.getProperty("java.io.tmpdir"), "self-update-test-files")
+        assertEquals(
+            SelfUpdateInstallWorker.stagingDir(filesDir).path,
+            SelfUpdateInstallWorker.apkFilePath(filesDir, 29).parentFile?.path,
+        )
+    }
+
+    // -- pruneStagedApks against a REAL filesystem (not just the pure name filter above) --
+
+    /** Fresh, isolated staging dir per test, seeded with [names] as real non-empty files. */
+    private fun seedStagingDir(vararg names: String): java.io.File {
+        val filesDir = java.io.File(
+            System.getProperty("java.io.tmpdir"),
+            "ramblr-prune-test-${System.nanoTime()}",
+        )
+        val staging = SelfUpdateInstallWorker.stagingDir(filesDir)
+        staging.mkdirs()
+        for (name in names) java.io.File(staging, name).writeText("apk bytes")
+        return filesDir
+    }
+
+    private fun stagedNames(filesDir: java.io.File): List<String> =
+        SelfUpdateInstallWorker.stagingDir(filesDir).list()?.sorted() ?: emptyList()
+
+    @Test fun `prune actually deletes the orphan and keeps the current target on disk`() {
+        val filesDir = seedStagingDir("ramblr-update-26.apk", "ramblr-update-29.apk")
+        try {
+            val deleted = SelfUpdateInstallWorker.pruneStagedApks(filesDir, currentTargetVersionCode = 29)
+            assertEquals(listOf("ramblr-update-26.apk"), deleted)
+            assertEquals(listOf("ramblr-update-29.apk"), stagedNames(filesDir))
+        } finally {
+            filesDir.deleteRecursively()
+        }
+    }
+
+    @Test fun `prune with no pending update clears every staged apk but spares other files`() {
+        val filesDir = seedStagingDir("ramblr-update-26.apk", "ramblr-update-29.apk", "notes.txt")
+        try {
+            val deleted = SelfUpdateInstallWorker.pruneStagedApks(filesDir, currentTargetVersionCode = null)
+            assertEquals(listOf("ramblr-update-26.apk", "ramblr-update-29.apk"), deleted.sorted())
+            assertEquals(listOf("notes.txt"), stagedNames(filesDir))
+        } finally {
+            filesDir.deleteRecursively()
+        }
+    }
+
+    @Test fun `prune leaves a mid-download part file alone`() {
+        val filesDir = seedStagingDir("ramblr-update-29.apk.part", "ramblr-update-26.apk")
+        try {
+            val deleted = SelfUpdateInstallWorker.pruneStagedApks(filesDir, currentTargetVersionCode = 29)
+            assertEquals(listOf("ramblr-update-26.apk"), deleted)
+            assertEquals(listOf("ramblr-update-29.apk.part"), stagedNames(filesDir))
+        } finally {
+            filesDir.deleteRecursively()
+        }
+    }
+
+    @Test fun `prune on a missing staging dir is a harmless no-op`() {
+        // First-run case: nothing has ever been downloaded, so the directory doesn't exist yet.
+        val filesDir = java.io.File(
+            System.getProperty("java.io.tmpdir"),
+            "ramblr-prune-absent-${System.nanoTime()}",
+        )
+        assertTrue(SelfUpdateInstallWorker.pruneStagedApks(filesDir, 29).isEmpty())
+        assertTrue(SelfUpdateInstallWorker.pruneStagedApks(filesDir, null).isEmpty())
+    }
+
+    @Test fun `prune is idempotent`() {
+        val filesDir = seedStagingDir("ramblr-update-26.apk", "ramblr-update-29.apk")
+        try {
+            assertEquals(listOf("ramblr-update-26.apk"), SelfUpdateInstallWorker.pruneStagedApks(filesDir, 29))
+            assertTrue(SelfUpdateInstallWorker.pruneStagedApks(filesDir, 29).isEmpty())
+            assertEquals(listOf("ramblr-update-29.apk"), stagedNames(filesDir))
+        } finally {
+            filesDir.deleteRecursively()
+        }
+    }
+
+    @Test fun `prune reclaims the exact real-world leak from issue 249`() {
+        // The observed device state: an 18-day-old ramblr-update-26.apk stranded next to the
+        // live -29 because the update target moved and nothing ever deleted the old one.
+        val filesDir = seedStagingDir("ramblr-update-26.apk", "ramblr-update-29.apk")
+        try {
+            SelfUpdateInstallWorker.pruneStagedApks(filesDir, currentTargetVersionCode = 29)
+            val stale = java.io.File(SelfUpdateInstallWorker.stagingDir(filesDir), "ramblr-update-26.apk")
+            val live = java.io.File(SelfUpdateInstallWorker.stagingDir(filesDir), "ramblr-update-29.apk")
+            assertFalse("stale staged APK must be gone", stale.exists())
+            assertTrue("in-flight staged APK must survive", live.exists())
+        } finally {
+            filesDir.deleteRecursively()
+        }
+    }
+
     private fun assertEquals(message: String, expected: Any?, actual: Any?) {
         org.junit.Assert.assertEquals(message, expected, actual)
     }

--- a/app/src/testGithub/kotlin/com/trevornk/ramblr/SelfUpdateStatusFormatterTest.kt
+++ b/app/src/testGithub/kotlin/com/trevornk/ramblr/SelfUpdateStatusFormatterTest.kt
@@ -1,6 +1,8 @@
 package com.trevornk.ramblr
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /** Covers [SelfUpdateStatusFormatter], the pure status-string logic backing Part 3's Settings
@@ -71,5 +73,64 @@ class SelfUpdateStatusFormatterTest {
             runningVersionCode = 13,
         )
         assertEquals("Last checked 5m ago · Running v1.0.10 (13) · Up to date", subtitle)
+    }
+
+    // -- deferredReason: making a gate deferral visible (#249) --
+    //
+    // A staged, checksum-verified update waiting on the quiet-hours window used to be completely
+    // invisible to the user, which made correct deferral behavior look like a broken updater.
+
+    @Test fun `dictation deferral explains the immediate cause, not the overnight window`() {
+        val reason = SelfUpdateStatusFormatter.deferredReason(isDictating = true)
+        assertEquals("Downloaded. Waiting until dictation finishes.", reason)
+    }
+
+    @Test fun `quiet-hours deferral names the actual configured window`() {
+        val reason = SelfUpdateStatusFormatter.deferredReason(
+            isDictating = false,
+            quietHoursStartHour = 1,
+            quietHoursEndHour = 5,
+        )
+        assertEquals("Downloaded. Will install overnight, between 1am and 5am.", reason)
+    }
+
+    @Test fun `deferral copy tracks a reconfigured quiet-hours window`() {
+        val reason = SelfUpdateStatusFormatter.deferredReason(
+            isDictating = false,
+            quietHoursStartHour = 22,
+            quietHoursEndHour = 6,
+        )
+        assertEquals("Downloaded. Will install overnight, between 10pm and 6am.", reason)
+    }
+
+    @Test fun `dictation takes precedence when both conditions would defer`() {
+        // Telling someone who is mid-dictation to wait until 1am would be actively misleading:
+        // the dictation clears in seconds, the window is hours away.
+        val reason = SelfUpdateStatusFormatter.deferredReason(isDictating = true)
+        assertTrue(reason.contains("dictation"))
+        assertFalse(reason.contains("overnight"))
+    }
+
+    @Test fun `deferral copy never reads as a failure`() {
+        // The whole point of splitting this from postInstallFailure: nothing has gone wrong.
+        for (dictating in listOf(true, false)) {
+            val reason = SelfUpdateStatusFormatter.deferredReason(isDictating = dictating).lowercase()
+            assertFalse(reason, reason.contains("fail"))
+            assertFalse(reason, reason.contains("error"))
+        }
+    }
+
+    @Test fun `formatHour renders 12-hour clock boundaries correctly`() {
+        assertEquals("12am", SelfUpdateStatusFormatter.formatHour(0))
+        assertEquals("1am", SelfUpdateStatusFormatter.formatHour(1))
+        assertEquals("11am", SelfUpdateStatusFormatter.formatHour(11))
+        assertEquals("12pm", SelfUpdateStatusFormatter.formatHour(12))
+        assertEquals("1pm", SelfUpdateStatusFormatter.formatHour(13))
+        assertEquals("11pm", SelfUpdateStatusFormatter.formatHour(23))
+    }
+
+    @Test fun `formatHour normalizes out-of-range hours instead of throwing`() {
+        assertEquals("12am", SelfUpdateStatusFormatter.formatHour(24))
+        assertEquals("11pm", SelfUpdateStatusFormatter.formatHour(-1))
     }
 }


### PR DESCRIPTION
Fixes the two defects that actually exist behind #249. The issue's original FGS-timeout diagnosis was wrong and is [withdrawn in a comment](https://github.com/trevornk/ramblr/issues/249#issuecomment-5495785976) — the ~159 ms service teardown after download was a normal return through the quiet-hours deferral branch, not a kill mid-install.

## 1. Stale staged APKs leaked app-private disk forever

Staged APKs are keyed by versionCode (`files/self_update/ramblr-update-<code>.apk`), but every existing delete path only touched the **current** target's file. When the target moved 26 → 29, the old download was abandoned permanently.

Observed on the Fold: a 57 MB `ramblr-update-26.apk` stranded for 18 days next to the live `-29` — 113 MB in storage the user cannot see or clear from Android's Files UI.

`SelfUpdateInstallGate.orphanedStagedApks()` decides what's orphaned relative to the current target (`null` = nothing pending, so all of them). It matches only the exact `ramblr-update-<digits>.apk` name, so foreign files and in-flight `.part` downloads are never touched. `SelfUpdateInstallWorker.pruneStagedApks()` applies it at the top of `doWork()` and on the no-update-cached branch — the latter is what reclaims the file once an update has actually installed.

## 2. A correct deferral looked like nothing happened

A verified download outside the 01:00–05:00 window is retained and retried, but the only notification read *"Tap to view the release on GitHub"* — implying nothing had downloaded. `postInstallDeferred()` now reports the real state with an **Install now** action, and `deferredReason()` gives the actual cause (\`Waiting until dictation finishes\` / \`Will install overnight, between 1am and 5am\`), deriving the window from the gate's own constants instead of hardcoding it.

## Testing

**1,773 github (+22) and 1,685 storefront, 0 failures / 0 errors / 0 skipped.** \`lintGithubDebug\` and \`assembleGithubDebug\` clean.

The prune tests run against real files in a real temp directory, not just the pure name filter: the exact 26-next-to-29 leak from the issue, \`.part\` survival, unrecognized-name survival, idempotency, and a missing staging dir.

\`pruneStagedApks\` takes a plain \`File\` rather than a \`Context\` and returns deleted names instead of logging them, specifically so that filesystem behavior is JVM-testable — this project has no Robolectric and doesn't set \`unitTests.returnDefaultValues\`, so an \`android.util.Log\` call inside it throws *"not mocked"* (caught by these tests failing first). The \`Context\` overload does the logging.

## What is not verified here

The end-to-end device path was **not** exercised. Both phones are on versionCode 29 and current, so \`cachedResult()\` never returns \`UpdateAvailable\` and no self-update worker is scheduled — reaching it would have required fabricating a fake release. The unit tests cover the deletion logic against a real filesystem; the worker wiring is covered by inspection only. Real end-to-end confirmation comes with the next actual release.

Refs #249