### PR TITLE
Bump to 1.0.27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,8 +98,8 @@ android {
         applicationId = "com.trevornk.ramblr"
         minSdk = 30
         targetSdk = 36
-        versionCode = 29
-        versionName = "1.0.26"
+        versionCode = 30
+        versionName = "1.0.27"
 
         buildConfigField("String", "OMNIROUTE_BASE_URL", "\"$omniRouteBaseUrl\"")
 

--- a/fastlane/metadata/android/en-US/changelogs/30.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30.txt
@@ -1,0 +1,11 @@
+Housekeeping for the built-in updater.
+
+- Ramblr no longer leaves old downloaded update files behind. Each update was saved
+  under its own version number, and when a newer one came along the previous file was
+  never deleted -- on one phone that had quietly grown to 113 MB of storage you cannot
+  see or clear from the Files app. Old files are now cleaned up automatically.
+- When an update has downloaded but is waiting to install, Ramblr now says so. It
+  installs overnight, between 1am and 5am, and never interrupts you mid-dictation --
+  but the notification used to just say "tap to view the release", which made it look
+  like nothing had happened. It now tells you the update is ready, why it is waiting,
+  and offers an Install now button if you do not want to wait.


### PR DESCRIPTION
Ships the staged-APK pruning and deferred-install visibility merged in #251.

The other reason to cut this: **it is the only way to test the updater.** Both phones sit on versionCode 29 and current, so `cachedResult()` never returns `UpdateAvailable`, no self-update worker is ever scheduled, and #251's prune path cannot be reached without fabricating a fake release. A real v1.0.27 gives the devices something real to find — real check, real staged download, and a real orphaned versionCode 29 file for the prune to reclaim.

Contents:

- `versionCode` 29 → 30, `versionName` 1.0.26 → 1.0.27
- `fastlane/metadata/android/en-US/changelogs/30.txt`, user-facing prose describing the storage cleanup and the clearer waiting-to-install notification

`DRY_RUN=1 ./scripts/cut-release.sh` gates on a clean tree, signing identity, artifact naming, and that the published body parses with `SelfUpdateResolver`'s own versionCode regex — the check that exists because v1.0.24/v1.0.25 both silently broke updates for every user.

Refs #249