### PR TITLE
Automation off-hook, stale-component repair, and distinct service labels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,8 +98,8 @@ android {
         applicationId = "com.trevornk.ramblr"
         minSdk = 30
         targetSdk = 36
-        versionCode = 30
-        versionName = "1.0.27"
+        versionCode = 31
+        versionName = "1.0.28"
 
         buildConfigField("String", "OMNIROUTE_BASE_URL", "\"$omniRouteBaseUrl\"")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -167,6 +167,7 @@
         <service
             android:name=".WhisperAccessibilityService"
             android:exported="false"
+            android:label="@string/accessibility_service_label_floating"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService" />
@@ -184,14 +185,17 @@
              covers. Disabled by default so fresh installs and updates show exactly ONE "Ramblr"
              entry in system Settings; the Invocation screen's mode switch flips the two
              components via PackageManager.setComponentEnabledSetting (InvocationServiceMode).
-             android:label stays the plain app name: only one component is ever PM-enabled at a
-             time, so Settings never lists both, and the plain name reads cleanest in the
-             shortcut UIs (a11y button chooser, volume-keys first-use dialog). -->
+             android:label MUST differ from the floating component's (#258): system Settings only
+             ever lists one of the two, but automation apps (MacroDroid/Tasker) address services
+             by COMPONENT and present a picker of labels. Two entries both reading "Ramblr" are
+             indistinguishable, and a macro that captured the inactive one silently no-ops on
+             disable and strips Ramblr from enabled_accessibility_services on enable (AMS drops
+             any entry naming a PM-disabled component). -->
         <service
             android:name=".SystemControlsAccessibilityService"
             android:enabled="false"
             android:exported="false"
-            android:label="@string/app_name"
+            android:label="@string/accessibility_service_label_system"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -273,5 +273,22 @@
                 android:resource="@xml/benchmark_log_file_paths" />
         </provider>
 
+        <!-- #257: automation off-hook. Exported so MacroDroid/Tasker/a shell can turn the
+             accessibility service off on a trigger (entering a banking app, a time of day)
+             without fighting the OS: an external write to enabled_accessibility_services is
+             component-addressed and racy, while this routes to disableSelf() on the live
+             service. Gated behind AutomationOffHookToggle, DEFAULT OFF, because exported means
+             any app on the device can silence dictation with no user interaction, so it stays
+             the user's explicit opt-in. Deliberately no enable counterpart (see
+             AutomationOffHookToggle's KDoc: re-enabling needs WRITE_SECURE_SETTINGS and is a
+             far worse capability to hand to arbitrary callers). -->
+        <receiver
+            android:name=".AutomationOffReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.trevornk.ramblr.action.TURN_OFF" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/trevornk/ramblr/AutomationOffHook.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/AutomationOffHook.kt
@@ -1,0 +1,83 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * #257: the automation-facing equivalent of #255's in-app "Turn Ramblr off" row. Off by default.
+ *
+ * WHY THIS EXISTS
+ *
+ * The #254 reporter automates Ramblr around banking apps with MacroDroid, using an
+ * `Accessibility Service -> Disable` action that writes `enabled_accessibility_services`
+ * directly. That write is a component-addressed race the automation tool cannot win reliably:
+ *
+ *  - it must name the exact component, and Ramblr ships two (#156), only one PM-enabled at a
+ *    time -- naming the wrong one is a silent no-op in one direction and makes AMS strip Ramblr
+ *    entirely in the other (#258);
+ *  - it takes effect whenever the OS gets round to it, so a macro triggered by an app launch is
+ *    racing that app's own startup.
+ *
+ * [android.accessibilityservice.AccessibilityService.disableSelf] has neither problem: it is
+ * addressed to the live service rather than a component name, it persists through
+ * AccessibilityServiceConnection.disableSelf immediately, and the invisible-toggle shortcut sync
+ * never runs against it. But only Ramblr can call it -- hence this hook.
+ *
+ * WHY IT IS OFF BY DEFAULT
+ *
+ * An exported receiver means any app on the device can silence dictation with no user
+ * interaction. That is a small blast radius but a real one, so it is the user's explicit choice.
+ * Enabling it is a deliberate act by someone who already runs an automation tool; the default
+ * install surface is unchanged.
+ *
+ * There is deliberately NO enable counterpart. An app cannot add itself back to
+ * `enabled_accessibility_services` without WRITE_SECURE_SETTINGS, so a symmetric "on" action
+ * would work only on the advanced tier and would hand arbitrary callers the power to switch an
+ * accessibility service ON -- a much worse thing to expose than the power to switch it off.
+ * Re-enabling stays a user action (Settings, or Ramblr's own one-tap route on the advanced tier).
+ */
+object AutomationOffHookToggle {
+    private const val PREFS_NAME = "ramblr"
+    const val KEY = "automation_off_hook_enabled"
+    private const val DEFAULT = false
+
+    fun isEnabled(prefs: SharedPreferences): Boolean = prefs.getBoolean(KEY, DEFAULT)
+
+    fun setEnabled(prefs: SharedPreferences, enabled: Boolean) {
+        prefs.edit().putBoolean(KEY, enabled).apply()
+    }
+
+    fun isEnabled(context: Context): Boolean = isEnabled(prefs(context))
+
+    fun setEnabled(context: Context, enabled: Boolean) = setEnabled(prefs(context), enabled)
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}
+
+/** What [AutomationOffReceiver] should do with an incoming broadcast. */
+enum class AutomationOffOutcome {
+    /** The hook setting is off: ignore the broadcast entirely. */
+    IGNORED_DISABLED,
+
+    /** Hook on, but no service instance is connected -- nothing to disable. */
+    IGNORED_NOT_RUNNING,
+
+    /** Hook on and a live service exists: call disableSelf(). */
+    DISABLE,
+}
+
+/**
+ * Pure decision for an incoming automation off-broadcast, so the policy is unit-testable without
+ * a device. The receiver does the two impure things (read the toggle, ask for the live instance)
+ * and hands the answers here.
+ *
+ * Note the deliberate ordering: the toggle is checked FIRST, so a disabled hook is indifferent to
+ * whether the service happens to be running. That keeps the off state a flat "this app does not
+ * respond to that broadcast at all" rather than something an outside caller can probe for
+ * service state.
+ */
+fun resolveAutomationOff(hookEnabled: Boolean, serviceConnected: Boolean): AutomationOffOutcome = when {
+    !hookEnabled -> AutomationOffOutcome.IGNORED_DISABLED
+    !serviceConnected -> AutomationOffOutcome.IGNORED_NOT_RUNNING
+    else -> AutomationOffOutcome.DISABLE
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/AutomationOffReceiver.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/AutomationOffReceiver.kt
@@ -1,0 +1,64 @@
+package com.trevornk.ramblr
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * #257: exported receiver that lets an automation app (MacroDroid, Tasker) turn Ramblr's
+ * accessibility service off, gated behind [AutomationOffHookToggle] (default off).
+ *
+ * Usage once enabled in Ramblr's Behavior settings:
+ *
+ *     am broadcast -a com.trevornk.ramblr.action.TURN_OFF -n com.trevornk.ramblr/.AutomationOffReceiver
+ *
+ * The explicit `-n` component is what makes this reachable from a shell/automation context on
+ * modern Android, where an implicit broadcast to a manifest receiver is not delivered.
+ *
+ * The disable itself routes through [WhisperAccessibilityService.disableServiceFromApp] --
+ * the same disableSelf() path as #255's in-app off switch, and the reason this hook exists at
+ * all: an external write to `enabled_accessibility_services` is component-addressed and racy,
+ * while disableSelf targets the live service directly. See [AutomationOffHookToggle] for why
+ * there is no enable counterpart.
+ *
+ * Like the in-app switch, this records the user-intent flag so #258's stale-component repair
+ * does not treat an automation-requested off as damage to be undone -- otherwise every macro
+ * that turns Ramblr off before a banking app would be fought by Ramblr turning itself back on
+ * at next launch. [InvocationGuardRail.recordServiceConnected] clears it when the service is
+ * next enabled, so a genuine later loss is still detected.
+ */
+class AutomationOffReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_TURN_OFF) return
+
+        val outcome = resolveAutomationOff(
+            hookEnabled = AutomationOffHookToggle.isEnabled(context),
+            serviceConnected = WhisperAccessibilityService.instance != null,
+        )
+
+        when (outcome) {
+            AutomationOffOutcome.IGNORED_DISABLED ->
+                Log.i(TAG, "Automation off-hook broadcast ignored: hook disabled in settings")
+
+            AutomationOffOutcome.IGNORED_NOT_RUNNING ->
+                Log.i(TAG, "Automation off-hook broadcast ignored: service not connected")
+
+            AutomationOffOutcome.DISABLE -> {
+                // Mark the off as intentional BEFORE disabling: onDestroy runs synchronously
+                // inside disableSelf()'s teardown, and #258's detector reads this flag on the
+                // next MainActivity refresh.
+                InvocationGuardRail.dismissBanner(context)
+                InvocationGuardRail.recordUserTurnedOff(context)
+                val disabled = WhisperAccessibilityService.disableServiceFromApp()
+                Log.i(TAG, "Automation off-hook: disableSelf dispatched (success=$disabled)")
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_TURN_OFF = "com.trevornk.ramblr.action.TURN_OFF"
+        private const val TAG = "PhoneWhisper"
+    }
+}

--- a/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/BehaviorActivity.kt
@@ -24,6 +24,7 @@ class BehaviorActivity : BaseSettingsActivity() {
     private lateinit var debugVisibilitySwitch: MaterialSwitch
     private lateinit var perAppPersonaSwitch: MaterialSwitch
     private lateinit var hideIconSwitch: MaterialSwitch
+    private lateinit var automationOffHookSwitch: MaterialSwitch
     private lateinit var autoPeekSwitch: MaterialSwitch
     private lateinit var autoPeekDelayRow: LinearLayout
     private lateinit var peekSizeRow: LinearLayout
@@ -103,6 +104,26 @@ class BehaviorActivity : BaseSettingsActivity() {
             val newVal = !hideIconSwitch.isChecked
             HideIconToggle.setEnabled(this, newVal)
             hideIconSwitch.isChecked = newVal
+        })
+
+        // #257: opt-in automation hook. Placed next to the other invocation-adjacent toggles
+        // rather than in Advanced, because the people who want it (automation users trying to
+        // keep Ramblr out of banking apps) are looking at behavior, not internals.
+        automationOffHookSwitch = MaterialSwitch(this).apply {
+            isChecked = AutomationOffHookToggle.isEnabled(this@BehaviorActivity)
+            isClickable = false
+        }
+        root.addView(settingsRow(
+            "Let automation apps turn Ramblr off",
+            "Adds a broadcast MacroDroid or Tasker can send to switch the accessibility service " +
+                "off — more reliable than having them edit the accessibility setting directly. " +
+                "Any app on your phone can send it, so leave this off unless you use it",
+            automationOffHookSwitch
+        ) {
+            val newVal = !automationOffHookSwitch.isChecked
+            AutomationOffHookToggle.setEnabled(this, newVal)
+            automationOffHookSwitch.isChecked = newVal
+            if (newVal) showAutomationOffHookHelp()
         })
 
         autoPeekSwitch = MaterialSwitch(this).apply {
@@ -294,6 +315,7 @@ class BehaviorActivity : BaseSettingsActivity() {
         debugVisibilitySwitch.isChecked = DebugVisibilityToggle.isEnabled(this)
         perAppPersonaSwitch.isChecked = PerAppPersonaToggle.isEnabled(this)
         hideIconSwitch.isChecked = HideIconToggle.isEnabled(this)
+        automationOffHookSwitch.isChecked = AutomationOffHookToggle.isEnabled(this)
         autoPeekSwitch.isChecked = AutoPeekToggle.isEnabled(this)
         singleTapRestoreSwitch.isChecked = SingleTapRestoreToggle.isEnabled(this)
         rawTextRetrySwitch.isChecked = RawTextRetryToggle.isEnabled(this)
@@ -342,6 +364,36 @@ class BehaviorActivity : BaseSettingsActivity() {
     private fun dismissedSuggestionsSummary(): String {
         val count = VocabularySuggestionStore.dismissedTerms(this).size
         return "$count term${if (count == 1) "" else "s"} you chose not to add. Tap to review or restore"
+    }
+
+    /**
+     * #257: shown once when the user opts in, because a broadcast hook is useless if you don't
+     * know the exact intent to send. Copy-to-clipboard rather than prose-only: the component
+     * name is long and mistyping it fails silently (an unmatched broadcast is a no-op, not an
+     * error), which would look exactly like the feature not working.
+     */
+    private fun showAutomationOffHookHelp() {
+        val command = "am broadcast -a ${AutomationOffReceiver.ACTION_TURN_OFF} " +
+            "-n $packageName/.AutomationOffReceiver"
+        android.app.AlertDialog.Builder(this)
+            .setTitle("Automation off-hook enabled")
+            .setMessage(
+                "Ramblr now responds to this broadcast by turning its accessibility service " +
+                    "off:\n\n$command\n\nIn MacroDroid or Tasker, use a \u201CShell\u201D / \u201CRun " +
+                    "command\u201D action with that line — it needs ADB or root privileges, the " +
+                    "same as your existing accessibility actions.\n\nThere is no matching " +
+                    "\u201Cturn on\u201D broadcast: re-enabling an accessibility service needs a " +
+                    "permission apps aren't given, so that stays a manual step."
+            )
+            .setPositiveButton("Copy command") { _, _ ->
+                val clipboard = getSystemService(android.content.ClipboardManager::class.java)
+                clipboard?.setPrimaryClip(
+                    android.content.ClipData.newPlainText("Ramblr off-hook", command)
+                )
+                toast("Command copied")
+            }
+            .setNegativeButton("Close", null)
+            .show()
     }
 
     /** Add/Dismiss decision dialog for one suggestion. Add goes through [VocabularyEditor.addTerm]

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationActivity.kt
@@ -522,6 +522,9 @@ class InvocationActivity : BaseSettingsActivity() {
         // it here marks this detection handled, and the service clears the dismissal itself the
         // next time it connects, so a genuine future kill still gets the banner.
         InvocationGuardRail.dismissBanner(this)
+        // Same reasoning for the #258 repair path: this off is deliberate, so the stale-component
+        // detector must not "recover" from it. Cleared when the service next connects.
+        InvocationGuardRail.recordUserTurnedOff(this)
         if (action == ServiceOffAction.SELF_DISABLE && WhisperAccessibilityService.disableServiceFromApp()) {
             toast("Ramblr turned off")
             // The OS unbinds asynchronously, so an immediate re-read can still show the old

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationGuardRail.kt
@@ -23,6 +23,8 @@ object InvocationGuardRail {
     private const val PREFS_NAME = "ramblr"
     const val KEY_SERVICE_WAS_ENABLED = "service_was_enabled"
     const val KEY_BANNER_DISMISSED = "service_killed_banner_dismissed"
+    const val KEY_USER_TURNED_OFF = "user_turned_off_in_app"
+    const val KEY_STALE_BANNER_DISMISSED = "stale_component_banner_dismissed"
 
     /** Called from [WhisperAccessibilityService.onServiceConnected]: records that this install
      *  has a working service and re-arms the banner for the next fresh detection. */
@@ -30,8 +32,40 @@ object InvocationGuardRail {
         prefs(context).edit()
             .putBoolean(KEY_SERVICE_WAS_ENABLED, true)
             .putBoolean(KEY_BANNER_DISMISSED, false)
+            // The service is running again, so any earlier deliberate off is spent: a LATER
+            // disappearance is a fresh event the #258 repair path is allowed to act on.
+            .putBoolean(KEY_USER_TURNED_OFF, false)
+            .putBoolean(KEY_STALE_BANNER_DISMISSED, false)
             .apply()
     }
+
+    /** The user turned Ramblr off with the in-app off switch (#254). Distinguishes a deliberate
+     *  off from the #258 automation breakage, which is the only thing keeping the repair path
+     *  from overriding the user's own choice. */
+    fun recordUserTurnedOff(context: Context) {
+        prefs(context).edit().putBoolean(KEY_USER_TURNED_OFF, true).apply()
+    }
+
+    /** The user dismissed the #258 stale-component banner: quiet until the service reconnects. */
+    fun dismissStaleBanner(context: Context) {
+        prefs(context).edit().putBoolean(KEY_STALE_BANNER_DISMISSED, true).apply()
+    }
+
+    /** Whether the #258 stale-component banner has been dismissed for this detection. */
+    fun staleBannerDismissed(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_STALE_BANNER_DISMISSED, false)
+
+    /**
+     * The #258 decision: is Ramblr off because automation named the wrong component, and can the
+     * app put it back? Assembles live OS state for the pure [resolveStaleComponentAction].
+     */
+    fun staleComponentAction(context: Context): StaleComponentAction = resolveStaleComponentAction(
+        activeComponentEnabled = InvocationSecureSettings.isActiveComponentEnabled(context),
+        inactiveComponentEnabled = InvocationSecureSettings.isInactiveComponentEnabled(context),
+        serviceWasEnabled = prefs(context).getBoolean(KEY_SERVICE_WAS_ENABLED, false),
+        userTurnedOffInApp = prefs(context).getBoolean(KEY_USER_TURNED_OFF, false),
+        canWrite = InvocationSecureSettings.canWrite(context),
+    )
 
     /** The user tapped the banner's dismiss affordance: stay quiet until a fresh detection. */
     fun dismissBanner(context: Context) {

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationMethods.kt
@@ -279,6 +279,97 @@ fun serviceOffConfirmMessage(risk: ServiceOffShortcutRisk): String {
     }
 }
 
+// --- #258 stale-component detection ---------------------------------------------------------
+
+/**
+ * What the app should do about the INACTIVE service component appearing in (or Ramblr being
+ * missing from) `enabled_accessibility_services` (#258).
+ *
+ * Ramblr ships two components and exactly one is PM-enabled at a time. Automation apps address
+ * accessibility services by COMPONENT, not by app: MacroDroid's "Disable: [Ramblr]" stores the
+ * component that was active when the user picked it. When the stored component is no longer the
+ * active one, two failures follow, both reported in #254 and both reproduced on-device:
+ *
+ *  - DISABLE targets a component that isn't in the list -> no-op. The active component stays
+ *    enabled and bound, which the user experiences as "Ramblr turns itself back on".
+ *  - ENABLE writes the PM-DISABLED component into `enabled_accessibility_services`. AMS refuses
+ *    to bind an entry naming a component that PackageManager reports as disabled and drops the
+ *    entry on its next reconcile -- so Ramblr disappears from the list entirely and never comes
+ *    back until the user re-enables it by hand.
+ *
+ * The second case is the damaging one and it is silently recoverable: "the user's automation
+ * asked for Ramblr and the OS threw it away" is unambiguous intent, so [REPAIR_TO_ACTIVE] swaps
+ * the stale entry for the active component. [OFFER_RECOVERY] is the same intent without the
+ * means -- Ramblr was working, is now absent, and no in-app off switch was used, so the user is
+ * told rather than left to discover it.
+ *
+ * Note [userTurnedOffInApp]: the #254 off switch is a deliberate off, so it must NEVER be
+ * second-guessed by this repair path. That flag is the only thing distinguishing "automation
+ * broke it" from "the user meant it", which is why the off switch records it.
+ */
+enum class StaleComponentAction {
+    /** Nothing to do: the active component is enabled, or Ramblr is off on purpose. */
+    NONE,
+
+    /** The inactive component is listed (or Ramblr was stripped): rewrite it to the active
+     *  component. Requires the WRITE_SECURE_SETTINGS tier. */
+    REPAIR_TO_ACTIVE,
+
+    /** Same state, no way to write it: surface the recovery banner instead. */
+    OFFER_RECOVERY,
+}
+
+/**
+ * @param activeComponentEnabled  the PM-enabled component is in `enabled_accessibility_services`
+ * @param inactiveComponentEnabled  the OTHER component is listed -- the stale-macro signature
+ * @param serviceWasEnabled  this install has had a working service at least once (guard-rail pref)
+ * @param userTurnedOffInApp  the user's last off came from Ramblr's own off switch
+ * @param canWrite  WRITE_SECURE_SETTINGS granted
+ */
+fun resolveStaleComponentAction(
+    activeComponentEnabled: Boolean,
+    inactiveComponentEnabled: Boolean,
+    serviceWasEnabled: Boolean,
+    userTurnedOffInApp: Boolean,
+    canWrite: Boolean,
+): StaleComponentAction = when {
+    // The active component is enabled: whatever else is in the list, Ramblr works. A stale
+    // inactive entry alongside it is inert (AMS ignores it) and gets cleaned up by the next
+    // mode switch's componentListReplace.
+    activeComponentEnabled -> StaleComponentAction.NONE
+    // A deliberate off must stay off -- never fight the user's own choice.
+    userTurnedOffInApp -> StaleComponentAction.NONE
+    // Ramblr never worked here: this is an unfinished setup, not a broken one.
+    !serviceWasEnabled -> StaleComponentAction.NONE
+    // The inactive component is listed: automation asked for Ramblr and named the wrong
+    // component. Repair where we can, tell the user where we can't.
+    inactiveComponentEnabled -> if (canWrite) {
+        StaleComponentAction.REPAIR_TO_ACTIVE
+    } else {
+        StaleComponentAction.OFFER_RECOVERY
+    }
+    // Ramblr worked before, isn't listed now, and the user didn't turn it off in-app: the
+    // stripped-by-AMS end state. Same intent, same handling.
+    else -> if (canWrite) StaleComponentAction.REPAIR_TO_ACTIVE else StaleComponentAction.OFFER_RECOVERY
+}
+
+/** The #258 recovery banner's body: names the cause, because a user whose macro did this has no
+ *  way to guess it and will otherwise keep re-enabling Ramblr by hand forever. */
+fun staleComponentBannerText(mode: InvocationMode): String {
+    val other = when (mode) {
+        InvocationMode.FLOATING_ICON -> "Ramblr (System controls)"
+        InvocationMode.SYSTEM_CONTROLS -> "Ramblr (Floating icon)"
+    }
+    val active = when (mode) {
+        InvocationMode.FLOATING_ICON -> "Ramblr (Floating icon)"
+        InvocationMode.SYSTEM_CONTROLS -> "Ramblr (System controls)"
+    }
+    return "Ramblr's accessibility service was switched off by something other than Ramblr. " +
+        "If you use an automation app (MacroDroid, Tasker), check which service it targets — " +
+        "picking \u201c$other\u201d while you're in the other mode turns Ramblr off without " +
+        "turning it back on. Select \u201c$active\u201d instead."
+}
+
 /**
  * The #156 guard-rail decision: should the "Ramblr was turned off by the system shortcut
  * switch" recovery banner be showing right now?

--- a/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/InvocationSecureSettings.kt
@@ -84,6 +84,47 @@ object InvocationSecureSettings {
     fun isServiceEnabled(context: Context): Boolean =
         anyRamblrIn(context, read(context, KEY_ENABLED_SERVICES))
 
+    /** Whether the component the CURRENT mode actually uses is enabled (#258). Distinct from
+     *  [isServiceEnabled]: a stale automation entry naming the other component makes that
+     *  return true while Ramblr is in fact not running. */
+    fun isActiveComponentEnabled(context: Context): Boolean =
+        componentListContains(read(context, KEY_ENABLED_SERVICES), serviceComponent(context))
+
+    /** Whether the component the current mode does NOT use is enabled (#258) -- the signature of
+     *  an automation macro holding a stale component. AMS drops such an entry when it names the
+     *  PM-disabled component, which is what takes Ramblr out of the list entirely. */
+    fun isInactiveComponentEnabled(context: Context): Boolean {
+        val active = serviceComponent(context)
+        return InvocationServiceMode.allComponents(context)
+            .filterNot { componentEquals(it, active) }
+            .any { componentListContains(read(context, KEY_ENABLED_SERVICES), it) }
+    }
+
+    /**
+     * Replaces a stale INACTIVE-component entry with the active one, or adds the active one when
+     * Ramblr was stripped from the list entirely (#258). Other apps' entries are preserved
+     * verbatim by [componentListReplace]/[componentListAdd]. Advanced tier only -- returns false
+     * so the caller can fall back to the recovery banner.
+     */
+    fun repairToActiveComponent(context: Context): Boolean {
+        if (!canWrite(context)) return false
+        val active = serviceComponent(context)
+        val current = read(context, KEY_ENABLED_SERVICES)
+        val stale = InvocationServiceMode.allComponents(context)
+            .firstOrNull { !componentEquals(it, active) && componentListContains(current, it) }
+        val updated = if (stale != null) {
+            componentListReplace(current, stale, active)
+        } else {
+            componentListAdd(current, active)
+        }
+        return try {
+            Settings.Secure.putString(context.contentResolver, KEY_ENABLED_SERVICES, updated)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "WRITE_SECURE_SETTINGS repair of $KEY_ENABLED_SERVICES failed despite grant", e)
+            false
+        }
+    }
+
     /** Whether ANY OS shortcut still binds Ramblr -- the guard rail's "targets empty" input. */
     fun anyShortcutBound(context: Context): Boolean =
         isButtonTargetBound(context) || isVolumeKeysBound(context)

--- a/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/MainActivity.kt
@@ -40,6 +40,7 @@ class MainActivity : BaseSettingsActivity() {
     private lateinit var invocationRowSub: TextView
     private lateinit var voiceKeyboardRowSub: TextView
     private lateinit var serviceKilledBanner: View
+    private lateinit var staleComponentBanner: View
 
     // First-run wizard state (#6). Tracked in-memory so a dialog already on screen is never
     // duplicated by a stray onResume, and reset per Activity instance so a fresh launch always
@@ -90,6 +91,11 @@ class MainActivity : BaseSettingsActivity() {
         // Settings), so onResume picks up a fresh kill immediately.
         serviceKilledBanner = buildServiceKilledBanner()
         root.addView(serviceKilledBanner)
+
+        // #258 stale-component banner: same build-once/toggle-in-refresh pattern, same reason --
+        // an automation macro flips enabled_accessibility_services while this Activity is paused.
+        staleComponentBanner = buildStaleComponentBanner()
+        root.addView(staleComponentBanner)
 
         // Status row -- tapping it (re-)launches the setup walkthrough when setup isn't done yet
         // (#52); once ready it's just informational, same as before.
@@ -305,6 +311,24 @@ class MainActivity : BaseSettingsActivity() {
         serviceKilledBanner.visibility =
             if (InvocationGuardRail.shouldShowBanner(this)) View.VISIBLE else View.GONE
 
+        // #258: the inactive component is listed (or Ramblr was stripped) and the user didn't
+        // ask for that. On the advanced tier repair it silently -- the intent is unambiguous and
+        // a self-healing service beats a banner. Otherwise explain it, once.
+        staleComponentBanner.visibility = View.GONE
+        when (InvocationGuardRail.staleComponentAction(this)) {
+            StaleComponentAction.REPAIR_TO_ACTIVE ->
+                if (InvocationSecureSettings.repairToActiveComponent(this)) {
+                    toast("Ramblr's accessibility service was restored")
+                } else if (!InvocationGuardRail.staleBannerDismissed(this)) {
+                    staleComponentBanner.visibility = View.VISIBLE
+                }
+            StaleComponentAction.OFFER_RECOVERY ->
+                if (!InvocationGuardRail.staleBannerDismissed(this)) {
+                    staleComponentBanner.visibility = View.VISIBLE
+                }
+            StaleComponentAction.NONE -> Unit
+        }
+
         // Ready logic -- see OnboardingWizard.isSetupComplete for what "ready" means (#52).
         val ready = OnboardingWizard.isSetupComplete(
             audioGranted = audio,
@@ -412,6 +436,58 @@ class MainActivity : BaseSettingsActivity() {
             }
         }
         banner.addView(dismiss)
+        banner.setOnClickListener { onServiceKilledBannerTapped() }
+        return banner
+    }
+
+    /**
+     * The #258 recovery banner: Ramblr's accessibility service is off because something outside
+     * the app named the wrong service component -- in practice an automation macro holding a
+     * stale component after a mode switch, which AMS then strips from
+     * `enabled_accessibility_services` because the named component is PM-disabled.
+     *
+     * Only shown on the base tier (the advanced tier repairs silently in [refresh]) or when a
+     * repair write fails. Tap deep-links to the service's own Accessibility page where the enable
+     * switch lives; dismiss stays quiet until the service next connects, matching the #156
+     * banner's non-nagging contract.
+     */
+    private fun buildStaleComponentBanner(): View {
+        val banner = vertical(dp(16), dp(12)).apply {
+            background = android.graphics.drawable.GradientDrawable().apply {
+                cornerRadius = dp(12).toFloat()
+                setColor(withAlpha(attrColor(com.google.android.material.R.attr.colorPrimary), 0x22))
+            }
+            layoutParams = android.widget.LinearLayout.LayoutParams(LP_MATCH, LP_WRAP).apply {
+                setMargins(dp(16), 0, dp(16), dp(8))
+            }
+            visibility = View.GONE
+        }
+        banner.addView(TextView(this).apply {
+            text = "Ramblr's accessibility service was turned off"
+            textSize = 16f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTextColor(attrColor(android.R.attr.textColorPrimary))
+        })
+        banner.addView(TextView(this).apply {
+            text = staleComponentBannerText(InvocationServiceMode.currentMode(this@MainActivity))
+            textSize = 14f
+            setTextColor(attrColor(android.R.attr.textColorSecondary))
+            setPadding(0, dp(4), 0, 0)
+        })
+        banner.addView(TextView(this).apply {
+            text = "Dismiss"
+            textSize = 14f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTextColor(attrColor(com.google.android.material.R.attr.colorPrimary))
+            setPadding(dp(8), dp(8), dp(8), dp(4))
+            setOnClickListener {
+                InvocationGuardRail.dismissStaleBanner(this@MainActivity)
+                refresh()
+            }
+        })
+        // Same recovery target as the #156 banner: advanced tier re-enables in one tap, base tier
+        // deep-links to the service's Accessibility page. Reused rather than duplicated -- the
+        // two banners differ in WHY the service is off, not in how to turn it back on.
         banner.setOnClickListener { onServiceKilledBannerTapped() }
         return banner
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Ramblr</string>
+    <!-- #258: the two accessibility-service components MUST NOT share a label. Only one is ever
+         PM-enabled, so system Settings shows one entry either way, but automation apps
+         (MacroDroid/Tasker) address services by COMPONENT and let the user pick from a list of
+         labels. With both labelled plain "Ramblr" the user cannot tell which component they
+         captured, and a macro holding the inactive one silently no-ops on disable and, on
+         enable, writes a PM-disabled component that AMS strips (taking Ramblr out of
+         enabled_accessibility_services entirely). Distinct labels make the two visibly
+         different at pick time. Keep the mode names identical to the Invocation screen's cards
+         so a user can map picker entry to mode without guessing. -->
+    <string name="accessibility_service_label_floating">Ramblr (Floating icon)</string>
+    <string name="accessibility_service_label_system">Ramblr (System controls)</string>
     <string name="accessibility_description">Dictation: records audio, transcribes, and inserts text into focused fields. Note: Android may also show its own system Accessibility Button shortcut for Ramblr in Settings > Accessibility -- that\'s a separate OS-level shortcut, not Ramblr\'s own floating mic button.</string>
     <!-- Floating overlay mic button contentDescription (accessibility pass): announced by
          TalkBack per RecordingStateMachine.State, see applyButtonAppearance in

--- a/app/src/test/kotlin/com/trevornk/ramblr/AutomationOffHookTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/AutomationOffHookTest.kt
@@ -1,0 +1,55 @@
+package com.trevornk.ramblr
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #257 automation off-hook policy. The gate is the whole security story for an exported
+ * receiver, so it is pinned here rather than left to a device test.
+ */
+class AutomationOffHookTest {
+
+    @Test
+    fun `hook disabled ignores the broadcast even when the service is running`() {
+        assertEquals(
+            AutomationOffOutcome.IGNORED_DISABLED,
+            resolveAutomationOff(hookEnabled = false, serviceConnected = true),
+        )
+    }
+
+    @Test
+    fun `hook disabled ignores the broadcast when the service is not running`() {
+        assertEquals(
+            AutomationOffOutcome.IGNORED_DISABLED,
+            resolveAutomationOff(hookEnabled = false, serviceConnected = false),
+        )
+    }
+
+    @Test
+    fun `hook enabled with a connected service disables it`() {
+        assertEquals(
+            AutomationOffOutcome.DISABLE,
+            resolveAutomationOff(hookEnabled = true, serviceConnected = true),
+        )
+    }
+
+    @Test
+    fun `hook enabled with no connected service is a no-op`() {
+        assertEquals(
+            AutomationOffOutcome.IGNORED_NOT_RUNNING,
+            resolveAutomationOff(hookEnabled = true, serviceConnected = false),
+        )
+    }
+
+    /**
+     * The disabled check must come first, so an outside caller cannot use the outcome to learn
+     * whether Ramblr's service is running while the hook is off.
+     */
+    @Test
+    fun `disabled hook reports the same outcome regardless of service state`() {
+        assertEquals(
+            resolveAutomationOff(hookEnabled = false, serviceConnected = true),
+            resolveAutomationOff(hookEnabled = false, serviceConnected = false),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/InvocationMethodsTest.kt
@@ -216,6 +216,89 @@ class InvocationMethodsTest {
         assertEquals(InvocationMode.FLOATING_ICON, resolveInvocationMode(systemComponentPmEnabled = false))
     }
 
+    // --- #258 resolveStaleComponentAction ---------------------------------------------------
+
+    // The reporter's exact case (#254): floating mode, a MacroDroid macro holding the SYSTEM
+    // component. Its "enable" writes a PM-disabled component, AMS strips the entry, and Ramblr
+    // ends up absent from enabled_accessibility_services with the user having asked for the
+    // opposite. Base tier can't write, so the banner explains it.
+    @Test fun `stripped service with no direct control offers recovery`() {
+        assertEquals(StaleComponentAction.OFFER_RECOVERY, resolveStaleComponentAction(
+            activeComponentEnabled = false,
+            inactiveComponentEnabled = false,
+            serviceWasEnabled = true,
+            userTurnedOffInApp = false,
+            canWrite = false,
+        ))
+    }
+
+    @Test fun `stripped service repairs itself on the advanced tier`() {
+        assertEquals(StaleComponentAction.REPAIR_TO_ACTIVE, resolveStaleComponentAction(
+            activeComponentEnabled = false,
+            inactiveComponentEnabled = false,
+            serviceWasEnabled = true,
+            userTurnedOffInApp = false,
+            canWrite = true,
+        ))
+    }
+
+    @Test fun `inactive component listed alone is the stale-macro signature and repairs`() {
+        assertEquals(StaleComponentAction.REPAIR_TO_ACTIVE, resolveStaleComponentAction(
+            activeComponentEnabled = false,
+            inactiveComponentEnabled = true,
+            serviceWasEnabled = true,
+            userTurnedOffInApp = false,
+            canWrite = true,
+        ))
+    }
+
+    @Test fun `deliberate in-app off is never second-guessed by the repair path`() {
+        // The #254 off switch must stay off. This is the ONLY thing separating "automation
+        // broke it" from "the user meant it", so it outranks every repair signal.
+        assertEquals(StaleComponentAction.NONE, resolveStaleComponentAction(
+            activeComponentEnabled = false,
+            inactiveComponentEnabled = true,
+            serviceWasEnabled = true,
+            userTurnedOffInApp = true,
+            canWrite = true,
+        ))
+    }
+
+    @Test fun `fresh install that never had a working service is left alone`() {
+        // Unfinished setup, not breakage: onboarding owns this state, not the repair path.
+        assertEquals(StaleComponentAction.NONE, resolveStaleComponentAction(
+            activeComponentEnabled = false,
+            inactiveComponentEnabled = false,
+            serviceWasEnabled = false,
+            userTurnedOffInApp = false,
+            canWrite = true,
+        ))
+    }
+
+    @Test fun `active component enabled means nothing to repair`() {
+        // Even with a stale inactive entry alongside it: AMS ignores that entry, Ramblr works,
+        // and the next mode switch's componentListReplace cleans it up.
+        assertEquals(StaleComponentAction.NONE, resolveStaleComponentAction(
+            activeComponentEnabled = true,
+            inactiveComponentEnabled = true,
+            serviceWasEnabled = true,
+            userTurnedOffInApp = false,
+            canWrite = true,
+        ))
+    }
+
+    @Test fun `stale banner names the component to pick for the current mode`() {
+        // The whole point of the banner: tell the user WHICH picker entry is right. In floating
+        // mode that's the floating label, and the wrong one it warns about is the system label.
+        val floating = staleComponentBannerText(InvocationMode.FLOATING_ICON)
+        assertTrue(floating.contains("Ramblr (System controls)"))
+        assertTrue(floating.contains("Ramblr (Floating icon)"))
+
+        val system = staleComponentBannerText(InvocationMode.SYSTEM_CONTROLS)
+        assertTrue(system.contains("Ramblr (Floating icon)"))
+        assertTrue(system.contains("Ramblr (System controls)"))
+    }
+
     // --- shouldShowServiceKilledBanner ------------------------------------------------------
 
     @Test fun `banner fires on the exact invisible-toggle kill state in system controls mode`() {

--- a/fastlane/metadata/android/en-US/changelogs/31.txt
+++ b/fastlane/metadata/android/en-US/changelogs/31.txt
@@ -1,0 +1,20 @@
+Automation control, and recovery when something else turns Ramblr off.
+
+- If you use MacroDroid, Tasker or similar to switch Ramblr off around banking apps,
+  there is now a proper way to do it. Editing Android's accessibility setting from
+  outside the app is unreliable: it names one exact service, and Ramblr has two (only
+  one is active at a time), so the wrong choice either does nothing or makes Android
+  drop Ramblr entirely until you turn it back on by hand. Turn on "Let automation apps
+  turn Ramblr off" in Settings > Behavior and Ramblr will show you a command to paste
+  into your macro. It is off by default, because any app on your phone could send it.
+- Ramblr now notices when it has been switched off by something other than you. If it
+  has permission it puts itself back; if not, it explains what happened and offers a
+  one-tap way to fix it, instead of silently staying off.
+- Turning Ramblr off yourself, in the app or from a macro, is respected. It will not
+  undo a choice you made on purpose.
+- The two accessibility services are now named "Ramblr (Floating icon)" and
+  "Ramblr (System controls)" instead of both being called "Ramblr", so you can tell
+  which is which if you ever see both.
+
+Known issue: one user reports crashes when another app hands off to a banking app.
+That is not fixed here and is still being investigated.


### PR DESCRIPTION
Addresses the root cause behind #254, and implements #257.

## What #254 actually is

The reporter automates Ramblr around banking apps with MacroDroid. His macro's `Accessibility Service -> Disable/Enable` actions write `enabled_accessibility_services` directly, which cannot be made reliable from outside the app:

- **Component-addressed.** Ramblr ships two components (#156), one PM-enabled at a time. Targeting the inactive one is a silent no-op for disable (service stays bound — *"Ramblr turns itself back on"*), and for enable makes AMS strip the entry outright (service unbound, no self-recovery — *"stays off until I re-enable it by hand"*). Both reproduced on a Pixel 10a / Android 17 in his configuration.
- **Racy.** The write lands whenever the OS gets to it, so a macro triggered by an app launch is racing that app's startup.

### Correction to this PR's original premise

I first claimed identical `android:label` values put two indistinguishable "Ramblr" entries in his picker. **That was wrong**, and the reporter independently confirmed it — he sees *"only a Singular Ramblr accessibility setting at any given time."* Automation apps enumerate via `getInstalledAccessibilityServiceList()` (`queryIntentServices` without `MATCH_DISABLED_COMPONENTS`), so the PM-disabled component is never returned:

```
$ cmd package query-services --components -a android.accessibilityservice.AccessibilityService
com.trevornk.ramblr/.WhisperAccessibilityService     <- only one, ever
$ ... --match 512   # MATCH_DISABLED_COMPONENTS
(no second Ramblr entry)
```

The labels are kept as a genuine usability improvement — they disambiguate across a mode switch and in Settings — but they are **not** the fix, and how his macro came to hold a stale component remains unproven.

## What actually fixes it

**1. `#257` automation hook (the real fix for his workflow).** An opt-in exported receiver routing to `disableSelf()`, which is addressed to the live service rather than a component name, persists immediately, and is never undone by the shortcut sync:

```
am broadcast -a com.trevornk.ramblr.action.TURN_OFF \
  -n com.trevornk.ramblr/.AutomationOffReceiver
```

Off by default — exported means any app can silence dictation with no user interaction. `resolveAutomationOff` checks the toggle *before* service state so a disabled hook can't be used to probe whether Ramblr is running. No enable counterpart: that needs `WRITE_SECURE_SETTINGS` and would be a far worse capability to expose.

**2. Detect and repair.** `resolveStaleComponentAction` spots the inactive component listed, or Ramblr absent after having worked. On the WSS tier `repairToActiveComponent` rewrites to the active component, preserving other apps' entries. This fixes the broken end state *regardless* of how the stale component was acquired.

**3. Base-tier recovery banner**, since that tier can't write the setting itself.

Both the in-app off switch (#255) and the automation hook record `KEY_USER_TURNED_OFF`, so a deliberate off is never "repaired" against the user's intent. Cleared when the service next connects.

## Device verification (Pixel 10a, Android 17)

Automation hook:

```
hook OFF  -> broadcast delivered, ignored, bound=1   (default is inert)
hook ON   -> bound 1 -> 0, tasker entry preserved, disableSelf success=true
then open Ramblr -> bound=0   (#258 respects the intentional off)
```

Stale-component repair:

```
1. baseline          [tasker, ramblr/…Whisper]  bound=1
2. stale write       [tasker]                   bound=0   (AMS stripped it)
3. open Ramblr       [tasker, ramblr/…Whisper]  bound=1   (repaired)
```

Base tier (WSS revoked) correctly makes **no** write and shows the recovery banner naming the right component for the active mode.

Tests: 1,796 passing (12 new), 0 failures.

## Known-unfixed, tracked separately

- **Crashes.** The reporter narrowed it to *"crashes when any app redirects to the banking app"*, never on direct launch. Not reproduced, not diagnosed, not claimed fixed here.
- **Pre-existing status-line bug** (unrelated, untouched): the home screen shows "Ready — tap the overlay dot to dictate" while the accessibility service is off, because `OnboardingWizard.isSetupComplete` treats `accessibilityEnabled || imeEnabled` as invocation-ready.

Refs #258, #257, #254
