### PR TITLE
Unwind partial overlay attaches instead of leaking a window

### DIFF
--- a/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
+++ b/app/src/main/kotlin/com/trevornk/ramblr/WhisperAccessibilityService.kt
@@ -772,6 +772,10 @@ open class WhisperAccessibilityService : AccessibilityService() {
     // --- Overlay ---
 
     private fun showOverlay() {
+        // #260: no-op if the overlay is already attached. Without this, a second call would add
+        // a duplicate window and overwrite the tracking fields pointing at the first one,
+        // orphaning it beyond removeOverlay()'s reach.
+        if (overlayView != null) return
         val wm = getSystemService(WINDOW_SERVICE) as WindowManager
         val ringSizeDp = OverlayAppearancePrefs.load(this).ringSizeDp
         val buttonSize = (dpScaledToRing(BTN_DP, ringSizeDp) * dp).toInt()
@@ -1027,14 +1031,36 @@ open class WhisperAccessibilityService : AccessibilityService() {
         }
         positionFeedback(feedbackParams, params, feedbackHeight = 0)
 
-        wm.addView(overlay, params)
-        wm.addView(feedback, feedbackParams)
-        overlayView = overlay
-        button = img
-        spinner = ring
-        feedbackView = feedback
-        layoutParams = params
-        feedbackLayoutParams = feedbackParams
+        // #260: record each window as it attaches, rather than assigning every tracking field
+        // after both addView calls returned. Under the old ordering a throw on the second call
+        // left the first window attached with overlayView still null, and removeOverlay()'s
+        // null-guarded teardown could then never remove it -- the window leaked for the life of
+        // the process. These are TYPE_ACCESSIBILITY_OVERLAY windows whose token belongs to the
+        // live service connection, so addView legitimately throws BadTokenException when that
+        // connection is torn down between onServiceConnected() and here (an automation app
+        // toggling the service off mid-connect does exactly that). Uncaught, it propagated out
+        // of a lifecycle callback and took the process down; failing to attach the overlay
+        // should cost the user their floating button, not the whole service.
+        try {
+            wm.addView(overlay, params)
+            overlayView = overlay
+            button = img
+            spinner = ring
+            layoutParams = params
+            wm.addView(feedback, feedbackParams)
+            feedbackView = feedback
+            feedbackLayoutParams = feedbackParams
+        } catch (e: WindowManager.BadTokenException) {
+            Log.e(TAG, "Could not attach overlay windows; floating button unavailable", e)
+            removeOverlay()
+            return
+        } catch (e: IllegalStateException) {
+            // "View has already been added to the window manager" -- unreachable via the entry
+            // guard above, but unwinding beats leaking a window if it ever is reached.
+            Log.e(TAG, "Could not attach overlay windows; floating button unavailable", e)
+            removeOverlay()
+            return
+        }
         applyButtonAppearance(COLOR_IDLE)
         applyOverlayVisibility()
         armIdlePeekTimer()
@@ -1407,12 +1433,26 @@ open class WhisperAccessibilityService : AccessibilityService() {
         peekAnimator?.cancel()
         peekAnimator = null
         val wm = getSystemService(WINDOW_SERVICE) as WindowManager
+        // #260: removeOverlay() is now also the unwind path for a failed attach in showOverlay(),
+        // so a throw here would defeat that recovery. removeView throws IllegalArgumentException
+        // for a view WMS no longer considers attached, which is exactly the state a torn-down
+        // service connection leaves behind. Null the field either way: if the view is already
+        // gone there is nothing left to remove, and holding the reference only risks a later
+        // removeView against a stale token.
         overlayView?.let {
-            wm.removeView(it)
+            try {
+                wm.removeView(it)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Overlay window already detached", e)
+            }
             overlayView = null
         }
         feedbackView?.let {
-            wm.removeView(it)
+            try {
+                wm.removeView(it)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Feedback window already detached", e)
+            }
             feedbackView = null
         }
         button = null
@@ -1710,10 +1750,25 @@ open class WhisperAccessibilityService : AccessibilityService() {
             y = ringParams.y
         }
 
-        wm.addView(scrim, scrimParams)
-        wm.addView(menu, menuParams)
-        styleMenuScrim = scrim
-        styleMenuView = menu
+        // #260: same attach-ordering fix as showOverlay(). A throw on the second addView
+        // previously left the scrim attached with styleMenuScrim still null, which
+        // dismissStyleMenu()'s null-guarded teardown could never remove -- a full-screen scrim
+        // stuck over the user's screen until the process died. Lower exposure than the overlay
+        // (long-press triggered, not lifecycle driven) but the same failure.
+        try {
+            wm.addView(scrim, scrimParams)
+            styleMenuScrim = scrim
+            wm.addView(menu, menuParams)
+            styleMenuView = menu
+        } catch (e: WindowManager.BadTokenException) {
+            Log.e(TAG, "Could not attach style menu", e)
+            dismissStyleMenu()
+            return
+        } catch (e: IllegalStateException) {
+            Log.e(TAG, "Could not attach style menu", e)
+            dismissStyleMenu()
+            return
+        }
 
         // WRAP_CONTENT's real size isn't known until after the first layout pass, so the anchor
         // math runs once more here rather than trying to pre-compute the menu's height.
@@ -1727,8 +1782,21 @@ open class WhisperAccessibilityService : AccessibilityService() {
 
     private fun dismissStyleMenu() {
         val wm = getSystemService(WINDOW_SERVICE) as WindowManager
-        styleMenuView?.let { wm.removeView(it) }
-        styleMenuScrim?.let { wm.removeView(it) }
+        // #260: also the unwind path for a failed attach above, so it must not throw.
+        styleMenuView?.let {
+            try {
+                wm.removeView(it)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Style menu already detached", e)
+            }
+        }
+        styleMenuScrim?.let {
+            try {
+                wm.removeView(it)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Style menu scrim already detached", e)
+            }
+        }
         styleMenuView = null
         styleMenuScrim = null
     }

--- a/app/src/test/kotlin/com/trevornk/ramblr/OverlayAttachGuardTest.kt
+++ b/app/src/test/kotlin/com/trevornk/ramblr/OverlayAttachGuardTest.kt
@@ -1,0 +1,189 @@
+package com.trevornk.ramblr
+
+import android.content.Context
+import android.view.View
+import android.view.WindowManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.lang.reflect.Field
+
+/**
+ * #260 regression coverage for overlay window attach/teardown.
+ *
+ * The defect was ordering, not just the missing catch. `showOverlay()` ran both `wm.addView()`
+ * calls and only then assigned `overlayView`/`feedbackView`. A throw on the second call left the
+ * first window attached while `overlayView` was still null, and `removeOverlay()` only removes
+ * through those null-guarded fields -- so nothing could ever remove it. The window leaked for
+ * the life of the process, and because `showOverlay()` runs from `onServiceConnected()`, the
+ * uncaught exception killed the service.
+ *
+ * These drive the real [WhisperAccessibilityService.showOverlay] and
+ * [WhisperAccessibilityService.removeOverlay] against a WindowManager that throws where the
+ * framework actually throws, rather than re-modelling the logic in the test.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OverlayAttachGuardTest {
+
+    /**
+     * The real service with its WindowManager swapped for one that can fail on a chosen call.
+     * [WindowManager.BadTokenException] is what the framework raises when the accessibility-service
+     * connection backing a TYPE_ACCESSIBILITY_OVERLAY token is torn down mid-attach -- exactly what
+     * an automation app toggling the service off during connect produces.
+     */
+    open class TestService(
+        private val failOnAdd: Int = -1,
+        private val throwOnRemove: Boolean = false
+    ) : WhisperAccessibilityService() {
+        var addCalls = 0
+        var removeCalls = 0
+        val attached = mutableListOf<View>()
+        private var wrapped: WindowManager? = null
+
+        override fun getSystemService(name: String): Any? {
+            if (name != Context.WINDOW_SERVICE) return super.getSystemService(name)
+            if (wrapped == null) {
+                val real = super.getSystemService(name) as WindowManager
+                wrapped = object : WindowManager by real {
+                    override fun addView(view: View, params: android.view.ViewGroup.LayoutParams) {
+                        addCalls++
+                        if (addCalls == failOnAdd) {
+                            throw WindowManager.BadTokenException("token invalid: connection torn down")
+                        }
+                        real.addView(view, params)
+                        attached += view
+                    }
+
+                    override fun removeView(view: View) {
+                        removeCalls++
+                        if (throwOnRemove) {
+                            throw IllegalArgumentException("View=$view not attached to window manager")
+                        }
+                        real.removeView(view)
+                        attached -= view
+                    }
+                }
+            }
+            return wrapped
+        }
+    }
+
+    class FailSecondAdd : TestService(failOnAdd = 2)
+    class FailFirstAdd : TestService(failOnAdd = 1)
+    class FailRemove : TestService(throwOnRemove = true)
+
+    private fun field(name: String): Field =
+        WhisperAccessibilityService::class.java.getDeclaredField(name).apply { isAccessible = true }
+
+    private fun overlayView(service: WhisperAccessibilityService) = field("overlayView").get(service)
+    private fun feedbackView(service: WhisperAccessibilityService) = field("feedbackView").get(service)
+
+    private fun <T : WhisperAccessibilityService> build(cls: Class<T>): T =
+        Robolectric.buildService(cls, null).create().get()
+
+    private fun showOverlay(service: WhisperAccessibilityService) {
+        WhisperAccessibilityService::class.java
+            .getDeclaredMethod("showOverlay").apply { isAccessible = true }
+            .invoke(service)
+    }
+
+    private fun removeOverlay(service: WhisperAccessibilityService) {
+        WhisperAccessibilityService::class.java
+            .getDeclaredMethod("removeOverlay").apply { isAccessible = true }
+            .invoke(service)
+    }
+
+    // --- happy path ---
+
+    @Test fun `both windows attach and are tracked`() {
+        val service = build(TestService::class.java)
+
+        showOverlay(service)
+
+        assertEquals(2, service.addCalls)
+        assertNotNull(overlayView(service))
+        assertNotNull(feedbackView(service))
+    }
+
+    // --- the #260 defect ---
+
+    @Test fun `second attach failing does not leak the first window`() {
+        val service = build(FailSecondAdd::class.java)
+
+        showOverlay(service) // must not throw
+
+        assertEquals("the attached window must be unwound", 0, service.attached.size)
+    }
+
+    @Test fun `second attach failing clears all tracking fields`() {
+        val service = build(FailSecondAdd::class.java)
+
+        showOverlay(service)
+
+        assertNull(overlayView(service))
+        assertNull(feedbackView(service))
+    }
+
+    @Test fun `first attach failing attaches and tracks nothing`() {
+        val service = build(FailFirstAdd::class.java)
+
+        showOverlay(service)
+
+        assertEquals(0, service.attached.size)
+        assertNull(overlayView(service))
+        assertNull(feedbackView(service))
+    }
+
+    // --- guards ---
+
+    @Test fun `entry guard makes a redundant showOverlay a no-op`() {
+        val service = build(TestService::class.java)
+        showOverlay(service)
+        val first = overlayView(service)
+
+        showOverlay(service)
+
+        assertEquals("no duplicate windows", 2, service.addCalls)
+        assertSame("original overlay still tracked", first, overlayView(service))
+    }
+
+    @Test fun `removeOverlay clears tracking fields`() {
+        val service = build(TestService::class.java)
+        showOverlay(service)
+
+        removeOverlay(service)
+
+        assertNull(overlayView(service))
+        assertNull(feedbackView(service))
+    }
+
+    @Test fun `removeOverlay survives windows the framework already detached`() {
+        // removeOverlay is the unwind path for a failed attach, so it must not throw.
+        val service = build(FailRemove::class.java)
+        showOverlay(service)
+
+        removeOverlay(service)
+
+        assertNull(overlayView(service))
+        assertNull(feedbackView(service))
+    }
+
+    @Test fun `showOverlay after removeOverlay re-attaches`() {
+        // The entry guard must not wedge the overlay off permanently after a teardown.
+        val service = build(TestService::class.java)
+        showOverlay(service)
+        removeOverlay(service)
+
+        showOverlay(service)
+
+        assertNotNull(overlayView(service))
+        assertNotNull(feedbackView(service))
+    }
+}


### PR DESCRIPTION
Refs #260.

## What was wrong

`showOverlay()` attached two windows and then recorded them:

```kotlin
wm.addView(overlay, params)
wm.addView(feedback, feedbackParams)
overlayView = overlay      // only reached if BOTH adds returned
feedbackView = feedback
```

If the second `addView` threw, the first window was already on screen but
`overlayView` was still null. `removeOverlay()` only removes through those
null-guarded fields, so nothing could ever remove it — the window stayed
attached for the life of the process, invisible to the app's own teardown.

These are `TYPE_ACCESSIBILITY_OVERLAY` windows whose token belongs to the live
service connection, so `addView` legitimately throws `BadTokenException` when
that connection goes away mid-attach — which is what an automation app toggling
the service off during connect produces. `showOverlay()` is called from
`onServiceConnected()`, so uncaught, that also took the service down.

`showStyleMenu()`/`dismissStyleMenu()` had the identical shape: a failed menu
attach stranded a full-screen scrim with no way to remove it.

## What changed

- Each field is assigned immediately after its own successful attach, so
  whatever attached is always tracked and therefore always removable.
- A failed attach unwinds what did attach and leaves the user without a floating
  button rather than without a service.
- `showOverlay()` gets an entry guard — a redundant call previously added a
  duplicate window and overwrote the reference to the first one, orphaning it
  the same way.
- Both teardown paths tolerate windows the framework already detached, since
  they are now also the unwind path.

## Tests

Eight tests drive the real `WhisperAccessibilityService` under Robolectric with
a `WindowManager` that throws where the framework throws, rather than
re-modelling the logic in the test.

Verified by mutation: reverting to the previous ordering fails four of them,
including the leak guard. They fail for the right reason.

Full suite: 168 suites, 1804 tests, 0 failures, 0 errors, 0 skipped.

Device-checked on a Pixel 10a: overlay still attaches normally, 60 rapid
enable/disable cycles across the connect window produced 0 process restarts and
no fatals.

## Scope

This is a robustness fix found by reading the code, not a reproduction of
#254. I attempted that crash 60 times on device and never reproduced it, so
this is **not** claimed to be that reporter's crash — the leak and the
service-kill path are real defects worth fixing on their own merits.
