### PR TITLE
Add an in-app off switch for the accessibility service

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
@@ -50,6 +50,7 @@ class InvocationActivity : BaseSettingsActivity() {
     private lateinit var systemButtonRowSub: TextView
     private lateinit var volumeKeysRowSub: TextView
     private lateinit var advancedTierRowSub: TextView
+    private lateinit var serviceOffRowSub: TextView
     private lateinit var voiceKeyboardSectionSub: TextView
     private lateinit var voiceKeyboardRowSub: TextView
 
@@ -178,6 +179,15 @@ class InvocationActivity : BaseSettingsActivity() {
 
         root.addView(sectionHeader("Advanced"))
 
+        // --- #254 off switch. Deliberately NOT hidden in Advanced-only territory despite
+        // sitting under that header: in system-controls mode this is the ONLY off switch that
+        // exists anywhere, because the OS hides the master toggle on Ramblr's own Accessibility
+        // page for INVISIBLE_TOGGLE services. A user who wants Ramblr gone before opening a
+        // banking app must be able to find it here.
+        val serviceOffRow = settingsRow("Turn Ramblr off", "Checking...") { onServiceOffRowTapped() }
+        serviceOffRowSub = serviceOffRow.findViewWithTag("subtitle")
+        root.addView(serviceOffRow)
+
         val advancedTierRow = settingsRow("Direct shortcut control", "Checking...") {
             showAdvancedTierDialog()
         }
@@ -219,6 +229,10 @@ class InvocationActivity : BaseSettingsActivity() {
             directControl = direct,
         )
         advancedTierRowSub.text = invocationAdvancedTierSubtitleText(granted = direct)
+        serviceOffRowSub.text = serviceOffRowSubtitleText(
+            serviceEnabled = InvocationSecureSettings.isServiceEnabled(this),
+            mode = mode,
+        )
 
         // Read live from the OS every refresh -- nothing about the keyboard is persisted by
         // Ramblr, so onResume after a trip to system settings always reflects reality.
@@ -455,6 +469,70 @@ class InvocationActivity : BaseSettingsActivity() {
             )
             .setPositiveButton("OK", null)
             .show()
+    }
+
+    // --- #254 in-app off switch -------------------------------------------------------------
+
+    /**
+     * "Turn Ramblr off": the app-side master off switch, and in system-controls mode the only
+     * one that exists (the OS hides the master toggle on an INVISIBLE_TOGGLE service's own
+     * Accessibility page). Confirm first -- this stops dictation everywhere -- then take the
+     * action [resolveServiceOffAction] picks, sweeping OS shortcut bindings beforehand when we
+     * can, since a bound volume-keys shortcut would otherwise turn the service straight back on
+     * (AMS.performAccessibilityShortcutTargetService).
+     */
+    private fun onServiceOffRowTapped() {
+        val action = resolveServiceOffAction(
+            serviceEnabled = InvocationSecureSettings.isServiceEnabled(this),
+            serviceConnected = WhisperAccessibilityService.instance != null,
+        )
+        if (action == ServiceOffAction.ALREADY_OFF) {
+            toast("Ramblr's accessibility service is already off")
+            refresh()
+            return
+        }
+        val risk = resolveServiceOffShortcutRisk(
+            mode = InvocationServiceMode.currentMode(this),
+            buttonTargetBound = InvocationSecureSettings.isButtonTargetBound(this),
+            volumeKeysBound = InvocationSecureSettings.isVolumeKeysBound(this),
+            canWrite = InvocationSecureSettings.canWrite(this),
+        )
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Turn Ramblr off?")
+            .setMessage(serviceOffConfirmMessage(risk))
+            .setPositiveButton("Turn off") { _, _ -> performServiceOff(action, risk) }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun performServiceOff(action: ServiceOffAction, risk: ServiceOffShortcutRisk) {
+        // Sweep the OS shortcut bindings BEFORE disabling, in that order and only on the tier
+        // that can: raw Secure writes bypass the invisible-toggle sync (#156 memo §3), so this
+        // cannot itself trip the "last shortcut off" kill, and once nothing is bound there is
+        // nothing left that can resurrect the service after disableSelf().
+        if (risk == ServiceOffShortcutRisk.SWEEPABLE) {
+            InvocationSecureSettings.setBinding(
+                this, InvocationSecureSettings.KEY_BUTTON_TARGETS, bound = false,
+            )
+            InvocationSecureSettings.setBinding(
+                this, InvocationSecureSettings.KEY_SHORTCUT_TARGET_SERVICE, bound = false,
+            )
+        }
+        // The guard-rail banner must not fire for a disable the user just asked for: dismissing
+        // it here marks this detection handled, and the service clears the dismissal itself the
+        // next time it connects, so a genuine future kill still gets the banner.
+        InvocationGuardRail.dismissBanner(this)
+        if (action == ServiceOffAction.SELF_DISABLE && WhisperAccessibilityService.disableServiceFromApp()) {
+            toast("Ramblr turned off")
+            // The OS unbinds asynchronously, so an immediate re-read can still show the old
+            // enabled state; refresh on the next resume instead of asserting a state we
+            // haven't observed.
+            return
+        }
+        // Listed as enabled with no live instance to disable (crashed / not yet connected):
+        // only system Settings can clear the entry. Same deep link the mode switch uses.
+        toast("Opening Ramblr's accessibility settings")
+        openServiceDetailsSettings()
     }
 
     /** The advanced tier's explainer: what it unlocks, the exact adb command (selectable for

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -152,6 +152,133 @@ enum class InvocationMode {
 fun resolveInvocationMode(systemComponentPmEnabled: Boolean): InvocationMode =
     if (systemComponentPmEnabled) InvocationMode.SYSTEM_CONTROLS else InvocationMode.FLOATING_ICON
 
+// --- #254 in-app off switch -----------------------------------------------------------------
+
+/**
+ * How the "Turn Ramblr off" row must act right now (#254).
+ *
+ * The row exists because in SYSTEM_CONTROLS mode the OS gives the user NO off switch at all:
+ * `flagRequestAccessibilityButton` + targetSdk > 29 classifies the component INVISIBLE_TOGGLE,
+ * and Settings' InvisibleToggleAccessibilityServicePreferenceFragment hides the master
+ * on/off preference outright -- the only switch left on Ramblr's Accessibility page is
+ * "Ramblr shortcut". Automation (MacroDroid/Tasker) can't fill the gap either: the framework
+ * re-enables an INVISIBLE_TOGGLE service whenever a shortcut is bound to it
+ * (ShortcutUtils.updateInvisibleToggleAccessibilityServiceEnableState) and again when the
+ * volume-keys shortcut fires (AMS.performAccessibilityShortcutTargetService). So the app has
+ * to provide the off switch, and [AccessibilityService.disableSelf] is the way: it needs no
+ * permission, it works identically in both modes, and it writes
+ * `enabled_accessibility_services` through AccessibilityServiceConnection.disableSelf ->
+ * persistComponentNamesToSettingLocked WITHOUT going near the invisible-toggle sync (that sync
+ * has exactly one caller, AMS.enableShortcutForTargets), so nothing undoes it.
+ *
+ * [NEEDS_SETTINGS] is the one case disableSelf can't serve: the OS lists the service as enabled
+ * but nothing is bound to call it on (crashed/not-yet-connected), so there's no live
+ * AccessibilityService instance and only system Settings can clear the entry.
+ */
+enum class ServiceOffAction {
+    /** Not in `enabled_accessibility_services`: the row is already in its target state. */
+    ALREADY_OFF,
+
+    /** A connected service instance exists -- call disableSelf() on it. */
+    SELF_DISABLE,
+
+    /** Listed as enabled but no live instance to disable: deep-link to the service's page. */
+    NEEDS_SETTINGS,
+}
+
+fun resolveServiceOffAction(serviceEnabled: Boolean, serviceConnected: Boolean): ServiceOffAction = when {
+    !serviceEnabled -> ServiceOffAction.ALREADY_OFF
+    serviceConnected -> ServiceOffAction.SELF_DISABLE
+    else -> ServiceOffAction.NEEDS_SETTINGS
+}
+
+/**
+ * Whether an OS shortcut binding will undo the off switch, and whether Ramblr can do anything
+ * about it before disabling itself (#254).
+ *
+ * Only SYSTEM_CONTROLS mode is at risk: the floating component is an ordinary TOGGLE service,
+ * so the OS never re-enables it from a shortcut. Within system mode the two bindings behave
+ * DIFFERENTLY and the copy must not lump them together:
+ *
+ *  - volume-keys (`accessibility_shortcut_target_service`): AMS 4341-4346 -- for targetSdk > Q
+ *    WITH the button flag, the hardware shortcut enables the service when it is not enabled.
+ *    Holding both volume keys genuinely turns Ramblr back on.
+ *  - a11y button/gesture (`accessibility_button_targets`): the same path falls through to the
+ *    "callback to a bound service" branch, which bails out when the service isn't running
+ *    (AMS 4349-4355). It does NOT revive Ramblr -- it just leaves a button on screen that
+ *    silently does nothing.
+ *
+ * Both are sweepable with the WRITE_SECURE_SETTINGS tier, because raw Secure writes bypass the
+ * invisible-toggle sync (#156 memo §3, device-verified) -- unbinding via raw write cannot itself
+ * trip the "last shortcut off" kill, and once nothing is bound, nothing can resurrect the
+ * service.
+ */
+enum class ServiceOffShortcutRisk {
+    /** Floating-icon mode, or nothing binds Ramblr: off stays off. */
+    NONE,
+
+    /** System mode with bindings AND the advanced tier: sweep them, then disable. */
+    SWEEPABLE,
+
+    /** Volume-keys bound with no way to unbind in-app: holding them re-enables Ramblr. */
+    VOLUME_KEYS,
+
+    /** Only the button/gesture bound with no way to unbind in-app: it won't revive Ramblr,
+     *  but it stays on screen doing nothing until the user removes it in system Settings. */
+    STALE_BUTTON,
+}
+
+fun resolveServiceOffShortcutRisk(
+    mode: InvocationMode,
+    buttonTargetBound: Boolean,
+    volumeKeysBound: Boolean,
+    canWrite: Boolean,
+): ServiceOffShortcutRisk = when {
+    mode != InvocationMode.SYSTEM_CONTROLS -> ServiceOffShortcutRisk.NONE
+    !buttonTargetBound && !volumeKeysBound -> ServiceOffShortcutRisk.NONE
+    canWrite -> ServiceOffShortcutRisk.SWEEPABLE
+    volumeKeysBound -> ServiceOffShortcutRisk.VOLUME_KEYS
+    else -> ServiceOffShortcutRisk.STALE_BUTTON
+}
+
+/** The "Turn Ramblr off" row subtitle. In system mode it says WHY the row exists, because the
+ *  user's instinct is to look in system Settings -- where the switch has been hidden by the OS. */
+fun serviceOffRowSubtitleText(serviceEnabled: Boolean, mode: InvocationMode): String = when {
+    !serviceEnabled -> "Ramblr's accessibility service is off — turn it back on from the setup screen"
+    mode == InvocationMode.SYSTEM_CONTROLS ->
+        "Stops dictation everywhere and releases the accessibility service. In this mode " +
+            "Android hides the off switch on Ramblr's system Accessibility page, so this is it."
+    else -> "Stops dictation everywhere and releases the accessibility service. Same as the " +
+        "switch on Ramblr's system Accessibility page."
+}
+
+/**
+ * The confirmation dialog body. Every branch states plainly what happens to the OS shortcuts,
+ * because "off" that quietly comes back on is the exact complaint in #254 and a user turning
+ * Ramblr off before a banking app needs to know whether it actually stayed off.
+ */
+fun serviceOffConfirmMessage(risk: ServiceOffShortcutRisk): String {
+    val base = "Dictation stops everywhere and Ramblr releases the accessibility service — it " +
+        "can no longer read or type into any app.\n\nTurn it back on from Ramblr's home screen " +
+        "whenever you want it again.\n\n"
+    return base + when (risk) {
+        ServiceOffShortcutRisk.NONE ->
+            "Nothing will turn it back on by itself."
+        ServiceOffShortcutRisk.SWEEPABLE ->
+            "Ramblr's system button and volume-keys shortcuts will be removed first, so nothing " +
+                "can turn the service back on by itself."
+        ServiceOffShortcutRisk.VOLUME_KEYS ->
+            "\u26a0\ufe0f Heads up: the volume-keys shortcut is still bound to Ramblr, and Android " +
+                "turns an accessibility service back ON when that shortcut is used. To make the " +
+                "off stick, switch to Floating icon mode first, or remove the volume-keys " +
+                "shortcut on Ramblr's system Accessibility page."
+        ServiceOffShortcutRisk.STALE_BUTTON ->
+            "The system accessibility button is still bound to Ramblr. It won't turn the service " +
+                "back on, but it will stay on screen doing nothing until you remove it on " +
+                "Ramblr's system Accessibility page."
+    }
+}
+
 /**
  * The #156 guard-rail decision: should the "Ramblr was turned off by the system shortcut
  * switch" recovery banner be showing right now?

--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -241,6 +241,31 @@ open class WhisperAccessibilityService : AccessibilityService() {
         /** Best-effort package name for whichever app currently owns the active accessibility root. */
         fun foregroundPackageNameOrNull(): String? = instance?.currentForegroundPackageName()
 
+        /**
+         * The #254 in-app off switch: turn the accessibility service off from inside Ramblr.
+         * Returns false when no service instance is connected (nothing to disable -- caller
+         * falls back to the system Settings deep link; see [resolveServiceOffAction]).
+         *
+         * [AccessibilityService.disableSelf] is the only app-callable way to leave
+         * `enabled_accessibility_services`, and it is the ONLY correct one here: in
+         * SYSTEM_CONTROLS mode the OS hides the master on/off switch on Ramblr's own
+         * Accessibility page (INVISIBLE_TOGGLE classification), so without this the user has no
+         * off switch anywhere. disableSelf routes through
+         * AccessibilityServiceConnection.disableSelf, which persists the enabled-services list
+         * directly and never calls the invisible-toggle shortcut sync, so the OS does not undo
+         * it -- unlike an external write, which a bound shortcut can immediately reverse.
+         *
+         * Any in-flight recording is torn down by the ordinary destroy path: disableSelf()
+         * unbinds the service, so [onDestroy] -> [DictationRuntime.shutdown] runs exactly as it
+         * does when the user flips the system Settings switch off -- reader forced off
+         * RECORDING, AudioRecord released, no stranded mic. Nothing extra to do here.
+         */
+        fun disableServiceFromApp(): Boolean {
+            val service = instance ?: return false
+            service.disableSelf()
+            return true
+        }
+
         private const val TAG = "PhoneWhisper"
         private const val BTN_DP = 44
         private const val PAD_DP = 10

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -283,6 +283,156 @@ class InvocationMethodsTest {
         ))
     }
 
+    // --- #254 in-app off switch -------------------------------------------------------------
+
+    @Test fun `off action is a self-disable when the service is enabled and connected`() {
+        assertEquals(
+            ServiceOffAction.SELF_DISABLE,
+            resolveServiceOffAction(serviceEnabled = true, serviceConnected = true),
+        )
+    }
+
+    @Test fun `off action falls back to settings when enabled but no live instance`() {
+        // Listed in enabled_accessibility_services with nothing bound to call disableSelf() on
+        // (crashed or not yet connected): only system Settings can clear the entry.
+        assertEquals(
+            ServiceOffAction.NEEDS_SETTINGS,
+            resolveServiceOffAction(serviceEnabled = true, serviceConnected = false),
+        )
+    }
+
+    @Test fun `off action is a no-op when the service is already disabled`() {
+        assertEquals(
+            ServiceOffAction.ALREADY_OFF,
+            resolveServiceOffAction(serviceEnabled = false, serviceConnected = false),
+        )
+        // A stale instance reference must not turn "already off" into a disable attempt.
+        assertEquals(
+            ServiceOffAction.ALREADY_OFF,
+            resolveServiceOffAction(serviceEnabled = false, serviceConnected = true),
+        )
+    }
+
+    @Test fun `floating icon mode has no shortcut risk even with stale bindings`() {
+        // The floating component is TOGGLE-classified: the OS never re-enables it from a
+        // shortcut, so a leftover pre-rework binding can't undo the off switch.
+        assertEquals(
+            ServiceOffShortcutRisk.NONE,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.FLOATING_ICON,
+                buttonTargetBound = true,
+                volumeKeysBound = true,
+                canWrite = false,
+            ),
+        )
+    }
+
+    @Test fun `system mode with nothing bound has no shortcut risk`() {
+        assertEquals(
+            ServiceOffShortcutRisk.NONE,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                buttonTargetBound = false,
+                volumeKeysBound = false,
+                canWrite = false,
+            ),
+        )
+    }
+
+    @Test fun `advanced tier sweeps bindings instead of warning`() {
+        assertEquals(
+            ServiceOffShortcutRisk.SWEEPABLE,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                buttonTargetBound = true,
+                volumeKeysBound = true,
+                canWrite = true,
+            ),
+        )
+    }
+
+    @Test fun `bound volume keys without the write tier is the re-enable risk`() {
+        // AMS.performAccessibilityShortcutTargetService: for targetSdk > Q WITH the button flag,
+        // the hardware shortcut ENABLES a disabled service. This one genuinely undoes the off.
+        assertEquals(
+            ServiceOffShortcutRisk.VOLUME_KEYS,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                buttonTargetBound = false,
+                volumeKeysBound = true,
+                canWrite = false,
+            ),
+        )
+        // Volume keys outrank a co-bound button: it's the branch with the worse consequence.
+        assertEquals(
+            ServiceOffShortcutRisk.VOLUME_KEYS,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                buttonTargetBound = true,
+                volumeKeysBound = true,
+                canWrite = false,
+            ),
+        )
+    }
+
+    @Test fun `button-only binding is the stale-button case, not a re-enable`() {
+        // The a11y-button path falls through to "callback to a bound service" and bails when the
+        // service isn't running -- it leaves a dead button on screen, it does not revive Ramblr.
+        assertEquals(
+            ServiceOffShortcutRisk.STALE_BUTTON,
+            resolveServiceOffShortcutRisk(
+                mode = InvocationMode.SYSTEM_CONTROLS,
+                buttonTargetBound = true,
+                volumeKeysBound = false,
+                canWrite = false,
+            ),
+        )
+    }
+
+    @Test fun `off row subtitle names the hidden system switch only in system mode`() {
+        val systemMode = serviceOffRowSubtitleText(
+            serviceEnabled = true, mode = InvocationMode.SYSTEM_CONTROLS,
+        )
+        assertTrue(systemMode.contains("hides the off switch"))
+        val floatingMode = serviceOffRowSubtitleText(
+            serviceEnabled = true, mode = InvocationMode.FLOATING_ICON,
+        )
+        assertFalse(floatingMode.contains("hides the off switch"))
+        assertTrue(floatingMode.contains("system Accessibility page"))
+    }
+
+    @Test fun `off row subtitle reports the already-off state in both modes`() {
+        for (mode in InvocationMode.entries) {
+            assertTrue(
+                serviceOffRowSubtitleText(serviceEnabled = false, mode = mode)
+                    .startsWith("Ramblr's accessibility service is off"),
+            )
+        }
+    }
+
+    @Test fun `confirm copy tells the truth about what happens to the shortcuts`() {
+        // The whole point of #254 is an "off" the user can trust, so each branch must state
+        // whether something can turn Ramblr back on -- and only the volume-keys branch may
+        // claim it will.
+        val none = serviceOffConfirmMessage(ServiceOffShortcutRisk.NONE)
+        assertTrue(none.contains("Nothing will turn it back on"))
+
+        val sweepable = serviceOffConfirmMessage(ServiceOffShortcutRisk.SWEEPABLE)
+        assertTrue(sweepable.contains("will be removed first"))
+
+        val volumeKeys = serviceOffConfirmMessage(ServiceOffShortcutRisk.VOLUME_KEYS)
+        assertTrue(volumeKeys.contains("turns an accessibility service back ON"))
+        assertTrue(volumeKeys.contains("Floating icon mode"))
+
+        val staleButton = serviceOffConfirmMessage(ServiceOffShortcutRisk.STALE_BUTTON)
+        assertTrue(staleButton.contains("won't turn the service back on"))
+
+        // Every branch keeps the shared lead-in: what "off" actually means for the user.
+        for (risk in ServiceOffShortcutRisk.entries) {
+            assertTrue(serviceOffConfirmMessage(risk).contains("Dictation stops everywhere"))
+        }
+    }
+
     // --- subtitle formatters ----------------------------------------------------------------
 
     @Test fun `main row subtitle leads with the mode and lists active methods`() {


### PR DESCRIPTION
Refs #254.

## Problem

In **System controls** mode Ramblr has no off switch anywhere. That component (`SystemControlsAccessibilityService`) declares `flagRequestAccessibilityButton`, which with `targetSdk 36` classifies it `INVISIBLE_TOGGLE`, and `InvisibleToggleAccessibilityServicePreferenceFragment` hides the master on/off preference — the only switch left on Ramblr's system Accessibility page is "Ramblr shortcut". The reporter in #254 found exactly this ("the system settings invocation mode doesn't even have the Option to disable the accessibility settings") while trying to turn Ramblr off before banking apps.

Automation can't substitute. The framework re-enables an `INVISIBLE_TOGGLE` service whenever a shortcut is bound to it (`ShortcutUtils.updateInvisibleToggleAccessibilityServiceEnableState`) and again when the volume-keys shortcut fires (`AccessibilityManagerService.performAccessibilityShortcutTargetService`, AOSP 4341-4346). So a MacroDroid macro that clears the service is fighting the OS.

Ramblr itself is **not** re-enabling anything: the only writes to `enabled_accessibility_services` are `InvocationSecureSettings.setBinding` / `swapEnabledServicesEntry`, both gated on `WRITE_SECURE_SETTINGS`, which a normal user hasn't granted.

Affects 1.0.26+ only — `1369697` (the flag) is not an ancestor of any tag through v1.0.25.

## Change

A **"Turn Ramblr off"** row on the Invocation screen, backed by `AccessibilityService.disableSelf()`. That call needs no permission, works identically in both modes, and persists the enabled-services list through `AccessibilityServiceConnection.disableSelf` without going near the invisible-toggle sync (which has exactly one caller, `AMS.enableShortcutForTargets`), so the OS doesn't undo it.

The confirm dialog states what will actually happen to the shortcuts, because an "off" that quietly comes back on is the bug:

| Situation | Behavior |
|---|---|
| Floating icon mode, or nothing bound | "Nothing will turn it back on by itself." |
| System mode + `WRITE_SECURE_SETTINGS` | Bindings swept first (raw writes bypass the sync, #156 memo §3), then disable |
| Volume-keys bound, no write tier | Warned as a **genuine** re-enable path, with the switch-to-Floating-icon workaround |
| Button/gesture bound only, no write tier | Warned as a **dead on-screen button** — that path bails when the service isn't running (AMS 4349-4355); it does not revive Ramblr |

Not lumping those last two together is deliberate: only the volume-keys shortcut actually turns the service back on.

Also: `resolveServiceOffAction` falls back to the Settings deep link when the service is listed as enabled but has no live instance (crashed / not yet connected) — nothing to call `disableSelf()` on. And the tap dismisses the #156 guard-rail banner, so a disable the user *asked for* doesn't trigger "Ramblr was turned off by the system shortcut switch"; the service re-arms the banner itself on its next connect.

## Testing

`./gradlew testGithubDebugUnitTest assembleGithubDebug` — **1,784 tests, 0 failures**, APK builds. 11 new tests in `InvocationMethodsTest` covering the action resolution, all four shortcut-risk branches, and the copy invariants (each branch must state whether something can turn Ramblr back on, and only the volume-keys branch may claim it will).

Not yet validated on-device; the mode-dependent behavior wants a real S24/One UI check before release.

## Not in scope

The per-app exclusion list #254 also asks for is a separate feature — the foreground package is already available via `currentForegroundPackageName()`, but it needs its own UI, store, and an honest caveat that the service stays *bound* (suppressed, not detached). Filed separately; #254 stays open.
